### PR TITLE
Add RawHtmlElements component

### DIFF
--- a/components/Account/Memberships/Claim.js
+++ b/components/Account/Memberships/Claim.js
@@ -4,6 +4,7 @@ import { compose, graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
 import Loader from '../../Loader'
+import RawHtmlElements from '../../RawHtmlElements'
 import ErrorMessage from '../../ErrorMessage'
 import { gotoMerci } from '../../Pledge/Merci'
 
@@ -172,20 +173,16 @@ class ClaimMembership extends Component {
     if (polling) {
       return (
         <div>
-          <RawHtml type={P} dangerouslySetInnerHTML={{
-            __html: t('signIn/polling', {
+          <P>
+            <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
               phrase,
-              email: values.email
-            })
-          }} />
-          <P key='link'>
-            {t.elements('signIn/polling/signInLink', {
+              email: values.email,
               signInLink: (
                 <Link route='signin'>
                   <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
                 </Link>
               )
-            })}
+            }} />
           </P>
           <Poller onSuccess={() => {
             this.setState(() => ({

--- a/components/Account/Memberships/Claim.js
+++ b/components/Account/Memberships/Claim.js
@@ -175,11 +175,11 @@ class ClaimMembership extends Component {
         <div>
           <P>
             <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
-              phrase,
-              email: values.email,
-              signInLink: (
+              phrase: <b key='phrase'>{phrase}</b>,
+              email: <b key='email'>{values.email}</b>,
+              link: (
                 <Link route='signin'>
-                  <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
+                  <a {...linkRule}>{t('signIn/polling/link')}</a>
                 </Link>
               )
             }} />

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -7,6 +7,7 @@ import { Link } from '../../lib/routes'
 import withT from '../../lib/withT'
 import {validate as isEmail} from 'email-validator'
 import ErrorMessage from '../ErrorMessage'
+import RawHtmlElements from '../RawHtmlElements'
 
 import {
   Button,
@@ -14,7 +15,6 @@ import {
   Interaction,
   Field,
   Label,
-  RawHtml,
   colors,
   linkRule
 } from '@project-r/styleguide'
@@ -65,22 +65,16 @@ class SignIn extends Component {
     } = this.state
     if (polling) {
       return (
-        <div>
-          <RawHtml type={P} dangerouslySetInnerHTML={{
-            __html: t('signIn/polling', {
-              phrase,
-              email
-            })
+        <P>
+          <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
+            phrase,
+            email,
+            signInLink: (
+              <Link route='signin'>
+                <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
+              </Link>
+            )
           }} />
-          <P key='link'>
-            {t.elements('signIn/polling/signInLink', {
-              signInLink: (
-                <Link route='signin'>
-                  <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
-                </Link>
-              )
-            })}
-          </P>
           <Poller onSuccess={(me, ms) => {
             this.setState(() => ({
               polling: false,
@@ -90,7 +84,7 @@ class SignIn extends Component {
               })
             }))
           }} />
-        </div>
+        </P>
       )
     }
     if (success) {

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -67,11 +67,11 @@ class SignIn extends Component {
       return (
         <P>
           <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
-            phrase,
-            email,
-            signInLink: (
+            phrase: <b key='phrase'>{phrase}</b>,
+            email: <b key='email'>{email}</b>,
+            link: (
               <Link route='signin'>
-                <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
+                <a {...linkRule}>{t('signIn/polling/link')}</a>
               </Link>
             )
           }} />

--- a/components/Faq/Form.js
+++ b/components/Faq/Form.js
@@ -210,11 +210,11 @@ class QuestionForm extends Component {
             <div>
               <P>
                 <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
-                  phrase,
-                  email: values.email,
-                  signInLink: (
+                  phrase: <b key='phrase'>{phrase}</b>,
+                  email: <b key='email'>{values.email}</b>,
+                  link: (
                     <Link route='signin'>
-                      <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
+                      <a {...linkRule}>{t('signIn/polling/link')}</a>
                     </Link>
                   )
                 }} />

--- a/components/Faq/Form.js
+++ b/components/Faq/Form.js
@@ -11,12 +11,13 @@ import withMe from '../../lib/apollo/withMe'
 import {withSignOut} from '../Auth/SignOut'
 import {withSignIn} from '../Auth/SignIn'
 import ErrorMessage from '../ErrorMessage'
+import RawHtmlElements from '../RawHtmlElements'
 import FieldSet, {styles as fieldSetStyles} from '../FieldSet'
 
 import Poller from '../Auth/Poller'
 
 import {
-  Interaction, RawHtml, InlineSpinner, Field, Button, A, linkRule
+  Interaction, InlineSpinner, Field, Button, A, linkRule
 } from '@project-r/styleguide'
 
 import {H2} from './List'
@@ -207,20 +208,16 @@ class QuestionForm extends Component {
 
           {!!polling && (
             <div>
-              <RawHtml type={P} dangerouslySetInnerHTML={{
-                __html: t('signIn/polling', {
+              <P>
+                <RawHtmlElements t={t} translationKey='signIn/polling' replacements={{
                   phrase,
-                  email: values.email
-                })
-              }} />
-              <P key='link'>
-                {t.elements('signIn/polling/signInLink', {
+                  email: values.email,
                   signInLink: (
                     <Link route='signin'>
                       <a {...linkRule}>{t('signIn/polling/signInLink/text')}</a>
                     </Link>
                   )
-                })}
+                }} />
               </P>
               <Poller onSuccess={() => {
                 this.setState(() => ({

--- a/components/RawHtmlElements.js
+++ b/components/RawHtmlElements.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { RawHtml } from '@project-r/styleguide'
+
+const RawHtmlElements = ({ t, translationKey, replacements, missingValue }) =>
+  t.elements(translationKey, replacements, missingValue).map(
+    (element, i) =>
+      typeof element === 'string' ? (
+        <RawHtml
+          key={`html${i}`}
+          dangerouslySetInnerHTML={{
+            __html: element
+          }}
+        />
+      ) : (
+        element
+      )
+  )
+
+RawHtmlElements.propTypes = {
+  t: PropTypes.func.isRequired,
+  translationKey: PropTypes.string.isRequired,
+  replacements: PropTypes.object,
+  missingValue: PropTypes.string
+}
+
+export default RawHtmlElements

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-12T00:53:55.971Z",
+  "updated": "2018-01-12T10:54:04.595Z",
   "title": "live",
   "data": [
     {
@@ -236,7 +236,7 @@
     },
     {
       "key": "signIn/polling",
-      "value": "Vielen Dank! \n<br /><br />\nJetzt müssen Sie noch Ihre Mailadresse bestätigen. Gehen Sie zu Ihrem Postfach, öffnen Sie das Mail, und klicken Sie den Link. In dem Mail finden Sie übrigens folgende drei seltsame, fett gedruckte Wörter:<br /><br />\n<b>«{phrase}»</b>\n<br /><br /> \nKontrollieren Sie, ob in Ihrem Mail die gleichen drei zugegeben absurden Wörter stehen. (Das ist leider nötig. Es ist eine Sicherheitsmassnahme, damit niemand mit Ihrer Mailadresse Unfug treiben kann.)\n<br /><br />\nSollten Sie kein Mail erhalten haben, ist es möglich, dass Sie sich bei der Eingabe Ihrer E-Mail-Adresse vertippt haben. Die Adresse, die Sie uns gegeben haben lautete: <b>{email}</b>\n<br /><br />",
+      "value": "Vielen Dank! \n<br /><br />\nJetzt müssen Sie noch Ihre Mailadresse bestätigen. Gehen Sie zu Ihrem Postfach, öffnen Sie das Mail, und klicken Sie den Link. In dem Mail finden Sie übrigens folgende drei seltsame, fett gedruckte Wörter:<br /><br /><b>«{phrase}»</b><br /><br />Kontrollieren Sie, ob in Ihrem Mail die gleichen drei zugegeben absurden Wörter stehen. (Das ist leider nötig. Es ist eine Sicherheitsmassnahme, damit niemand mit Ihrer Mailadresse Unfug treiben kann.)\n<br /><br />\nSollten Sie kein Mail erhalten haben, ist es möglich, dass Sie sich bei der Eingabe Ihrer E-Mail-Adresse vertippt haben. Die Adresse, die Sie uns gegeben haben lautete: <b>{email}</b>\n<br /><br />\nSollte das der Fall sein, versuchen Sie es {signInLink}.",
       "Clara ok": null,
       "Braucht Const": null,
       "Korrektorat": null,

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-01-12T10:54:04.595Z",
+  "updated": "2018-01-12T14:00:57.233Z",
   "title": "live",
   "data": [
     {
@@ -236,22 +236,14 @@
     },
     {
       "key": "signIn/polling",
-      "value": "Vielen Dank! \n<br /><br />\nJetzt müssen Sie noch Ihre Mailadresse bestätigen. Gehen Sie zu Ihrem Postfach, öffnen Sie das Mail, und klicken Sie den Link. In dem Mail finden Sie übrigens folgende drei seltsame, fett gedruckte Wörter:<br /><br /><b>«{phrase}»</b><br /><br />Kontrollieren Sie, ob in Ihrem Mail die gleichen drei zugegeben absurden Wörter stehen. (Das ist leider nötig. Es ist eine Sicherheitsmassnahme, damit niemand mit Ihrer Mailadresse Unfug treiben kann.)\n<br /><br />\nSollten Sie kein Mail erhalten haben, ist es möglich, dass Sie sich bei der Eingabe Ihrer E-Mail-Adresse vertippt haben. Die Adresse, die Sie uns gegeben haben lautete: <b>{email}</b>\n<br /><br />\nSollte das der Fall sein, versuchen Sie es {signInLink}.",
+      "value": "Vielen Dank! \n<br /><br />\nJetzt müssen Sie noch Ihre Mailadresse bestätigen. Gehen Sie zu Ihrem Postfach, öffnen Sie das Mail, und klicken Sie den Link. In dem Mail finden Sie übrigens folgende drei seltsame, fett gedruckte Wörter:<br /><br />«{phrase}»<br /><br />Kontrollieren Sie, ob in Ihrem Mail die gleichen drei zugegeben absurden Wörter stehen. (Das ist leider nötig. Es ist eine Sicherheitsmassnahme, damit niemand mit Ihrer Mailadresse Unfug treiben kann.)\n<br /><br />\nSollten Sie kein Mail erhalten haben, ist es möglich, dass Sie sich bei der Eingabe Ihrer E-Mail-Adresse vertippt haben. Die Adresse, die Sie uns gegeben haben lautete: {email}\n<br /><br />\nSollte das der Fall sein, versuchen Sie es {link}.",
       "Clara ok": null,
       "Braucht Const": null,
       "Korrektorat": null,
       "Bemerkung": "Braucht einen Link und saubere Formatierung"
     },
     {
-      "key": "signIn/polling/signInLink",
-      "value": "Sollte das der Fall sein, versuchen Sie es {signInLink}.",
-      "Clara ok": null,
-      "Braucht Const": null,
-      "Korrektorat": null,
-      "Bemerkung": null
-    },
-    {
-      "key": "signIn/polling/signInLink/text",
+      "key": "signIn/polling/link",
       "value": "hier nochmal",
       "Clara ok": null,
       "Braucht Const": null,
@@ -508,7 +500,15 @@
     },
     {
       "key": "marketing/noActiveMembership",
-      "value": "Leider existiert unter Ihrer E-Mail-Adresse kein laufendes Abonnement. Dieses Problem kann mehrere Ursachen haben. Die Lösungen dazu finden Sie hier: {AccountLink}",
+      "value": "Leider existiert unter Ihrer E-Mail-Adresse kein laufendes Abonnement. Das kann mehrere Ursachen haben. Die Lösungen dazu finden Sie in Ihrem {link}.",
+      "Clara ok": null,
+      "Braucht Const": null,
+      "Korrektorat": null,
+      "Bemerkung": null
+    },
+    {
+      "key": "marketing/noActiveMembership/link",
+      "value": "Konto",
       "Clara ok": null,
       "Braucht Const": null,
       "Korrektorat": null,


### PR DESCRIPTION
This is almost doing what it should, but not fully there yet. What I'm trying to achieve is supporting one translation string that has HTML tags and elements, with replacements nested inside HTML tags.

In particular, it doesn't treat the `<b>` tags well in this string:
`fett gedruckte Wörter:<br /><br /><b>«{phrase}»</b><br /><br />Kontrollieren`

Result:
![screen shot 2018-01-12 at 12 07 53](https://user-images.githubusercontent.com/23520051/34872547-8c308ffa-f791-11e7-8ac2-335a35e164bc.png)

FYI, here's also a console.log(typeof element, element) from RawHtmlElements:
![screen shot 2018-01-12 at 11 51 30](https://user-images.githubusercontent.com/23520051/34872356-d7840988-f790-11e7-8948-30542b12b9c4.png)

FYI, I'm not piping through `type` to RawHtml yet because it will just make things worse at the moment (e.g. replacing the spans with a block element that breaks into a new element after `«`)