### PR TITLE
implement states of request preview form

### DIFF
--- a/components/Marketing/PreviewForm.js
+++ b/components/Marketing/PreviewForm.js
@@ -4,6 +4,7 @@ import gql from 'graphql-tag'
 import withMe from '../../lib/apollo/withMe'
 import { withSignIn } from '../Auth/SignIn'
 import withT from '../../lib/withT'
+import ErrorMessage from '../ErrorMessage'
 import FieldSet from '../FieldSet'
 import Loader from '../Loader'
 import Poller from '../Auth/Poller'
@@ -18,7 +19,8 @@ class PreviewForm extends Component {
       success: undefined,
       values: {},
       errors: {},
-      dirty: {}
+      dirty: {},
+      serverError: undefined
     }
   }
 
@@ -83,6 +85,7 @@ class PreviewForm extends Component {
       values,
       dirty,
       errors,
+      serverError,
       polling,
       success,
       phrase
@@ -134,6 +137,7 @@ class PreviewForm extends Component {
               {t('marketing/preview/button/label')}
             </Button>
           </div>
+          {!!serverError && <ErrorMessage error={serverError} />}
         </Fragment>
       )
     }
@@ -164,6 +168,7 @@ class PreviewForm extends Component {
         >
           {t('marketing/preview/button/label')}
         </Button>
+        {!!serverError && <ErrorMessage error={serverError} />}
       </Fragment>
     )
   }

