### PR TITLE
Use a new enhancer to inject the displayAuthor as it will be used when the current user submits a new comment

### DIFF
--- a/components/Discussion/DiscussionCommentComposer.js
+++ b/components/Discussion/DiscussionCommentComposer.js
@@ -2,7 +2,7 @@ import React, {PureComponent} from 'react'
 import {compose} from 'redux'
 import {CommentComposer, CommentComposerPlaceholder} from '@project-r/styleguide'
 import withT from '../../lib/withT'
-import {withMe, submitComment} from './enhancers'
+import {withMe, withDiscussionDisplayAuthor, submitComment} from './enhancers'
 import DiscussionPreferences from './DiscussionPreferences'
 
 class DiscussionCommentComposer extends PureComponent {
@@ -64,33 +64,20 @@ class DiscussionCommentComposer extends PureComponent {
   }
 
   render () {
-    const {t, discussionId, data: {loading, error, discussion, me}} = this.props
+    const {t, discussionId, discussionDisplayAuthor: displayAuthor, data: {loading, error, me}} = this.props
     const {state, showPreferences} = this.state
 
     if (loading || error || !me) {
       return null
     } else {
-      const profilePicture = me.publicUser && me.publicUser.testimonial && me.publicUser.testimonial.image
-
       if (state === 'idle') {
         return (
           <CommentComposerPlaceholder
             t={t}
-            profilePicture={profilePicture}
+            profilePicture={displayAuthor ? displayAuthor.profilePicture : null}
             onClick={this.onFocus}
           />
         )
-      }
-
-      const credential = (() => {
-        const {userPreference} = discussion
-        return userPreference ? userPreference.credential : undefined
-      })()
-
-      const displayAuthor = {
-        profilePicture,
-        name: me.name,
-        credential
       }
 
       return (
@@ -118,5 +105,6 @@ class DiscussionCommentComposer extends PureComponent {
 export default compose(
   withT,
   withMe,
+  withDiscussionDisplayAuthor,
   submitComment
 )(DiscussionCommentComposer)

--- a/components/Discussion/DiscussionTree.js
+++ b/components/Discussion/DiscussionTree.js
@@ -4,7 +4,7 @@ import {colors, CommentTreeLoadMore, CommentTreeCollapse, CommentTreeNode} from 
 import Loader from '../Loader'
 import withT from '../../lib/withT'
 import timeago from '../../lib/timeago'
-import {maxLogicalDepth, countNodes, withData, downvoteComment, upvoteComment, submitComment} from './enhancers'
+import {maxLogicalDepth, countNodes, withDiscussionDisplayAuthor, withData, downvoteComment, upvoteComment, submitComment} from './enhancers'
 import DiscussionPreferences from './DiscussionPreferences'
 
 class DiscussionTreePortal extends PureComponent {
@@ -147,6 +147,7 @@ class DiscussionTreeRenderer extends PureComponent {
   render () {
     const {
       discussionId,
+      discussionDisplayAuthor: displayAuthor,
       logicalDepth = 0,
       visualDepth = 0,
       top = true,
@@ -165,12 +166,6 @@ class DiscussionTreeRenderer extends PureComponent {
         error={error}
         message={'Loading…'}
         render={() => {
-          const displayAuthor = {
-            publicPicture: me.publicUser && me.publicUser.testimonial && me.publicUser.testimonial.image,
-            name: me.name,
-            credential: discussion.userPreference && discussion.userPreference.credential
-          }
-
           // This is the 'CommentTreeLoadMore' element which loads more comments in the discussion root.
           const tail = (() => {
             const {totalCount, pageInfo, nodes} = discussion.comments
@@ -232,6 +227,7 @@ class DiscussionTreeRenderer extends PureComponent {
 
 const DiscussionTree = compose(
   withT,
+  withDiscussionDisplayAuthor,
   withData,
   upvoteComment,
   downvoteComment,

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-11-08T10:50:06.945Z",
+  "updated": "2017-11-08T13:15:47.466Z",
   "title": "live",
   "data": [
     {
@@ -697,6 +697,10 @@
     {
       "key": "components/DiscussionPreferences/loading",
       "value": "Loading…"
+    },
+    {
+      "key": "discussion/displayUser/anonymous",
+      "value": "Anonym"
     }
   ]
 }


### PR DESCRIPTION
The displayAuthor is currently extracted from `me` and the `discussion` rules and user preferences. But it would be better to make it a separate type with its own id so that when it's updated it changes on the whole page (also in the discussion comments themselves).

I also noticed that the string "Anonymous" is included in the server responses. Should that be translated by the server to the correct locale? Or should the client handle all localization? The string "Anonym" that is shown in the CommentComposer when the user decides to comment anonymously is pulled out of the translations (see the diff).

![image](https://user-images.githubusercontent.com/34538/32552950-ccb34a88-c495-11e7-8c69-529178660a20.png)
