### PR TITLE
newsletter subscriptions: guide user based on account status

### DIFF
--- a/components/Account/NewsletterSubscriptions.js
+++ b/components/Account/NewsletterSubscriptions.js
@@ -45,20 +45,25 @@ class NewsletterSubscriptions extends Component {
         error={error}
         ErrorContainer={ErrorContainer}
         render={() => {
-          const newsletters = me.newsletters
+          const { subscriptions, status } = me.newsletterProfile
           const { mutating } = this.state
-          const hasNonEligibleSubscription = newsletters.some(
+          const hasNonEligibleSubscription = subscriptions.some(
             newsletter => !newsletter.isEligible
           )
 
           return (
             <Fragment>
+              {status !== 'subscribed' && (
+                <Box style={{ margin: '10px 0', padding: 15 }}>
+                  <P>{t('account/newsletterSubscriptions/unsubscribed')}</P>
+                </Box>
+              )}
               {hasNonEligibleSubscription && (
-                <Box style={{ padding: 15 }}>
+                <Box style={{ margin: '10px 0', padding: 15 }}>
                   <P>{t('account/newsletterSubscriptions/noMembership')}</P>
                 </Box>
               )}
-              {newsletters.map(({ name, subscribed, isEligible }) => (
+              {subscriptions.map(({ name, subscribed, isEligible }) => (
                 <p key={name}>
                   <Checkbox
                     checked={subscribed}
@@ -80,7 +85,8 @@ class NewsletterSubscriptions extends Component {
                       }
                       updateNewsletterSubscription({
                         name,
-                        subscribed: checked
+                        subscribed: checked,
+                        status
                       }).then(finish)
                     }}
                   >
@@ -105,8 +111,9 @@ const mutation = gql`
   mutation updateNewsletterSubscription(
     $name: NewsletterName!
     $subscribed: Boolean!
+    $status: String!
   ) {
-    updateNewsletterSubscription(name: $name, subscribed: $subscribed) {
+    updateNewsletterSubscription(name: $name, subscribed: $subscribed, status: $status) {
       id
       name
       subscribed
@@ -119,11 +126,14 @@ const query = gql`
   query myNewsletterSubscriptions {
     me {
       id
-      newsletters {
-        id
-        name
-        subscribed
-        isEligible
+      newsletterProfile {
+        status
+        subscriptions {
+          id
+          name
+          subscribed
+          isEligible
+        }
       }
     }
   }
@@ -132,11 +142,12 @@ const query = gql`
 export default compose(
   graphql(mutation, {
     props: ({ mutate }) => ({
-      updateNewsletterSubscription: ({ name, subscribed }) =>
+      updateNewsletterSubscription: ({ name, subscribed, status }) =>
         mutate({
           variables: {
             name,
-            subscribed
+            subscribed,
+            status
           }
         })
     })

--- a/components/Account/NewsletterSubscriptions.js
+++ b/components/Account/NewsletterSubscriptions.js
@@ -45,7 +45,7 @@ class NewsletterSubscriptions extends Component {
         error={error}
         ErrorContainer={ErrorContainer}
         render={() => {
-          const { subscriptions, status } = me.newsletterProfile
+          const { subscriptions, status } = me.newsletterSettings
           const { mutating } = this.state
           const hasNonEligibleSubscription = subscriptions.some(
             newsletter => !newsletter.isEligible
@@ -123,10 +123,10 @@ const mutation = gql`
 `
 
 const query = gql`
-  query myNewsletterSubscriptions {
+  query myNewsletterSettings {
     me {
       id
-      newsletterProfile {
+      newsletterSettings {
         status
         subscriptions {
           id

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-10T16:16:21.941Z",
+  "updated": "2018-01-10T23:32:06.340Z",
   "title": "live",
   "data": [
     {
@@ -927,6 +927,14 @@
       "value": "Journalismus kostet. Deswegen können nur Mitglieder und Abonnenten die Republik-Newsletter abonnieren.",
       "Clara ok": null,
       "Braucht Const": "x",
+      "Korrektorat": null,
+      "Bemerkung": null
+    },
+    {
+      "key": "account/newsletterSubscriptions/unsubscribed",
+      "value": "Sie haben sich von unseren Newslettern abgemeldet. Wenn Sie wieder einen Newsletter auswählen, erhalten Sie eine E-Mail, mit der Sie Ihre Neuanmeldung bestätigen können. Danach erhalten Sie wieder unsere Newsletter.",
+      "Clara ok": null,
+      "Braucht Const": null,
       "Korrektorat": null,
       "Bemerkung": null
     },


### PR DESCRIPTION
Depends on https://github.com/orbiting/republik-backend/pull/48

Solves the issue when a user has unsubscribed via the mailchimp link and our UI doesn't provide any guidance.

<img width="847" alt="screen shot 2018-01-11 at 00 47 00" src="https://user-images.githubusercontent.com/23520051/34802318-614fd34c-f66d-11e7-8151-5d5992a5ae9a.png">