--- a/components/Marketing/PreviewForm.js
+++ b/components/Marketing/PreviewForm.js
@@ -67,9 +67,10 @@ class PreviewForm extends Component {
 
     this.props
       .requestPreview(me.email)
-      .then(() => {
+      .then(({data}) => {
         this.setState(() => ({
-          loading: false
+          loading: false,
+          success: data.requestPreview.success
         }))
       })
       .catch(catchError)
@@ -169,20 +170,18 @@ class PreviewForm extends Component {
 }
 
 const requestPreview = gql`
-  mutation requestPreview($email: String!) {
-    requestPreview(email: $email)
+  mutation requestPreview {
+    requestPreview {
+      success
+    }
   }
 `
 
 export default compose(
   graphql(requestPreview, {
     props: ({ mutate }) => ({
-      requestPreview: email =>
-        mutate({
-          variables: {
-            email
-          }
-        })
+      requestPreview: () =>
+        mutate()
     })
   }),
   withSignIn,

--- a/components/Marketing/PreviewForm.js
+++ b/components/Marketing/PreviewForm.js
@@ -22,7 +22,8 @@ class PreviewForm extends Component {
     }
   }
 
-  handleEmail (value, shouldValidate, t) {
+  handleEmail (value, shouldValidate) {
+    const {t} = this.props
     this.setState(
       FieldSet.utils.mergeField({
         field: 'email',
@@ -67,7 +68,9 @@ class PreviewForm extends Component {
     this.props
       .requestPreview(me.email)
       .then(() => {
-        console.log('done')
+        this.setState(() => ({
+          loading: false
+        }))
       })
       .catch(catchError)
   }
@@ -113,6 +116,10 @@ class PreviewForm extends Component {
       return <Loader loading />
     }
 
+    if (success) {
+      return <Interaction.P>{t('marketing/preview/success')}</Interaction.P>
+    }
+
     if (me) {
       return (
         <Fragment>
@@ -120,21 +127,14 @@ class PreviewForm extends Component {
           <div style={{ marginTop: 20 }}>
             <Button
               onClick={() => {
-                if (loading) {
-                  return
-                }
                 this.requestPreview()
               }}
             >
-              Bestellen
+              {t('marketing/preview/button/label')}
             </Button>
           </div>
         </Fragment>
       )
-    }
-
-    if (success) {
-      return <Interaction.P>{t('marketing/preview/success')}</Interaction.P>
     }
 
     return (
@@ -146,7 +146,7 @@ class PreviewForm extends Component {
           label={t('marketing/preview/email/label')}
           error={dirty && errors.email}
           onChange={(_, value, shouldValidate) => {
-            this.handleEmail(value, shouldValidate, t)
+            this.handleEmail(value, shouldValidate)
           }}
           value={values.email}
         />
@@ -158,13 +158,10 @@ class PreviewForm extends Component {
               }))
               return
             }
-            if (loading) {
-              return
-            }
             this.requestPreview()
           }}
         >
-          Bestellen
+          {t('marketing/preview/button/label')}
         </Button>
       </Fragment>
     )

--- a/components/Marketing/PreviewForm.js
+++ b/components/Marketing/PreviewForm.js
@@ -1,46 +1,158 @@
-import React, { Component } from 'react'
-import { compose } from 'react-apollo'
+import React, { Component, Fragment } from 'react'
+import { compose, graphql } from 'react-apollo'
+import gql from 'graphql-tag'
+import withMe from '../../lib/apollo/withMe'
+import { withSignIn } from '../Auth/SignIn'
 import withT from '../../lib/withT'
+import FieldSet from '../FieldSet'
+import Loader from '../Loader'
+import Poller from '../Auth/Poller'
 import { validate as isEmail } from 'email-validator'
-import { Button, Field } from '@project-r/styleguide'
-
-// TODO: hook this up with a backend mutation.
+import { Button, Field, Interaction, RawHtml } from '@project-r/styleguide'
 
 class PreviewForm extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      email: props.email || '',
       loading: false,
-      success: undefined
+      success: undefined,
+      values: {},
+      errors: {},
+      dirty: {}
     }
   }
 
+  handleEmail (value, shouldValidate, t) {
+    this.setState(
+      FieldSet.utils.mergeField({
+        field: 'email',
+        value,
+        error:
+          (value.trim().length <= 0 &&
+            t('marketing/preview/email/error/empty')) ||
+          (!isEmail(value) && t('marketing/preview/email/error/invalid')),
+        dirty: shouldValidate
+      })
+    )
+  }
+
+  requestPreview () {
+    const { me } = this.props
+    const { values } = this.state
+
+    this.setState(() => ({
+      loading: true
+    }))
+
+    const catchError = error => {
+      this.setState(() => ({
+        loading: false,
+        serverError: error
+      }))
+    }
+
+    if (!me) {
+      this.props
+        .signIn(values.email)
+        .then(({ data }) => {
+          this.setState(() => ({
+            polling: true,
+            phrase: data.signIn.phrase
+          }))
+        })
+        .catch(catchError)
+      return
+    }
+
+    this.props
+      .requestPreview(me.email)
+      .then(() => {
+        console.log('done')
+      })
+      .catch(catchError)
+  }
+
   render () {
-    const { t } = this.props
-    const { loading, error, dirty, email } = this.state
+    const { t, me } = this.props
+    const {
+      loading,
+      values,
+      dirty,
+      errors,
+      polling,
+      success,
+      phrase
+    } = this.state
+
+    if (polling) {
+      return (
+        <div>
+          <RawHtml
+            type={Interaction.P}
+            dangerouslySetInnerHTML={{
+              __html: t('signIn/polling', {
+                phrase,
+                email: values.email
+              })
+            }}
+          />
+          <Poller
+            onSuccess={() => {
+              this.setState(() => ({
+                polling: false,
+                success: true
+              }))
+              this.requestPreview()
+            }}
+          />
+        </div>
+      )
+    }
+
+    if (loading) {
+      return <Loader loading />
+    }
+
+    if (me) {
+      return (
+        <Fragment>
+          <Interaction.P>{t('marketing/preview/text')}</Interaction.P>
+          <div style={{ marginTop: 20 }}>
+            <Button
+              onClick={() => {
+                if (loading) {
+                  return
+                }
+                this.requestPreview()
+              }}
+            >
+              Bestellen
+            </Button>
+          </div>
+        </Fragment>
+      )
+    }
+
+    if (success) {
+      return <Interaction.P>{t('marketing/preview/success')}</Interaction.P>
+    }
+
     return (
-      <div>
+      <Fragment>
+        <Interaction.P>{t('marketing/preview/text')}</Interaction.P>
         <Field
           name='email'
           type='email'
           label={t('marketing/preview/email/label')}
-          error={dirty && error}
+          error={dirty && errors.email}
           onChange={(_, value, shouldValidate) => {
-            this.setState(() => ({
-              email: value,
-              error:
-                (value.trim().length <= 0 &&
-                  t('marketing/preview/email/error/empty')) ||
-                (!isEmail(value) && t('marketing/preview/email/error/invalid')),
-              dirty: shouldValidate
-            }))
+            this.handleEmail(value, shouldValidate, t)
           }}
-          value={email}
+          value={values.email}
         />
         <Button
           onClick={() => {
-            if (error) {
+            if (errors.email) {
               this.setState(() => ({
                 dirty: true
               }))
@@ -49,16 +161,34 @@ class PreviewForm extends Component {
             if (loading) {
               return
             }
-            this.setState(() => ({
-              loading: true
-            }))
+            this.requestPreview()
           }}
         >
           Bestellen
         </Button>
-      </div>
+      </Fragment>
     )
   }
 }
 
-export default compose(withT)(PreviewForm)
+const requestPreview = gql`
+  mutation requestPreview($email: String!) {
+    requestPreview(email: $email)
+  }
+`
+
+export default compose(
+  graphql(requestPreview, {
+    props: ({ mutate }) => ({
+      requestPreview: email =>
+        mutate({
+          variables: {
+            email
+          }
+        })
+    })
+  }),
+  withSignIn,
+  withMe,
+  withT
+)(PreviewForm)

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -117,7 +117,6 @@ const MarketingPage = ({ t, crowdfundingName }) => [
         <Interaction.H3 style={{ marginBottom: '17px' }}>
           {t('marketing/preview/title')}
         </Interaction.H3>
-        <Interaction.P>{t('marketing/preview/text')}</Interaction.P>
         <PreviewForm />
       </div>
       <div {...styles.offers}>

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-07T22:59:25.163Z",
+  "updated": "2018-01-08T19:14:31.915Z",
   "title": "live",
   "data": [
     {
@@ -356,7 +356,7 @@
     },
     {
       "key": "marketing/preview/text",
-      "value": "Wir erwarten keinesfalls, dass Sie bei einem derart bedeutenden Entscheid die Katze im Sack kaufen. Und senden Ihnen deshalb gerne ein eine kleine Sammlung von Artikeln der letzten Zeit per Mail zu.",
+      "value": "Wir erwarten keinesfalls, dass Sie bei einem derart bedeutenden Entscheid die Katze im Sack kaufen. Und senden Ihnen deshalb gerne eine kleine Sammlung von Artikeln der letzten Zeit per Mail zu.",
       "Clara ok": "x",
       "Braucht Const": "x",
       "Korrektorat": null,
@@ -382,6 +382,14 @@
       "key": "marketing/preview/email/error/invalid",
       "value": "E-Mail ungültig",
       "Clara ok": "x",
+      "Braucht Const": null,
+      "Korrektorat": null,
+      "Bemerkung": null
+    },
+    {
+      "key": "marketing/preview/success",
+      "value": "Wir haben Ihnen eine kleine Sammlung von Artikeln per Mail zugeschickt.",
+      "Clara ok": null,
       "Braucht Const": null,
       "Korrektorat": null,
       "Bemerkung": null

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -387,6 +387,14 @@
       "Bemerkung": null
     },
     {
+      "key": "marketing/preview/button/label",
+      "value": "Bestellen",
+      "Clara ok": null,
+      "Braucht Const": null,
+      "Korrektorat": null,
+      "Bemerkung": null
+    },
+    {
       "key": "marketing/preview/success",
       "value": "Wir haben Ihnen eine kleine Sammlung von Artikeln per Mail zugeschickt.",
       "Clara ok": null,


### PR DESCRIPTION
Known issues / TODO:
- {signinLink} not replaced yet in signin phrase.
- if requesting user ends up being a member after signin-in, the preview mutation is triggered, but the success message won't show anymore (because the user ends up on the front).

Logged out:
<img width="563" alt="screen shot 2018-01-08 at 20 15 37" src="https://user-images.githubusercontent.com/23520051/34688219-b55052fe-f4b1-11e7-95c2-01b74b98b7b6.png">

Logged in, but !isAuthorized:
<img width="551" alt="screen shot 2018-01-08 at 20 18 34" src="https://user-images.githubusercontent.com/23520051/34688251-ca463b42-f4b1-11e7-9270-7603287f208a.png">

Loading:
<img width="554" alt="screen shot 2018-01-08 at 20 16 39" src="https://user-images.githubusercontent.com/23520051/34688259-d3c66de0-f4b1-11e7-93c0-bc41e09318e6.png">

Signin:
<img width="556" alt="screen shot 2018-01-08 at 20 15 55" src="https://user-images.githubusercontent.com/23520051/34688279-e1f3b0b2-f4b1-11e7-8a3b-f898d033e06f.png">

Success:
<img width="557" alt="screen shot 2018-01-08 at 20 16 19" src="https://user-images.githubusercontent.com/23520051/34688298-ebf7fc58-f4b1-11e7-8cd6-867b2caf308a.png">




  