### PR TITLE
port auth notifications page from cf

### DIFF
--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -146,8 +146,8 @@ SignIn.propTypes = {
 }
 
 const signInMutation = gql`
-mutation signIn($email: String!) {
-  signIn(email: $email) {
+mutation signIn($email: String!, $context: String) {
+  signIn(email: $email, context: $context) {
     phrase
   }
 }
@@ -155,8 +155,8 @@ mutation signIn($email: String!) {
 
 export const withSignIn = graphql(signInMutation, {
   props: ({mutate}) => ({
-    signIn: (email) =>
-      mutate({variables: {email}})
+    signIn: (email, context = 'signIn') =>
+      mutate({variables: {email, context}})
   })
 })
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -15,6 +15,7 @@ routes
   .add('media', '/media')
   .add('pledge', '/pledge')
   .add('claim', '/claim')
+  .add('notifications', '/notifications')
   .add('legal/imprint', '/legal/imprint')
   .add('legal/privacy', '/legal/privacy')
   .add('legal/statute', '/legal/statute')

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2017-12-04T02:28:38.516Z",
+  "updated": "2017-12-04T14:09:29.308Z",
   "title": "live",
   "data": [
     {
@@ -8,7 +8,7 @@
     },
     {
       "key": "nav/feed",
-      "value": "Neues"
+      "value": "Feed"
     },
     {
       "key": "nav/discussion",
@@ -32,7 +32,7 @@
     },
     {
       "key": "pages/account/title",
-      "value": "Mein Konto"
+      "value": "Konto ansehen"
     },
     {
       "key": "pages/profile/pageTitle",
@@ -52,11 +52,11 @@
     },
     {
       "key": "Frame/Popover/myaccount",
-      "value": "Mein Konto"
+      "value": "Konto"
     },
     {
       "key": "Frame/Popover/myprofile",
-      "value": "Mein Profil"
+      "value": "Profil"
     },
     {
       "key": "withAuthorization/title",
@@ -1449,6 +1449,42 @@
     {
       "key": "memberships/sequenceNumber/suffix",
       "value": "#{sequenceNumber}"
+    },
+    {
+      "key": "notifications/pageTitle",
+      "value": "Mitteilung – Republik"
+    },
+    {
+      "key": "notifications/email-confirmed/title",
+      "value": "E-Mail-Adresse ist bestätigt"
+    },
+    {
+      "key": "notifications/email-confirmed/text",
+      "value": "Perfekt! Ihre E-Mail-Adresse ist somit bestätigt. Sie können dieses Fenster wieder schliessen."
+    },
+    {
+      "key": "notifications/invalid-token/title",
+      "value": "Ungültiger Link"
+    },
+    {
+      "key": "notifications/invalid-token/text",
+      "value": "Der von Ihnen aufgerufene Link ist nicht gültig. Links zur Anmeldung sind nur einmal gültig."
+    },
+    {
+      "key": "notifications/unavailable/title",
+      "value": "System nicht verfügbar"
+    },
+    {
+      "key": "notifications/unavailable/text",
+      "value": "Leider kann unser System Ihre Anfrage zur Zeit nicht bearbeiten. Versuchen Sie es in 10 Minuten erneut. Klappt es ein zweites Mal nicht, stehen wir Ihnen gerne mit Rat zur Verfügung. Schreiben Sie uns an <a href=\"mailto:kontakt@republik.ch?subject=Anmeldung%20nicht%20verf%C3%BCgbar\">kontakt@republik.ch</a>."
+    },
+    {
+      "key": "notifications/links/home",
+      "value": "Startseite"
+    },
+    {
+      "key": "notifications/links/merci",
+      "value": "Ihre persönliche Übersicht"
     }
   ]
 }

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import { css } from 'glamor'
+import Head from 'next/head'
+
+import withData from '../lib/apollo/withData'
+import withT from '../lib/withT'
+import { intersperse } from '../lib/utils/helpers'
+import { Link } from '../lib/routes'
+
+import Me from '../components/Auth/Me'
+
+import {
+  Interaction, NarrowContainer, Logo, linkRule, RawHtml
+} from '@project-r/styleguide'
+
+const styles = {
+  logo: css({
+    textAlign: 'center',
+    maxWidth: 207,
+    margin: '0 auto',
+    paddingTop: 26
+  }),
+  text: css({
+    margin: '120px auto',
+    textAlign: 'center',
+    maxWidth: 580
+  }),
+  link: css({
+    marginTop: 20
+  }),
+  me: css({
+    marginTop: 80,
+    marginBottom: 80
+  })
+}
+
+const {H1, P} = Interaction
+
+export default withData(withT(({url: {query: {type, context, email}}, t}) => {
+  const links = [
+    context === 'pledge' && {
+      route: 'account',
+      label: t('notifications/links/merci')
+    }
+  ].filter(Boolean)
+
+  return (
+    <div>
+      <Head>
+        <title>{t('notifications/pageTitle')}</title>
+        <meta name='robots' content='noindex' />
+      </Head>
+      <NarrowContainer>
+        <div {...styles.logo}>
+          <Link route='index'>
+            <a><Logo /></a>
+          </Link>
+        </div>
+        <div {...styles.text}>
+          <H1>
+            {t(`notifications/${type}/title`, undefined, '')}
+          </H1>
+          <RawHtml type={P} dangerouslySetInnerHTML={{
+            __html: t(`notifications/${type}/text`, undefined, '')
+          }} />
+          {(
+            type === 'invalid-token' &&
+            (
+              context === 'signIn' ||
+              context === 'pledge'
+            )
+          ) && (
+            <div {...styles.me}>
+              <Me email={email} />
+            </div>
+          )}
+          {links.length > 0 && <P {...styles.link}>
+            {intersperse(links.map((link, i) => (
+              <Link key={i} route={link.route} params={link.params}>
+                <a {...linkRule}>
+                  {link.label}
+                </a>
+              </Link>
+            )), () => ' – ')}
+          </P>}
+        </div>
+      </NarrowContainer>
+    </div>
+  )
+}))


### PR DESCRIPTION
Adds nice landing page to the sign in flow with context and error help.

Examples:
http://localhost:3010/notifications?type=email-confirmed&context=pledge
http://localhost:3010/notifications?type=invalid-token&context=pledge
http://localhost:3010/notifications?type=unavailable&context=pledge

<img width="914" alt="screen shot 2017-12-04 at 15 46 38" src="https://user-images.githubusercontent.com/410211/33558564-7852b792-d90a-11e7-8a2b-dbcae4338a80.png">
<img width="914" alt="screen shot 2017-12-04 at 15 47 33" src="https://user-images.githubusercontent.com/410211/33558562-781be55a-d90a-11e7-91fa-58e3dd297129.png">
<img width="914" alt="screen shot 2017-12-04 at 15 47 01" src="https://user-images.githubusercontent.com/410211/33558563-78366e70-d90a-11e7-9ae7-27bc69aadc63.png">
