### PR TITLE
add webp html cache key suffix

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -14,7 +14,7 @@ import Discussion from '../Discussion/Discussion'
 import DiscussionIconLink from '../Discussion/IconLink'
 import Feed from '../Feed/Format'
 import StatusError from '../StatusError'
-import SSRCachingBoundary from '../SSRCachingBoundary'
+import SSRCachingBoundary, { webpCacheKey } from '../SSRCachingBoundary'
 
 import {
   colors,
@@ -330,7 +330,7 @@ class ArticlePage extends Component {
           return (
             <Fragment>
               {!isFormat && <PayNote.Before />}
-              <SSRCachingBoundary cacheKey={article.id}>
+              <SSRCachingBoundary cacheKey={webpCacheKey(this.props.headers, article.id)}>
                 {() => renderMdast({
                   ...article.content,
                   format: meta.format

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -8,7 +8,7 @@ import withT from '../../lib/withT'
 import Loader from '../Loader'
 import Frame from '../Frame'
 import Link from '../Link/Href'
-import SSRCachingBoundary from '../SSRCachingBoundary'
+import SSRCachingBoundary, { webpCacheKey } from '../SSRCachingBoundary'
 
 import { renderMdast } from 'mdast-react-render'
 
@@ -55,7 +55,7 @@ class Front extends Component {
         meta={meta}
       >
         <Loader loading={data.loading} error={data.error} message={t('pages/magazine/title')} render={() => {
-          return <SSRCachingBoundary cacheKey={front.id}>
+          return <SSRCachingBoundary cacheKey={webpCacheKey(this.props.headers, front.id)}>
             {() => renderMdast(front.content, schema)}
           </SSRCachingBoundary>
         }} />

--- a/components/SSRCachingBoundary/index.js
+++ b/components/SSRCachingBoundary/index.js
@@ -19,6 +19,12 @@ if (!process.browser) {
   }
 }
 
+export const webpCacheKey = (headers = {}, baseKey) => {
+  return headers.accept && headers.accept.indexOf('image/webp') !== -1
+  ? `${baseKey}webp`
+  : baseKey
+}
+
 const SSRCachingBoundary = ({cacheKey, children}) => getHtml
   ? <div dangerouslySetInnerHTML={{
     __html: getHtml(cacheKey, children)

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -19,9 +19,16 @@ export default ComposedComponent => {
         composedInitialProps = await ComposedComponent.getInitialProps(ctx)
       }
 
+      // we forward the accept header for webp detection
+      // - never forward cookie to client!
+      const headers = !process.browser
+        ? {accept: ctx.req.headers.accept}
+        : {}
+
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
       if (!process.browser) {
+        // server-side we initialize apollo with all headers (including cookie)
         const apollo = initApollo(undefined, ctx.req.headers)
         // Provide the `url` prop data in case a GraphQL query uses it
         const url = {
@@ -34,7 +41,7 @@ export default ComposedComponent => {
           // Run all GraphQL queries
           await getDataFromTree(
             <ApolloProvider client={apollo}>
-              <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} />
+              <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} headers={headers} />
             </ApolloProvider>
           )
         } catch (error) {
@@ -49,11 +56,7 @@ export default ComposedComponent => {
 
       return {
         serverState,
-        headers: !process.browser
-          // we forward accept header for webp detection
-          // - never forward cookie to client!
-          ? {accept: ctx.req.headers.accept}
-          : {},
+        headers,
         ...composedInitialProps
       }
     }


### PR DESCRIPTION
Totally forgot about webp when doing SSR caching. Here is a proper fix with webp in the cache key.

Long term it might be nice to add something like `Document.hash`. Allowing the backend server to control html cache busting. The server can already bust the cache by returning a new id but that is also a bit weird.

_Greetings from UTC+9 👋_