### PR TITLE
SSRCachingBoundary for front and articles

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -14,6 +14,7 @@ import Discussion from '../Discussion/Discussion'
 import DiscussionIconLink from '../Discussion/IconLink'
 import Feed from '../Feed/Format'
 import StatusError from '../StatusError'
+import SSRCachingBoundary from '../SSRCachingBoundary'
 
 import {
   colors,
@@ -70,7 +71,7 @@ const ActionBar = ({ title, discussionId, discussionPage, discussionPath, t, url
         title
       })}
     />
-    {discussionId &&
+    {discussionId && process.browser &&
       <DiscussionIconLink discussionId={discussionId} shouldUpdate={!discussionPage} path={discussionPath} />
     }
   </div>
@@ -320,10 +321,12 @@ class ArticlePage extends Component {
           return (
             <Fragment>
               {!isFormat && <PayNote.Before />}
-              {renderMdast({
-                ...article.content,
-                format: meta.format
-              }, schema)}
+              <SSRCachingBoundary cacheKey={article.id}>
+                {() => renderMdast({
+                  ...article.content,
+                  format: meta.format
+                }, schema)}
+              </SSRCachingBoundary>
               {meta.template === 'article' && <Center>
                 <div ref={this.bottomBarRef} {...styles.bar}>
                   {actionBar}

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -8,6 +8,7 @@ import withT from '../../lib/withT'
 import Loader from '../Loader'
 import Frame from '../Frame'
 import Link from '../Link/Href'
+import SSRCachingBoundary from '../SSRCachingBoundary'
 
 import { renderMdast } from 'mdast-react-render'
 
@@ -20,6 +21,7 @@ const schema = createFrontSchema({
 const getDocument = gql`
   query getFront($path: String!) {
     front: document(path: $path) {
+      id
       content
       meta {
         path
@@ -53,7 +55,9 @@ class Front extends Component {
         meta={meta}
       >
         <Loader loading={data.loading} error={data.error} message={t('pages/magazine/title')} render={() => {
-          return renderMdast(front.content, schema)
+          return <SSRCachingBoundary cacheKey={front.id}>
+            {() => renderMdast(front.content, schema)}
+          </SSRCachingBoundary>
         }} />
       </Frame>
     )

--- a/components/SSRCachingBoundary/index.js
+++ b/components/SSRCachingBoundary/index.js
@@ -1,0 +1,33 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+let getHtml
+if (!process.browser) {
+  const ReactDOMServer = require('react-dom/server')
+  const cache = require('lru-cache')({
+    max: 1000 * 1000 * 200, // 200mb
+    length: d => d.length
+  })
+
+  getHtml = (key, children) => {
+    if (cache.has(key)) {
+      return cache.get(key)
+    }
+    const html = ReactDOMServer.renderToStaticMarkup(children())
+    cache.set(key, html)
+    return html
+  }
+}
+
+const SSRCachingBoundary = ({cacheKey, children}) => getHtml
+  ? <div dangerouslySetInnerHTML={{
+    __html: getHtml(cacheKey, children)
+  }} />
+  : <div>{children()}</div>
+
+SSRCachingBoundary.propTypes = {
+  cacheKey: PropTypes.string.isRequired,
+  children: PropTypes.func.isRequired
+}
+
+export default SSRCachingBoundary

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,10 @@ module.exports = {
       }))
     }
 
+    config.externals = config.externals || {}
+    config.externals['lru-cache'] = 'lru-cache'
+    config.externals['react-dom/server'] = 'react-dom/server'
+
     const entryFactory = config.entry
     config.entry = () => (
       entryFactory()

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "graphql-tag": "^2.5.0",
     "isomorphic-unfetch": "^2.0.0",
     "load-script": "^1.0.0",
+    "lru-cache": "^4.1.1",
     "markdown-in-js": "^1.1.3",
     "mdast-react-render": "^1.1.0",
     "next": "^4.2.3",


### PR DESCRIPTION
cuts average SSR rendering time in half (for a really big mdast tree).

Rendering
/2018/02/26/render-stress-test (5x our longest article, [public 1x version](https://www.republik.ch/2018/01/15/demokratie-unter-irrationalen))
goes from a mean `542ms` to `282ms` (ab -n 1000 -c 4 against localhost).

**before**
```
$ ab -n 1000 -c 4 http://localhost:3010/2018/02/26/render-stress-test
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        
Server Hostname:        localhost
Server Port:            3010

Document Path:          /2018/02/26/render-stress-test
Document Length:        771012 bytes

Concurrency Level:      4
Time taken for tests:   135.570 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      771273000 bytes
HTML transferred:       771012000 bytes
Requests per second:    7.38 [#/sec] (mean)
Time per request:       542.280 [ms] (mean)
Time per request:       135.570 [ms] (mean, across all concurrent requests)
Transfer rate:          5555.78 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:   137  542 128.4    522    1625
Waiting:      136  432 130.3    420    1622
Total:        137  542 128.4    522    1626

Percentage of the requests served within a certain time (ms)
  50%    522
  66%    562
  75%    588
  80%    619
  90%    675
  95%    717
  98%    824
  99%    936
 100%   1626 (longest request)
```

**after**
```
$ ab -n 1000 -c 4 http://localhost:3010/2018/02/26/render-stress-test
This is ApacheBench, Version 2.3 <$Revision: 1807734 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 100 requests
Completed 200 requests
Completed 300 requests
Completed 400 requests
Completed 500 requests
Completed 600 requests
Completed 700 requests
Completed 800 requests
Completed 900 requests
Completed 1000 requests
Finished 1000 requests


Server Software:        
Server Hostname:        localhost
Server Port:            3010

Document Path:          /2018/02/26/render-stress-test
Document Length:        771023 bytes

Concurrency Level:      4
Time taken for tests:   70.519 seconds
Complete requests:      1000
Failed requests:        0
Total transferred:      771284000 bytes
HTML transferred:       771023000 bytes
Requests per second:    14.18 [#/sec] (mean)
Time per request:       282.074 [ms] (mean)
Time per request:       70.519 [ms] (mean, across all concurrent requests)
Transfer rate:          10680.98 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       1
Processing:    81  282 110.3    259    1512
Waiting:       81  246 105.1    227    1511
Total:         81  282 110.3    259    1513

Percentage of the requests served within a certain time (ms)
  50%    259
  66%    297
  75%    321
  80%    334
  90%    377
  95%    418
  98%    466
  99%    606
 100%   1513 (longest request)
```