### PR TITLE
render extract from document

### DIFF
--- a/components/Article/Extract.js
+++ b/components/Article/Extract.js
@@ -1,0 +1,46 @@
+import React, { Fragment } from 'react'
+import Head from 'next/head'
+import { renderMdast } from 'mdast-react-render'
+
+const parseRanges = ranges => (
+  ranges.split(':').map(range => {
+    let [start, end] = range.split('...')
+    start = +start || 0
+
+    if (end === '') {
+      end = undefined
+    } else if (end === undefined) {
+      end = start + 1
+    } else {
+      end = +end
+    }
+
+    return [start, end]
+  })
+)
+
+export default ({schema, mdast, ranges}) => {
+  const sliceNode = (tree, [[start, end], ...childRanges]) => {
+    const children = tree.children.slice(start, end)
+
+    return {
+      ...tree,
+      children: childRanges.length
+        ? children.map(child => sliceNode(child, childRanges))
+        : children
+    }
+  }
+
+  const part = sliceNode(
+    mdast, parseRanges(ranges)
+  )
+
+  return (
+    <Fragment>
+      <Head>
+        <meta name='robots' content='noindex' />
+      </Head>
+      {renderMdast(part, schema)}
+    </Fragment>
+  )
+}

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -8,6 +8,7 @@ import Loader from '../Loader'
 import RelatedEpisodes from './RelatedEpisodes'
 import SeriesNavButton from './SeriesNavButton'
 import * as PayNote from './PayNote'
+import Extract from './Extract'
 import withT from '../../lib/withT'
 
 import Discussion from '../Discussion/Discussion'
@@ -319,6 +320,22 @@ class ArticlePage extends Component {
     const formatColor = formatMeta && formatMeta.color
 
     const audioSource = showAudioPlayer ? meta && meta.audioSource : null
+
+    if (url.query.extract) {
+      return <Loader loading={data.loading} error={data.error} render={() => {
+        if (!article) {
+          return <StatusError
+            url={url}
+            statusCode={404}
+            serverContext={this.props.serverContext} />
+        }
+
+        return <Extract ranges={url.query.extract} schema={schema} mdast={{
+          ...article.content,
+          format: meta.format
+        }} />
+      }} />
+    }
 
     return (
       <Frame


### PR DESCRIPTION
This allow to render extracts from a article without any frame.

Example URL:
https://republik.love/2018/04/16/pdf-fixture?extract=3:16
As an Image:
![via CDN](https://cdn.republik.pink/render?width=1000&height=1&url=https%3A%2F%2Frepublik.love%2F2018%2F04%2F16%2Fpdf-fixture%3Fextract%3D3%3A16)

Ranges are also supported: https://republik.love/2018/04/16/pdf-fixture?extract=3:14...21

<img width="820" alt="screen shot 2018-04-23 at 01 22 22" src="https://user-images.githubusercontent.com/410211/39101087-d99a7ab0-4694-11e8-962c-1bf15f289672.png">

Will be used by the PDF-Renderer for HTML-Illustrations and other elements without an PDF component.