### PR TITLE
replace 'isemail' with 'validator' due to build issues

### DIFF
--- a/components/Account/Memberships/Claim.js
+++ b/components/Account/Memberships/Claim.js
@@ -11,7 +11,7 @@ import { gotoMerci } from '../../Pledge/Merci'
 import { Link } from '../../../lib/routes'
 import withT from '../../../lib/withT'
 import withMe, { meQuery } from '../../../lib/apollo/withMe'
-import { validate as isEmail } from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 
 import Poller from '../../Auth/Poller'
 import FieldSet from '../../FieldSet'

--- a/components/Account/UpdateEmail.js
+++ b/components/Account/UpdateEmail.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
-import {validate as isEmail} from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 
 import { errorToString } from '../../lib/utils/errors'
 import withT from '../../lib/withT'

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -5,7 +5,7 @@ import gql from 'graphql-tag'
 import {css} from 'glamor'
 import { Router } from '../../lib/routes'
 import withT from '../../lib/withT'
-import {validate as isEmail} from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 import ErrorMessage from '../ErrorMessage'
 import RawHtmlElements from '../RawHtmlElements'
 

--- a/components/Faq/Form.js
+++ b/components/Faq/Form.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react'
 import { compose, graphql } from 'react-apollo'
 import gql from 'graphql-tag'
-import {validate as isEmail} from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 import AutosizeInput from 'react-textarea-autosize'
 
 import { Link } from '../../lib/routes'

--- a/components/Marketing/PreviewForm.js
+++ b/components/Marketing/PreviewForm.js
@@ -8,7 +8,7 @@ import ErrorMessage from '../ErrorMessage'
 import FieldSet from '../FieldSet'
 import Loader from '../Loader'
 import Poller from '../Auth/Poller'
-import { validate as isEmail } from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 import { Button, Field, Interaction, RawHtml } from '@project-r/styleguide'
 
 class PreviewForm extends Component {

--- a/components/Pledge/Form.js
+++ b/components/Pledge/Form.js
@@ -10,7 +10,7 @@ import Loader from '../Loader'
 import FieldSet from '../FieldSet'
 import SignIn from '../Auth/SignIn'
 import { withSignOut } from '../Auth/SignOut'
-import { validate as isEmail } from 'isemail'
+import isEmail from 'validator/lib/isEmail'
 
 import {
   Interaction,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,21 +5610,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isemail": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
-      "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
-      "requires": {
-        "punycode": "2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
-        }
-      }
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9709,6 +9694,11 @@
       "requires": {
         "builtins": "1.0.3"
       }
+    },
+    "validator": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "glamor": "^2.20.40",
     "graphql": "^0.11.7",
     "graphql-tag": "^2.5.0",
-    "isemail": "^3.1.1",
     "isomorphic-unfetch": "^2.0.0",
     "load-script": "^1.0.0",
     "lru-cache": "^4.1.1",
@@ -136,6 +135,7 @@
     "react-textarea-autosize": "^5.1.0",
     "subscriptions-transport-ws": "^0.9.1",
     "uuid": "^3.1.0",
-    "valid-url": "^1.0.9"
+    "valid-url": "^1.0.9",
+    "validator": "^9.4.1"
   }
 }


### PR DESCRIPTION
Active and popular validation library: https://github.com/chriso/validator.js
Has more than we need, but integrates well with our codebase and we might actually use more of it (e.g. the URL validation that we currently do with valid-url).

Backends PR: https://github.com/orbiting/backends/pull/11