### PR TITLE
add formats overview page

### DIFF
--- a/components/Feed/index.js
+++ b/components/Feed/index.js
@@ -100,6 +100,9 @@ class Feed extends Component {
 
   render () {
     const { data: { loading, error, documents, greeting } } = this.props
+    const nodes = documents
+      ? [...documents.nodes].filter(node => node.meta.template !== 'format')
+      : []
     return (
       <Loader
         loading={loading}
@@ -112,8 +115,8 @@ class Feed extends Component {
                   {greeting.text}
                 </Interaction.H1>
               )}
-              {documents &&
-                documents.nodes.map(doc => (
+              {nodes &&
+                nodes.map(doc => (
                   <TeaserFeed
                     {...doc.meta}
                     kind={

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -95,7 +95,7 @@ class Formats extends Component {
                     {t('formats/title/editorial')}
                   </Interaction.H2>
                   {editorialNodes.map(doc => (
-                    <TeaserFeed {...doc.meta} Link={Link} key={doc.meta.path} />
+                    <TeaserFeed {...doc.meta} publishDate={null} Link={Link} key={doc.meta.path} />
                   ))}
                 </Fragment>
               )}
@@ -105,7 +105,7 @@ class Formats extends Component {
                     {t('formats/title/meta')}
                   </Interaction.H2>
                   {metaNodes.map(doc => (
-                    <TeaserFeed {...doc.meta} Link={Link} key={doc.meta.path} />
+                    <TeaserFeed {...doc.meta} publishDate={null} Link={Link} key={doc.meta.path} />
                   ))}
                 </Fragment>
               )}

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -43,6 +43,7 @@ const getFormats = gql`
     documents(template: "format", feed: true) {
       nodes {
         meta {
+          template
           kind
           title
           description
@@ -94,7 +95,7 @@ class Formats extends Component {
                     {t('formats/title/editorial')}
                   </Interaction.H2>
                   {editorialNodes.map(doc => (
-                    <TeaserFeed {...{...doc.meta, kind: 'meta'}} Link={Link} key={doc.meta.path} />
+                    <TeaserFeed {...doc.meta} Link={Link} key={doc.meta.path} />
                   ))}
                 </Fragment>
               )}

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -1,0 +1,119 @@
+import React, { Component, Fragment } from 'react'
+import { graphql, compose } from 'react-apollo'
+import { css } from 'glamor'
+import { descending } from 'd3-array'
+import gql from 'graphql-tag'
+import Loader from '../../components/Loader'
+import Link from '../Link/Href'
+import withT from '../../lib/withT'
+
+import {
+  Center,
+  TeaserFeed,
+  Editorial,
+  Interaction,
+  RawHtml,
+  mediaQueries
+} from '@project-r/styleguide'
+
+const styles = {
+  container: css({
+    padding: '30px 15px 120px',
+    [mediaQueries.mUp]: {
+      maxWidth: '695px',
+      padding: '60px 0 120px'
+    }
+  }),
+  h1: css({
+    marginBottom: '20px',
+    [mediaQueries.mUp]: {
+      marginBottom: '40px'
+    }
+  }),
+  h2: css({
+    marginBottom: '20px',
+    [mediaQueries.mUp]: {
+      marginBottom: '30px'
+    }
+  })
+}
+
+const getFormats = gql`
+  query getFormats {
+    documents(template: "format", feed: true) {
+      nodes {
+        meta {
+          kind
+          title
+          description
+          path
+          color
+          publishDate
+        }
+      }
+    }
+  }
+`
+
+class Formats extends Component {
+  render() {
+    const { data: { loading, error, documents }, t } = this.props
+    return (
+      <Loader
+        loading={loading}
+        error={error}
+        render={() => {
+          const editorialNodes = documents
+            ? [...documents.nodes]
+                .filter(node => node.meta.kind === 'editorial')
+                .sort((a, b) =>
+                  descending(a.meta.publishDate, b.meta.publishDate)
+                )
+            : []
+          const metaNodes = documents
+            ? [...documents.nodes]
+                .filter(node => node.meta.kind === 'meta')
+                .sort((a, b) =>
+                  descending(a.meta.publishDate, b.meta.publishDate)
+                )
+            : []
+          return (
+            <Center {...styles.container}>
+              <Interaction.H1 {...styles.h1}>
+                {t('formats/title')}
+              </Interaction.H1>
+              <RawHtml
+                type={Editorial.P}
+                dangerouslySetInnerHTML={{
+                  __html: t('formats/lead')
+                }}
+              />
+              {!!editorialNodes.length && (
+                <Fragment>
+                  <Interaction.H2 {...styles.h2}>
+                    {t('formats/title/editorial')}
+                  </Interaction.H2>
+                  {editorialNodes.map(doc => (
+                    <TeaserFeed {...{...doc.meta, kind: 'meta'}} Link={Link} key={doc.meta.path} />
+                  ))}
+                </Fragment>
+              )}
+              {!!metaNodes.length && (
+                <Fragment>
+                  <Interaction.H2 {...styles.h2}>
+                    {t('formats/title/meta')}
+                  </Interaction.H2>
+                  {metaNodes.map(doc => (
+                    <TeaserFeed {...doc.meta} Link={Link} key={doc.meta.path} />
+                  ))}
+                </Fragment>
+              )}
+            </Center>
+          )
+        }}
+      />
+    )
+  }
+}
+
+export default compose(withT, graphql(getFormats))(Formats)

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -141,6 +141,13 @@ const Nav = ({ me, url, closeHandler, children, t }) => {
             />
             <br />
             <NavLink
+              route='formats'
+              translation={t('nav/formats')}
+              active={active}
+              closeHandler={closeHandler}
+            />
+            <br />
+            <NavLink
               route='events'
               translation={t('nav/events')}
               active={active}

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -139,13 +139,13 @@ const Nav = ({ me, url, closeHandler, children, t }) => {
               active={active}
               closeHandler={closeHandler}
             />
-            <br />
+            {/*<br />
             <NavLink
               route='formats'
               translation={t('nav/formats')}
               active={active}
               closeHandler={closeHandler}
-            />
+            />*/}
             <br />
             <NavLink
               route='events'

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -22,6 +22,7 @@ routes
   .add('event', '/veranstaltung/:slug', 'events')
   .add('faq', '/faq')
   .add('feed', '/feed')
+  .add('formats', '/formate')
   .add('community', '/community')
   .add('etiquette', '/etikette')
   .add('crew', '/crew')

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -22,7 +22,7 @@ routes
   .add('event', '/veranstaltung/:slug', 'events')
   .add('faq', '/faq')
   .add('feed', '/feed')
-  .add('formats', '/formate')
+  .add('formats', '/rubriken')
   .add('community', '/community')
   .add('etiquette', '/etikette')
   .add('crew', '/crew')

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-02-06T10:11:09.872Z",
+  "updated": "2018-02-08T13:30:18.756Z",
   "title": "live",
   "data": [
     {
@@ -341,6 +341,14 @@
     {
       "key": "formats/lead",
       "value": "Sie bringen Farbe in den grauen Alltag: Unsere Formate. So nennen wir alle regelmässig erscheinenden Kolumnen, Rubriken und Newsletter der Republik. Jedes Format wirft seinen eigenen Blick auf die Welt. Und hat deshalb seine eigene Farbe. Was sind Ihre Lieblingsfarben?"
+    },
+    {
+      "key": "formats/title/editorial",
+      "value": "Editorial"
+    },
+    {
+      "key": "formats/title/meta",
+      "value": "Meta"
     },
     {
       "key": "crew/pageTitle",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-02-08T13:30:18.756Z",
+  "updated": "2018-02-09T13:17:34.042Z",
   "title": "live",
   "data": [
     {
@@ -12,7 +12,7 @@
     },
     {
       "key": "nav/formats",
-      "value": "Formate"
+      "value": "Rubriken"
     },
     {
       "key": "nav/events",
@@ -31,8 +31,12 @@
       "value": "Magazin"
     },
     {
+      "key": "pages/index/pageTitle",
+      "value": "Republik"
+    },
+    {
       "key": "pages/index/title",
-      "value": "Republik ist gestartet"
+      "value": "Republik"
     },
     {
       "key": "pages/index/description",
@@ -332,23 +336,23 @@
     },
     {
       "key": "formats/pageTitle",
-      "value": "Formate"
+      "value": "Rubriken"
     },
     {
       "key": "formats/title",
-      "value": "Formate"
+      "value": "Rubriken"
     },
     {
       "key": "formats/lead",
-      "value": "Sie bringen Farbe in den grauen Alltag: Unsere Formate. So nennen wir alle regelmässig erscheinenden Kolumnen, Rubriken und Newsletter der Republik. Jedes Format wirft seinen eigenen Blick auf die Welt. Und hat deshalb seine eigene Farbe. Was sind Ihre Lieblingsfarben?"
+      "value": "Hier finden Sie alles, was regelmässig in der Republik auftaucht: Kolumnen, Unternehmensnachrichten, Debatten und Kleinzeug."
     },
     {
       "key": "formats/title/editorial",
-      "value": "Editorial"
+      "value": "Zum Stand der Dinge"
     },
     {
       "key": "formats/title/meta",
-      "value": "Meta"
+      "value": "Zur Lage der Republik"
     },
     {
       "key": "crew/pageTitle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "5.53.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.53.0.tgz",
-      "integrity": "sha1-/jIm2HqkApe/CZMc93XGco/Awhk=",
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.54.0.tgz",
+      "integrity": "sha1-IiE775yLOvwbN3rgfayZx5yeAUo=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "5.54.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.54.0.tgz",
-      "integrity": "sha1-IiE775yLOvwbN3rgfayZx5yeAUo=",
+      "version": "5.54.1",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.54.1.tgz",
+      "integrity": "sha1-4Zr175WrFENNkH3Iud7u8amALj8=",
       "requires": {
         "react-icons": "2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-bundle-analyzer": "^2.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^5.54.0",
+    "@project-r/styleguide": "^5.54.1",
     "apollo-cache-inmemory": "^1.1.4",
     "apollo-client": "^2.0.4",
     "apollo-fetch": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-bundle-analyzer": "^2.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^5.53.0",
+    "@project-r/styleguide": "^5.54.0",
     "apollo-cache-inmemory": "^1.1.4",
     "apollo-client": "^2.0.4",
     "apollo-fetch": "^0.7.0",

--- a/pages/formats.js
+++ b/pages/formats.js
@@ -4,10 +4,9 @@ import Frame from '../components/Frame'
 import Formats from '../components/Formats'
 import { enforceMembership } from '../components/Auth/withMembership'
 import withData from '../lib/apollo/withData'
-import withMe from '../lib/apollo/withMe'
 import withT from '../lib/withT'
 
-const FormatsPage = ({ url, me, t }) => {
+const FormatsPage = ({ url, t }) => {
   const meta = {
     title: t('formats/pageTitle')
   }
@@ -21,6 +20,5 @@ const FormatsPage = ({ url, me, t }) => {
 export default compose(
   withData,
   enforceMembership,
-  withMe,
   withT
 )(FormatsPage)

--- a/pages/formats.js
+++ b/pages/formats.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { compose } from 'react-apollo'
+import Frame from '../components/Frame'
+import Formats from '../components/Formats'
+import { enforceMembership } from '../components/Auth/withMembership'
+import withData from '../lib/apollo/withData'
+import withMe from '../lib/apollo/withMe'
+import withT from '../lib/withT'
+
+const FormatsPage = ({ url, me, t }) => {
+  const meta = {
+    title: t('formats/pageTitle')
+  }
+  return (
+    <Frame raw url={url} meta={meta}>
+      <Formats />
+    </Frame>
+  )
+}
+
+export default compose(
+  withData,
+  enforceMembership,
+  withMe,
+  withT
+)(FormatsPage)


### PR DESCRIPTION
Text copy still in progress ...

FYI, I forced meta headline style on editorial format headlines, since it looks inconsistent to render a format name in title serif while it's usually sans-serif. We could also just use the normal format style, but that looks to small IMHO when the focus is on the formats themselves.

Up for discussion: Show or hide dates? We didn't want them originally but now that we sort by date ...

![screen shot 2018-02-08 at 15 19 30](https://user-images.githubusercontent.com/23520051/35977910-935c9d24-0ce4-11e8-8991-74371764674b.png)
![screen shot 2018-02-08 at 15 19 37](https://user-images.githubusercontent.com/23520051/35977923-98f675de-0ce4-11e8-9fd4-004dde3e2c8e.png)
![screen shot 2018-02-08 at 15 20 18](https://user-images.githubusercontent.com/23520051/35977940-9ec02064-0ce4-11e8-8c44-8a140c474038.png)

