### PR TITLE
proposal for a generic signin page

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@ const routes = nextRoutes()
 
 routes
   .add('index', '/')
+  .add('signin', '/anmelden')
   .add('account', '/account')
   .add('profile', '/~:slug')
   .add('discussions', '/discussions')

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-09T17:57:33.891Z",
+  "updated": "2018-01-09T18:57:09.819Z",
   "title": "live",
   "data": [
     {
@@ -62,6 +62,14 @@
       "key": "pages/account/title",
       "value": "Konto",
       "Clara ok": "x",
+      "Braucht Const": null,
+      "Korrektorat": null,
+      "Bemerkung": null
+    },
+    {
+      "key": "pages/signin/title",
+      "value": "Anmelden",
+      "Clara ok": null,
       "Braucht Const": null,
       "Korrektorat": null,
       "Bemerkung": null

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -1,0 +1,44 @@
+import React, { Component } from 'react'
+import { compose } from 'react-apollo'
+import Router from 'next/router'
+import SignIn from '../components/Auth/SignIn'
+import Frame from '../components/Frame'
+import withData from '../lib/apollo/withData'
+import withMe from '../lib/apollo/withMe'
+import withT from '../lib/withT'
+import withMembership from '../components/Auth/withMembership'
+import { Container, Spinner } from '@project-r/styleguide'
+
+class SigninPage extends Component {
+  componentDidUpdate () {
+    const { isAuthorized, me } = this.props
+    if (isAuthorized) {
+      Router.push('/')
+      return
+    }
+    if (me) {
+      Router.push('/account')
+    }
+  }
+
+  render () {
+    const { url, t, me } = this.props
+    const meta = {
+      title: t('pages/signin/title')
+    }
+
+    if (me) {
+      return <Spinner />
+    }
+    return (
+      <Frame raw url={url} meta={meta}>
+        <Container style={{ marginTop: 100, maxWidth: 600 }}>
+          {/* TODO: some intro text. */}
+          <SignIn />
+        </Container>
+      </Frame>
+    )
+  }
+}
+
+export default compose(withData, withMe, withMembership, withT)(SigninPage)


### PR DESCRIPTION
`republik.ch/anmelden`

Use case: 
Point users to a signin page in all kinds of scenarios (newsletters, user guidance UI text, ...). 

After signing:
- Users with an active membership will be forwarded to the front.
- Users without an active membership will be forwarded to e.g. /account which will have some notification about membership status.

It works ... but you might have better suggestions on how to implement this.

Signed out state:
![screen shot 2018-01-09 at 20 07 04](https://user-images.githubusercontent.com/23520051/34738849-a4e62ba4-f57a-11e7-9415-a9b6ab89e912.png)

After sign-in, the page will show a spinner (and forward to either / or /account):
![screen shot 2018-01-09 at 20 07 15](https://user-images.githubusercontent.com/23520051/34738894-cd31d70c-f57a-11e7-8013-85c3104189e7.png)




  