### PR TITLE
feat: implement pdf options overlay

### DIFF
--- a/components/Article/PdfOverlay.js
+++ b/components/Article/PdfOverlay.js
@@ -1,0 +1,101 @@
+import React, { Component, Fragment } from 'react'
+
+import {
+  Overlay, OverlayBody,
+  OverlayToolbar, OverlayToolbarConfirm,
+  Interaction, A, Button, Checkbox
+} from '@project-r/styleguide'
+
+import DownloadIcon from 'react-icons/lib/md/file-download'
+import MdClose from 'react-icons/lib/md/close'
+
+import withT from '../../lib/withT'
+import { ASSETS_SERVER_BASE_URL } from '../../lib/constants'
+
+export const getPdfUrl = (meta, {images = true, download = false} = {}) => {
+  const query = [
+    !images && 'images=0',
+    download && 'download=1'
+  ].filter(Boolean)
+  return `${ASSETS_SERVER_BASE_URL}/pdf${meta.path}.pdf${query.length ? `?${query.join('&')}` : ''}`
+}
+
+const matchFigure = node => (
+  node.type === 'zone' &&
+  node.identifier === 'FIGURE'
+)
+const matchVideo = node => (
+  node.type === 'zone' &&
+  node.identifier === 'EMBEDVIDEO' &&
+  node.data.forceAudio
+)
+
+export const countImages = element => {
+  if (matchFigure(element) || matchVideo(element)) {
+    return 1
+  }
+  return (element.children || [])
+    .reduce(
+      (count, node) => count + countImages(node),
+      0
+    )
+}
+
+class PdfOverlay extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      images: true
+    }
+  }
+  render () {
+    const { onClose, article, t } = this.props
+    const { images } = this.state
+
+    const imageCount = countImages(article.content)
+
+    return <Overlay onClose={onClose} mUpStyle={{maxWidth: 300, minHeight: 'none'}}>
+      <OverlayToolbar>
+        <Interaction.Emphasis style={{padding: '15px 20px', fontSize: 16}}>
+          {t('article/pdf/title')}
+        </Interaction.Emphasis>
+        <OverlayToolbarConfirm
+          onClick={onClose}
+          label={<MdClose size={24} fill='#000' />} />
+      </OverlayToolbar>
+      <OverlayBody>
+        {!!imageCount && <Fragment>
+          <Checkbox
+            checked={images}
+            onChange={(_, checked) => {
+              this.setState({images: checked})
+            }}>
+            {t.pluralize('article/pdf/images', {
+              count: imageCount
+            })}
+          </Checkbox>
+          <br /><br />
+        </Fragment>}
+        <Button block onClick={(e) => {
+          e.preventDefault()
+          window.location = getPdfUrl(article.meta, {images})
+        }}>
+          {t('article/pdf/open')}
+        </Button>
+        <div style={{textAlign: 'center', marginTop: 10}}>
+          <A target='_blank'
+            href={getPdfUrl(article.meta, {
+              images,
+              download: true
+            })}
+            download>
+            <DownloadIcon />{' '}{t('article/pdf/download')}
+          </A>
+        </div>
+      </OverlayBody>
+    </Overlay>
+  }
+}
+
+export default withT(PdfOverlay)

--- a/components/Share.js
+++ b/components/Share.js
@@ -28,6 +28,7 @@ const ShareButtons = ({
   discussionCount,
   fill,
   onAudioClick,
+  onPdfClick,
   pdfUrl
 }) => {
   const emailAttache = emailAttachUrl ? `\n\n${url}` : ''
@@ -80,7 +81,16 @@ const ShareButtons = ({
     pdfUrl && {
       icon: 'pdf',
       href: pdfUrl,
-      title: t('article/actionbar/pdf')
+      onClick: onPdfClick && (e => {
+        if (e.currentTarget.nodeName === 'A' &&
+          (e.metaKey || e.ctrlKey || e.shiftKey || (e.nativeEvent && e.nativeEvent.which === 2))) {
+          // ignore click for new tab / new window behavior
+          return
+        }
+        e.preventDefault()
+        onPdfClick()
+      }),
+      title: t(`article/actionbar/pdf/${onPdfClick ? 'options' : 'open'}`)
     },
     onAudioClick && {
       icon: 'audio',
@@ -98,8 +108,8 @@ const ShareButtons = ({
       {shareOptions
         .filter(Boolean)
         .map((props, i) => props.space
-          ? '\u00a0'
-          : <IconLink key={i} fill={fill} {...props} />)}
+          ? '\u00a0\u00a0'
+          : <IconLink key={props.icon} fill={fill} {...props} />)}
     </span>
   )
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-04-26T14:37:38.432Z",
+  "updated": "2018-05-04T11:14:56.281Z",
   "title": "live",
   "data": [
     {
@@ -2207,12 +2207,36 @@
       "value": "Artikel anhören"
     },
     {
-      "key": "article/actionbar/pdf",
+      "key": "article/actionbar/pdf/open",
       "value": "Als PDF öffnen"
+    },
+    {
+      "key": "article/actionbar/pdf/options",
+      "value": "PDF-Optionen"
     },
     {
       "key": "article/series/episode",
       "value": "Episode {count}"
+    },
+    {
+      "key": "article/pdf/title",
+      "value": "PDF"
+    },
+    {
+      "key": "article/pdf/open",
+      "value": "öffnen"
+    },
+    {
+      "key": "article/pdf/download",
+      "value": "herunterladen"
+    },
+    {
+      "key": "article/pdf/images/1",
+      "value": "mit einem Bild"
+    },
+    {
+      "key": "article/pdf/images/other",
+      "value": "mit {count} Bilder"
     },
     {
       "key": "merci/postpay/waiting",


### PR DESCRIPTION
Show an overlay on click for articles with images:
<img width="727" alt="screen shot 2018-05-04 at 13 23 00" src="https://user-images.githubusercontent.com/410211/39625610-7b822cd0-4f9e-11e8-912f-3b0db88e0809.png">
<img width="728" alt="screen shot 2018-05-04 at 13 23 21" src="https://user-images.githubusercontent.com/410211/39625611-7ba4b9da-4f9e-11e8-85cc-df2e0f7e8f3e.png">
