### PR TITLE
OG Size & Twitter Resize

### DIFF
--- a/components/Frame/Meta.js
+++ b/components/Frame/Meta.js
@@ -1,11 +1,18 @@
 import React from 'react'
 import Head from 'next/head'
 
+import {
+  imageSizeInfo,
+  imageResizeUrl
+} from 'mdast-react-render/lib/utils'
+
 export default ({data, data: {image}}) => {
   const title = data.pageTitle || `${data.title} – Republik`
 
   const facebookImage = data.facebookImage || image
   const twitterImage = data.twitterImage || image
+
+  const fbSizeInfo = facebookImage && imageSizeInfo(facebookImage)
 
   return (
     <Head>
@@ -17,6 +24,8 @@ export default ({data, data: {image}}) => {
       <meta property='og:title' content={data.facebookTitle || data.title} />
       <meta property='og:description' content={data.facebookDescription || data.description} />
       {!!facebookImage && <meta property='og:image' content={facebookImage} />}
+      {!!fbSizeInfo && <meta property='og:image:width' content={fbSizeInfo.width} />}
+      {!!fbSizeInfo && <meta property='og:image:height' content={fbSizeInfo.height} />}
 
       <meta name='twitter:card' content='summary_large_image' />
       <meta name='twitter:card' content={twitterImage ? 'summary_large_image' : 'summary'} />
@@ -24,7 +33,7 @@ export default ({data, data: {image}}) => {
       <meta name='twitter:creator' content='@RepublikMagazin' />
       <meta name='twitter:title' content={data.twitterTitle || data.title} />
       <meta name='twitter:description' content={data.twitterDescription || data.description} />
-      {!!twitterImage && <meta name='twitter:image:src' content={twitterImage} />}
+      {!!twitterImage && <meta name='twitter:image:src' content={imageResizeUrl(twitterImage, '3000x')} />}
     </Head>
   )
 }


### PR DESCRIPTION
Adds size info for faster facebook previews and resize twitter image to stay within 3mb limit.