### PR TITLE
Render latestComments on profile page

### DIFF
--- a/components/Profile/LatestComments.js
+++ b/components/Profile/LatestComments.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import { css } from 'glamor'
+import { CommentTeaser, Interaction } from '@project-r/styleguide'
+import timeago from '../../lib/timeago'
+import withT from '../../lib/withT'
+
+const styles = {
+  container: css({
+    marginTop: '20px'
+  })
+}
+
+export const timeagoFromNow = (t, createdAtString) => {
+  return timeago(t, (Date.now() - Date.parse(createdAtString)) / 1000)
+}
+
+const LatestComments = ({ t, comments }) => {
+  const filteredComments = comments.filter(
+    comment => comment.discussion && comment.discussion.title
+  )
+  if (!filteredComments || !filteredComments.length) {
+    return <p>{t('profile/discussion/empty')}</p>
+  } else {
+    return (
+      <div>
+        <Interaction.H3>{t('profile/discussion')}</Interaction.H3>
+        <div {...styles.container}>
+          {filteredComments.map(function (comment) {
+            // Make sure not to wrap each comment teaser in a container
+            // so we get the dividers for adjacent elements.
+            return (
+              <CommentTeaser
+                key={comment.id}
+                title={comment.discussion.title}
+                content={comment.content}
+                timeago={timeagoFromNow(t, comment.createdAt)}
+                commentUrl={`/comment/${comment.id}`}
+                lineClamp={3}
+                t={t}
+              />
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+}
+
+export default withT(LatestComments)

--- a/components/Profile/index.js
+++ b/components/Profile/index.js
@@ -7,6 +7,7 @@ import { css, merge } from 'glamor'
 import Badge from './Badge'
 import { Link } from '../../lib/routes'
 import Meta from '../Frame/Meta'
+import LatestComments from './LatestComments'
 import PointerList from './PointerList'
 import Testimonial from '../Testimonial'
 import { HEADER_HEIGHT, TESTIMONIAL_IMAGE_SIZE } from '../constants'
@@ -63,7 +64,7 @@ const styles = {
 }
 
 const getPublicUser = gql`
-  query getPublicUser($userId: ID!) {
+  query getPublicUser($userId: ID!, $limit: Int!) {
     publicUser(id: $userId) {
       id
       name
@@ -81,9 +82,14 @@ const getPublicUser = gql`
       twitterHandle
       publicUrl
       badges
-      latestComments {
+      latestComments(limit: $limit) {
         id
         content
+        discussion {
+          id
+          title
+        }
+        createdAt
       }
     }
   }
@@ -199,17 +205,7 @@ class Profile extends Component {
                   )}
                   <PointerList publicUser={publicUser} />
                 </div>
-                {!publicUser.latestComments ||
-                !publicUser.latestComments.length ? (
-                  <p>{t('profile/discussion/empty')}</p>
-                ) : (
-                  <div>
-                    <Interaction.H3>{t('profile/discussion')}</Interaction.H3>
-                    {publicUser.latestComments.map(comment => (
-                      <p key={comment.id}>{comment.content}</p>
-                    ))}
-                  </div>
-                )}
+                <LatestComments comments={publicUser.latestComments} />
               </div>
             </div>
           )
@@ -224,7 +220,8 @@ export default compose(
   graphql(getPublicUser, {
     options: props => ({
       variables: {
-        userId: props.userId
+        userId: props.userId,
+        limit: 10
       }
     })
   })

--- a/components/Profile/index.js
+++ b/components/Profile/index.js
@@ -220,7 +220,8 @@ export default compose(
   graphql(getPublicUser, {
     options: props => ({
       variables: {
-        userId: props.userId
+        userId: props.userId,
+        limit: 7
       }
     })
   })

--- a/components/Profile/index.js
+++ b/components/Profile/index.js
@@ -64,7 +64,7 @@ const styles = {
 }
 
 const getPublicUser = gql`
-  query getPublicUser($userId: ID!, $limit: Int!) {
+  query getPublicUser($userId: ID!, $limit: Int) {
     publicUser(id: $userId) {
       id
       name
@@ -220,8 +220,7 @@ export default compose(
   graphql(getPublicUser, {
     options: props => ({
       variables: {
-        userId: props.userId,
-        limit: 10
+        userId: props.userId
       }
     })
   })

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-10-27T11:42:40.402Z",
+  "updated": "2017-11-02T12:29:43.882Z",
   "title": "live",
   "data": [
     {
@@ -603,6 +603,10 @@
       "value": "Antworten"
     },
     {
+      "key": "styleguide/CommentTeaser/commentLink",
+      "value": "Zum Beitrag"
+    },
+    {
       "key": "styleguide/CommentTreeLoadMore/label/1",
       "value": "Eine weiterer Kommentar"
     },
@@ -636,7 +640,7 @@
     },
     {
       "key": "timeago/hours/1",
-      "value": "vor einer Stunden"
+      "value": "vor einer Stunde"
     },
     {
       "key": "timeago/hours/other",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-2.8.0.tgz",
-      "integrity": "sha1-HJUSjetcyWuLFyGPEHRHS634U9k=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-3.2.0.tgz",
+      "integrity": "sha1-O6y5vPEdr1bzb4yGRsvg/8B3fPA=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
-    "@project-r/styleguide": "^2.8.0",
+    "@project-r/styleguide": "^3.2.0",
     "d3-array": "^1.1.1",
     "d3-format": "^1.2.0",
     "d3-time-format": "^2.0.5",


### PR DESCRIPTION
Currently filtering for comment.discussion.title on the client to hide old comments from the crowdfunding voting, until we have some backend filter in place.

![screen shot 2017-11-02 at 16 18 05](https://user-images.githubusercontent.com/23520051/32333965-76feb68c-bfe9-11e7-81c3-ed79012d943e.png)

