### PR TITLE
Show DiscussionPreferences in an Overlay

### DIFF
--- a/components/Discussion/DiscussionCommentComposer.js
+++ b/components/Discussion/DiscussionCommentComposer.js
@@ -3,6 +3,7 @@ import {compose} from 'redux'
 import {CommentComposer, CommentComposerPlaceholder} from '@project-r/styleguide'
 import withT from '../../lib/withT'
 import {withMe, submitComment} from './enhancers'
+import DiscussionPreferences from './DiscussionPreferences'
 
 class DiscussionCommentComposer extends PureComponent {
   constructor (props) {
@@ -10,19 +11,41 @@ class DiscussionCommentComposer extends PureComponent {
 
     this.state = {
       state: 'idle', // idle | focused | submitting | error
-      error: undefined // If state == error then this is the error string.
+      error: undefined, // If state == error then this is the error string.
+      showPreferences: false
     }
 
     this.onFocus = () => {
-      this.setState({state: 'focused', error: undefined})
+      this.setState({
+        state: 'focused',
+        error: undefined
+      })
     }
 
     this.onCancel = () => {
-      this.setState({state: 'idle', error: undefined})
+      this.setState({
+        state: 'idle',
+        error: undefined
+      })
+    }
+
+    this.showPreferences = () => {
+      this.setState({
+        showPreferences: true
+      })
+    }
+
+    this.closePreferences = () => {
+      this.setState({
+        showPreferences: false
+      })
     }
 
     this.submitComment = content => {
-      this.setState({state: 'submitting'})
+      this.setState({
+        state: 'submitting'
+      })
+
       this.props.submitComment(undefined, content).then(
         () => {
           this.setState({
@@ -41,8 +64,8 @@ class DiscussionCommentComposer extends PureComponent {
   }
 
   render () {
-    const {t, data: {loading, error, discussion, me}} = this.props
-    const {state} = this.state
+    const {t, discussionId, data: {loading, error, discussion, me}} = this.props
+    const {state, showPreferences} = this.state
 
     if (loading || error || !me) {
       return null
@@ -71,13 +94,22 @@ class DiscussionCommentComposer extends PureComponent {
       }
 
       return (
-        <CommentComposer
-          t={t}
-          displayAuthor={displayAuthor}
-          error={this.state.error}
-          onCancel={this.onCancel}
-          submitComment={this.submitComment}
-        />
+        <div>
+          <CommentComposer
+            t={t}
+            displayAuthor={displayAuthor}
+            error={this.state.error}
+            onEditPreferences={this.showPreferences}
+            onCancel={this.onCancel}
+            submitComment={this.submitComment}
+          />
+          {showPreferences && (
+            <DiscussionPreferences
+              discussionId={discussionId}
+              onClose={this.closePreferences}
+            />
+          )}
+        </div>
       )
     }
   }

--- a/components/Discussion/DiscussionPreferences.js
+++ b/components/Discussion/DiscussionPreferences.js
@@ -1,0 +1,168 @@
+import React, {PureComponent} from 'react'
+import PropTypes from 'prop-types'
+import {compose} from 'redux'
+import withT from '../../lib/withT'
+import {
+  Field,
+  Dropdown,
+  Checkbox,
+  Overlay,
+  OverlayToolbar,
+  OverlayToolbarClose,
+  OverlayToolbarConfirm,
+  OverlayBody
+} from '@project-r/styleguide'
+import Loader from '../Loader'
+import {withDiscussionPreferences, withSetDiscussionPreferences} from './enhancers'
+
+export const DiscussionPreferences = ({t, data: {loading, error, me, discussion}, onClose, setDiscussionPreferences}) => (
+  <Overlay onClose={onClose}>
+    <Loader
+      loading={loading}
+      error={error}
+      message={'Loading…'}
+      render={() => {
+        const {publicUser: {credentials}} = me
+        const {rules, userPreference} = discussion
+
+        return (
+          <DiscussionPreferencesEditor
+            t={t}
+            credentials={credentials}
+            rules={rules}
+            userPreference={userPreference}
+            onClose={onClose}
+            setDiscussionPreferences={setDiscussionPreferences}
+          />
+        )
+      }}
+    />
+  </Overlay>
+)
+
+DiscussionPreferences.propTypes = {
+  discussionId: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  setDiscussionPreferences: PropTypes.func.isRequired
+}
+
+export default compose(
+  withT,
+  withDiscussionPreferences,
+  withSetDiscussionPreferences
+)(DiscussionPreferences)
+
+class DiscussionPreferencesEditor extends PureComponent {
+  constructor (props) {
+    super(props)
+
+    this.state = (() => {
+      if (!props.userPreference) {
+        return {anonymity: false, credential: null}
+      }
+
+      const {anonymity, credential} = props.userPreference
+      return {
+        anonymity,
+        credential: credential ? credential.description : null
+      }
+    })()
+
+    this.onChangeAnonymity = (_, anonymity) => {
+      this.setState({anonymity})
+    }
+
+    this.onSave = () => {
+      const {onClose, setDiscussionPreferences} = this.props
+      const {anonymity, credential} = this.state
+
+      setDiscussionPreferences(anonymity, credential).then(
+        () => {
+          onClose()
+        },
+        (e) => {
+          console.error(e)
+        }
+      )
+    }
+  }
+
+  render () {
+    const {t, credentials, rules, onClose} = this.props
+
+    const anonymity = (() => {
+      switch (rules.anonymity) {
+        case 'ALLOWED': return {
+          disabled: false,
+          value: this.state.anonymity
+        }
+        case 'ENFORCED': return {
+          disabled: true,
+          value: true
+        }
+        case 'FORBIDDEN': return {
+          disabled: true,
+          value: false
+        }
+        default: {
+          console.warn(`DiscussionPreferencesForm: unknown anonymity permission: ${rules.anonymity}`)
+          return {
+            disabled: true,
+            value: false
+          }
+        }
+      }
+    })()
+
+    const descriptionOptions = credentials.map(cred => ({
+      value: cred.description,
+      text: cred.description
+    }))
+
+    // Append the credential string to the options if it dosen't appear in them
+    // (ie. user has entered a new one into the input field).
+    if (descriptionOptions.indexOf(item => item.text === this.state.credential) === -1) {
+      descriptionOptions.push({
+        value: this.state.credential,
+        text: this.state.credential
+      })
+    }
+
+    return (
+      <div>
+        <OverlayToolbar>
+          <OverlayToolbarClose onClick={onClose} />
+          <OverlayToolbarConfirm label={t('components/DiscussionPreferences/save')} onClick={this.onSave} />
+        </OverlayToolbar>
+
+        <OverlayBody>
+          <div style={{marginBottom: 12}}>
+            <Checkbox
+              disabled={anonymity.disabled}
+              checked={anonymity.value}
+              onChange={this.onChangeAnonymity}
+            >
+              {t('components/DiscussionPreferences/commentAnonymously')}
+            </Checkbox>
+          </div>
+
+          <Dropdown
+            label={t('components/DiscussionPreferences/credentialLabel')}
+            items={descriptionOptions}
+            value={this.state.credential}
+            onChange={(item) => {
+              this.setState({credential: item.value})
+            }}
+          />
+
+          <Field
+            label={t('components/DiscussionPreferences/newCredentialLabel')}
+            value={this.state.credential}
+            onChange={(_, value) => { this.setState({credential: value}) }}
+          />
+        </OverlayBody>
+      </div>
+    )
+  }
+}

--- a/components/Discussion/DiscussionPreferences.js
+++ b/components/Discussion/DiscussionPreferences.js
@@ -120,7 +120,7 @@ class DiscussionPreferencesEditor extends PureComponent {
       text: cred.description
     }))
 
-    // Append the credential string to the options if it dosen't appear in them
+    // Append the credential string to the options if it doesn't appear in them
     // (ie. user has entered a new one into the input field).
     if (descriptionOptions.indexOf(item => item.text === this.state.credential) === -1) {
       descriptionOptions.push({

--- a/components/Discussion/DiscussionPreferences.js
+++ b/components/Discussion/DiscussionPreferences.js
@@ -20,7 +20,7 @@ export const DiscussionPreferences = ({t, data: {loading, error, me, discussion}
     <Loader
       loading={loading}
       error={error}
-      message={'Loading…'}
+      message={t('components/DiscussionPreferences/loading')}
       render={() => {
         const {publicUser: {credentials}} = me
         const {rules, userPreference} = discussion

--- a/components/Discussion/DiscussionTree.js
+++ b/components/Discussion/DiscussionTree.js
@@ -5,6 +5,7 @@ import Loader from '../Loader'
 import withT from '../../lib/withT'
 import timeago from '../../lib/timeago'
 import {countNodes, withData, downvoteComment, upvoteComment, submitComment} from './enhancers'
+import DiscussionPreferences from './DiscussionPreferences'
 
 class DiscussionTreePortal extends PureComponent {
   constructor (props) {
@@ -56,7 +57,22 @@ class DiscussionTreeRenderer extends PureComponent {
   constructor (props) {
     super(props)
 
-    this.state = { now: Date.now() }
+    this.state = {
+      now: Date.now(),
+      showPreferences: false
+    }
+
+    this.showPreferences = () => {
+      this.setState({
+        showPreferences: true
+      })
+    }
+
+    this.closePreferences = () => {
+      this.setState({
+        showPreferences: false
+      })
+    }
 
     // Fetch more comments at the root level of this 'Discussion' tree.
     this.fetchMore = () => {
@@ -127,6 +143,7 @@ class DiscussionTreeRenderer extends PureComponent {
 
   render () {
     const {
+      discussionId,
       logicalDepth = 0,
       visualDepth = 0,
       top = true,
@@ -134,7 +151,7 @@ class DiscussionTreeRenderer extends PureComponent {
       data: {loading, error, me, discussion}
     } = this.props
 
-    const {now} = this.state
+    const {now, showPreferences} = this.state
     const timeagoFromNow = (createdAtString) => {
       return timeago(t, (now - Date.parse(createdAtString)) / 1000)
     }
@@ -164,9 +181,21 @@ class DiscussionTreeRenderer extends PureComponent {
                   onClick={this.fetchMore}
                 />
               )
-            } else {
-              return null
             }
+            return null
+          })()
+
+          const discussionPreferences = (() => {
+            if (showPreferences) {
+              return (
+                <DiscussionPreferences
+                  key='discussionPreferenes'
+                  discussionId={discussionId}
+                  onClose={this.closePreferences}
+                />
+              )
+            }
+            return null
           })()
 
           return [
@@ -182,13 +211,15 @@ class DiscussionTreeRenderer extends PureComponent {
                 displayAuthor={displayAuthor}
                 comment={comment}
                 timeago={timeagoFromNow}
+                onEditPreferences={this.showPreferences}
                 upvoteComment={this.props.upvoteComment}
                 downvoteComment={this.props.downvoteComment}
                 submitComment={this.props.submitComment}
                 More={this.More}
               />
             )),
-            tail
+            tail,
+            discussionPreferences
           ]
         }}
       />

--- a/components/Discussion/enhancers.js
+++ b/components/Discussion/enhancers.js
@@ -31,9 +31,7 @@ query discussionMe($discussionId: ID!) {
   }
 }
 `
-export const withMe = graphql(meQuery, {
-  variables: ({discussionId}) => ({discussionId})
-})
+export const withMe = graphql(meQuery)
 
 export const commentsSubscription = gql`
 subscription discussionComments($discussionId: ID!) {
@@ -129,9 +127,6 @@ const modifyComment = (comment, id, onComment) => {
 }
 
 export const withData = graphql(rootQuery, {
-  variables: ({discussionId, parentId, after, orderBy}) => ({
-    discussionId, parentId, after, orderBy
-  }),
   props: ({ownProps: {discussionId, orderBy}, data: {fetchMore, subscribeToMore, ...data}}) => ({
     data,
     fetchMore: (parentId, after) => fetchMore({
@@ -394,9 +389,7 @@ query discussionPreferences($discussionId: ID!) {
   }
 }
 `
-export const withDiscussionPreferences = graphql(discussionPreferencesQuery, {
-  variables: ({discussionId}) => ({discussionId})
-})
+export const withDiscussionPreferences = graphql(discussionPreferencesQuery)
 
 export const withSetDiscussionPreferences = graphql(gql`
 mutation setDiscussionPreferences($discussionId: ID!, $discussionPreferences: DiscussionPreferencesInput!) {

--- a/components/Frame/index.js
+++ b/components/Frame/index.js
@@ -13,6 +13,7 @@ css.global('html', { boxSizing: 'border-box' })
 css.global('*, *:before, *:after', { boxSizing: 'inherit' })
 
 css.global('body', {
+  width: '100%',
   fontFamily: fontFamilies.sansSerifRegular
 })
 

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-11-02T12:29:43.882Z",
+  "updated": "2017-11-08T05:55:05.233Z",
   "title": "live",
   "data": [
     {
@@ -677,6 +677,22 @@
     {
       "key": "timeago/years/other",
       "value": "vor {count} Jahren"
+    },
+    {
+      "key": "components/DiscussionPreferences/save",
+      "value": "Speichern"
+    },
+    {
+      "key": "components/DiscussionPreferences/commentAnonymously",
+      "value": "Anonym kommentieren"
+    },
+    {
+      "key": "components/DiscussionPreferences/credentialLabel",
+      "value": "Bezeichnung"
+    },
+    {
+      "key": "components/DiscussionPreferences/newCredentialLabel",
+      "value": "Neue Bezeichnung erstellen"
     }
   ]
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-11-08T05:55:05.233Z",
+  "updated": "2017-11-08T10:50:06.945Z",
   "title": "live",
   "data": [
     {
@@ -693,6 +693,10 @@
     {
       "key": "components/DiscussionPreferences/newCredentialLabel",
       "value": "Neue Bezeichnung erstellen"
+    },
+    {
+      "key": "components/DiscussionPreferences/loading",
+      "value": "Loading…"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-3.3.0.tgz",
-      "integrity": "sha1-OtVElOlUckZqlhu/ccGzzYVXLgY=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-3.5.0.tgz",
+      "integrity": "sha1-EBHxwZDUA90Y917SQ8ozfzMv5Dk=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
-    "@project-r/styleguide": "^3.3.0",
+    "@project-r/styleguide": "^3.5.0",
     "d3-array": "^1.1.1",
     "d3-format": "^1.2.0",
     "d3-time-format": "^2.0.5",


### PR DESCRIPTION
The discussion preferences open an an Overlay. There is currently one checkbox to control the anonymity and a dropdown + input field to allow the user to select / edit the credential.

![image](https://user-images.githubusercontent.com/34538/32534409-b9f9da32-c455-11e7-8e49-01c7f5904de5.png)

