### PR TITLE
Use the updated CommentTree components

### DIFF
--- a/components/Discussion/DiscussionTree.js
+++ b/components/Discussion/DiscussionTree.js
@@ -30,7 +30,7 @@ class DiscussionTreePortal extends PureComponent {
           <DiscussionTree
             {...props}
             visualDepth={1}
-            top={false}
+            top
             head={false}
             tail={false}
             t={t}
@@ -45,7 +45,8 @@ class DiscussionTreePortal extends PureComponent {
     return (
       <CommentTreeLoadMore
         t={t}
-        visualDepth={this.props.visualDepth - 1}
+        visualDepth={this.props.visualDepth}
+        connected={this.props.connected}
         count={count}
         onClick={this.toggle}
       />
@@ -92,7 +93,7 @@ class DiscussionTreeRenderer extends PureComponent {
       }
     }
 
-    const More = ({visualDepth, logicalDepth, comment}) => {
+    const More = ({visualDepth, connected, logicalDepth, comment}) => {
       const {t, discussionId, orderBy} = this.props
       const {comments} = comment
 
@@ -109,6 +110,7 @@ class DiscussionTreeRenderer extends PureComponent {
               orderBy={orderBy}
               count={count}
               visualDepth={visualDepth}
+              connected={connected}
             />
           )
         } else if (pageInfo && pageInfo.hasNextPage) {
@@ -116,6 +118,7 @@ class DiscussionTreeRenderer extends PureComponent {
             <CommentTreeLoadMore
               t={t}
               visualDepth={visualDepth}
+              connected={connected}
               count={count}
               onClick={() => this.fetchMoreReplies(comment)}
             />

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-3.5.0.tgz",
-      "integrity": "sha1-EBHxwZDUA90Y917SQ8ozfzMv5Dk=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-4.0.0.tgz",
+      "integrity": "sha1-Ujs+Itm3PYtYMkVF1QGZ23tLm3Q=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "tape": "^4.8.0"
   },
   "dependencies": {
-    "@project-r/styleguide": "^3.5.0",
+    "@project-r/styleguide": "^4.0.0",
     "d3-array": "^1.1.1",
     "d3-format": "^1.2.0",
     "d3-time-format": "^2.0.5",


### PR DESCRIPTION
Upgrade styleguide dependency to 4.x, and make compatible with the new `<CommentTreeLoadMore>` component because its API has changed.