### PR TITLE
fix: Accept base64-encoded email in query param, and render properly

### DIFF
--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 import {css} from 'glamor'
+import urlsafeBas64 from 'urlsafe-base64'
 import { Router } from '../../lib/routes'
 import withT from '../../lib/withT'
 import isEmail from 'validator/lib/isEmail'
@@ -52,12 +53,19 @@ class SignIn extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      email: props.email || '',
+      email: this.ensureDecodedEmail(props.email) || '',
       polling: false,
       loading: false,
       success: undefined
     }
   }
+
+  ensureDecodedEmail (email) {
+    return email && urlsafeBas64.validate(email)
+      ? urlsafeBas64.decode(Buffer.from(email)).toString()
+      : email
+  }
+
   render () {
     const {t, label} = this.props
     const {

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -49,19 +49,18 @@ const styles = {
   })
 }
 
+const ensureDecodedEmail =
+  (email = '') => match(email) ? decode(email) : email
+
 class SignIn extends Component {
   constructor (props) {
     super(props)
     this.state = {
-      email: this.ensureDecodedEmail(props.email) || '',
+      email: ensureDecodedEmail(props.email) || '',
       polling: false,
       loading: false,
       success: undefined
     }
-  }
-
-  ensureDecodedEmail (email) {
-    return email && match(email) ? decode(email) : email
   }
 
   render () {

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 import {css} from 'glamor'
-import urlsafeBas64 from 'urlsafe-base64'
 import { Router } from '../../lib/routes'
 import withT from '../../lib/withT'
+import { decode, match } from '../../lib/utils/base64u'
 import isEmail from 'validator/lib/isEmail'
 import ErrorMessage from '../ErrorMessage'
 import RawHtmlElements from '../RawHtmlElements'
@@ -61,9 +61,7 @@ class SignIn extends Component {
   }
 
   ensureDecodedEmail (email) {
-    return email && urlsafeBas64.validate(email)
-      ? urlsafeBas64.decode(Buffer.from(email)).toString()
-      : email
+    return email && match(email) ? decode(email) : email
   }
 
   render () {

--- a/lib/utils/base64u.js
+++ b/lib/utils/base64u.js
@@ -8,14 +8,30 @@ const urlEncode = string => string
   .replace(/\//g, '_')
   .replace(/=/g, '')
 
-export const decode = base64u =>
-  typeof window === 'object'
-    ? decodeURIComponent(escape(window.atob(urlDecode(base64u))))
+// see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding, section about "Unicode Problem"
+const toUnicode = string => encodeURIComponent(string).replace(
+  /%([0-9A-F]{2})/g,
+  function toSolidBytes (match, p1) {
+    return String.fromCharCode('0x' + p1)
+  }
+)
+
+// see https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding, section about "Unicode Problem"
+const fromUnicode = string => decodeURIComponent(
+  string.split('').map(function (c) {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+  }).join('')
+)
+
+export const decode = base64u => {
+  return typeof window === 'object'
+    ? fromUnicode(window.atob(urlDecode(base64u)))
     : Buffer.from(urlDecode(base64u), 'base64').toString('utf8')
+}
 
 export const encode = string => urlEncode(
   typeof window === 'object'
-    ? window.btoa(unescape(encodeURIComponent(string)))
+    ? window.btoa(toUnicode(string))
     : Buffer.from(string, 'utf8').toString('base64')
 )
 

--- a/lib/utils/base64u.js
+++ b/lib/utils/base64u.js
@@ -1,0 +1,22 @@
+const urlDecode = base64u =>
+  `${base64u}${'==='.slice((base64u.length + 3) % 4)}`
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+
+const urlEncode = string => string
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=/g, '')
+
+export const decode = base64u =>
+  typeof window === 'object'
+    ? window.atob(urlDecode(base64u))
+    : Buffer.from(urlDecode(base64u), 'base64').toString('utf8')
+
+export const encode = string => urlEncode(
+  typeof window === 'object'
+    ? window.btoa(string)
+    : Buffer.from(string, 'utf8').toString('base64')
+)
+
+export const match = base64u => /^[A-Za-z0-9\-_]+$/.test(base64u)

--- a/lib/utils/base64u.js
+++ b/lib/utils/base64u.js
@@ -10,12 +10,12 @@ const urlEncode = string => string
 
 export const decode = base64u =>
   typeof window === 'object'
-    ? window.atob(urlDecode(base64u))
+    ? decodeURIComponent(escape(window.atob(urlDecode(base64u))))
     : Buffer.from(urlDecode(base64u), 'base64').toString('utf8')
 
 export const encode = string => urlEncode(
   typeof window === 'object'
-    ? window.btoa(string)
+    ? window.btoa(unescape(encodeURIComponent(string)))
     : Buffer.from(string, 'utf8').toString('base64')
 )
 

--- a/lib/utils/base64u.test.js
+++ b/lib/utils/base64u.test.js
@@ -23,7 +23,7 @@ const testSeries = (env) => {
     }
   ]
     .forEach(({ title, string, base64u }) => {
-      test(`(${env}) base64 ${string} <-> ${base64u}`, assert => {
+      test(`(${env}) base64u ${string} <-> ${base64u}`, assert => {
         const encoded = encode(string)
         assert.equal(encoded, base64u)
 

--- a/lib/utils/base64u.test.js
+++ b/lib/utils/base64u.test.js
@@ -1,58 +1,78 @@
 import test from 'tape'
 import { encode, decode, match } from './base64u'
 
-[
-  {
-    string: 'heidi',
-    base64u: 'aGVpZGk'
-  },
-  {
-    string: 'peter?_',
-    base64u: 'cGV0ZXI_Xw' // Not urlsafe: cGV0ZXI/Xw
-  },
-  {
-    string: 'öhi&øπ',
-    base64u: 'w7ZoaSbDuM-A' // Not urlsafe: w7ZoaSbDuM+A
-  }
-]
-  .forEach(({ title, string, base64u }) => {
-    test(`base64 ${string} <-> ${base64u}`, assert => {
-      const encoded = encode(string)
-      assert.equal(encoded, base64u)
+const testSeries = (env) => {
+  [
+    {
+      string: 'heidi',
+      base64u: 'aGVpZGk'
+    },
+    {
+      string: 'peter?_',
+      base64u: 'cGV0ZXI_Xw' // Not urlsafe: cGV0ZXI/Xw
+    },
+    {
+      string: '12345><',
+      base64u: 'MTIzNDU-PA' // Not urlsafe: MTIzNDU+PA
+    },
+    {
+      // window.btoa(<string>) -> InvalidCharacterError
+      // requires escaping, URI component codec to be safe in browser
+      string: 'π',
+      base64u: 'z4A'
+    }
+  ]
+    .forEach(({ title, string, base64u }) => {
+      test(`(${env}) base64 ${string} <-> ${base64u}`, assert => {
+        const encoded = encode(string)
+        assert.equal(encoded, base64u)
 
-      const decoded = decode(encoded)
-      assert.equal(decoded, string)
+        const decoded = decode(encoded)
+        assert.equal(decoded, string)
 
-      assert.end()
+        assert.end()
+      })
     })
+
+  test(`(${env}) base64u.decode w/ block padding "="`, assert => {
+    assert.equal(decode('a2xhcmE='), 'klara')
+    assert.end()
   })
 
-test(`base64u.decode w/ block padding "="`, assert => {
-  assert.equal(decode('a2xhcmE='), 'klara')
-  assert.end()
-})
+  test(`(${env}) base64u.decode w/o block padding "="`, assert => {
+    assert.equal(decode('a2xhcmE'), 'klara')
+    assert.end()
+  })
 
-test(`base64u.decode w/o block padding "="`, assert => {
-  assert.equal(decode('a2xhcmE'), 'klara')
-  assert.end()
-})
+  test(`(${env}) base64u.match "a2xhcmE=" -> false`, assert => {
+    assert.equal(match('a2xhcmE='), false)
+    assert.end()
+  })
 
-test(`base64u.match "a2xhcmE=" -> false`, assert => {
-  assert.equal(match('a2xhcmE='), false)
-  assert.end()
-})
+  test(`(${env}) base64u.match "a2xhcmE" -> true`, assert => {
+    assert.equal(match('a2xhcmE'), true)
+    assert.end()
+  })
 
-test(`base64u.match "a2xhcmE" -> true`, assert => {
-  assert.equal(match('a2xhcmE'), true)
-  assert.end()
-})
+  test(`(${env}) base64u.match "cGV0ZXI_Xw" -> true`, assert => {
+    assert.equal(match('cGV0ZXI_Xw'), true)
+    assert.end()
+  })
 
-test(`base64u.match "cGV0ZXI_Xw" -> true`, assert => {
-  assert.equal(match('cGV0ZXI_Xw'), true)
-  assert.end()
-})
+  test(`(${env}) base64u.match "cGV0ZXI/Xw" -> false`, assert => {
+    assert.equal(match('cGV0ZXI/Xw'), false)
+    assert.end()
+  })
 
-test(`base64u.match "cGV0ZXI/Xw" -> false`, assert => {
-  assert.equal(match('cGV0ZXI/Xw'), false)
-  assert.end()
-})
+  test(`(${env}) base64u.match "cGV0ZXI/Xw" -> false`, assert => {
+    assert.equal(match('cGV0ZXI/Xw'), false)
+    assert.end()
+  })
+}
+
+// Test Node.JS path
+testSeries('node')
+
+// Test (emulated) Browser window global variable
+global.window = require('abab')
+testSeries('browser')

--- a/lib/utils/base64u.test.js
+++ b/lib/utils/base64u.test.js
@@ -1,78 +1,127 @@
-import test from 'tape'
 import { encode, decode, match } from './base64u'
+import abab from 'abab'
+import test from 'tape'
 
-const testSeries = (env) => {
+const testSeries = (env, runEnv) => {
   [
-    {
-      string: 'heidi',
-      base64u: 'aGVpZGk'
-    },
-    {
-      string: 'peter?_',
-      base64u: 'cGV0ZXI_Xw' // Not urlsafe: cGV0ZXI/Xw
-    },
-    {
-      string: '12345><',
-      base64u: 'MTIzNDU-PA' // Not urlsafe: MTIzNDU+PA
-    },
-    {
-      // window.btoa(<string>) -> InvalidCharacterError
-      // requires escaping, URI component codec to be safe in browser
-      string: 'π',
-      base64u: 'z4A'
-    }
+    { string: 'heidi', base64u: 'aGVpZGk' },
+    { string: 'peter?_', base64u: 'cGV0ZXI_Xw' }, // Not urlsafe: cGV0ZXI/Xw
+    { string: '12345><', base64u: 'MTIzNDU-PA' }, // Not urlsafe: MTIzNDU+PA
+    { string: 'äöüáàâéèê', base64u: 'w6TDtsO8w6HDoMOiw6nDqMOq' },
+    { string: 'π', base64u: 'z4A' },
+    { string: '😈', base64u: '8J-YiA' }, // Not urlsafe: 8J+YiA
+    { string: '\n', base64u: 'Cg' }
   ]
     .forEach(({ title, string, base64u }) => {
-      test(`(${env}) base64u ${string} <-> ${base64u}`, assert => {
-        const encoded = encode(string)
-        assert.equal(encoded, base64u)
+      test(
+        `(${env}) base64u ${string} <-> ${base64u}`,
+        assert => runEnv(
+          assert,
+          assert => {
+            const encoded = encode(string)
+            assert.equal(encoded, base64u)
 
-        const decoded = decode(encoded)
-        assert.equal(decoded, string)
+            const decoded = decode(encoded)
+            assert.equal(decoded, string)
 
-        assert.end()
-      })
+            assert.end()
+          }
+        )
+      )
     })
 
-  test(`(${env}) base64u.decode w/ block padding "="`, assert => {
-    assert.equal(decode('a2xhcmE='), 'klara')
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.decode w/ block padding "="`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(decode('a2xhcmE='), 'klara')
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.decode w/o block padding "="`, assert => {
-    assert.equal(decode('a2xhcmE'), 'klara')
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.decode w/o block padding "="`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(decode('a2xhcmE'), 'klara')
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.match "a2xhcmE=" -> false`, assert => {
-    assert.equal(match('a2xhcmE='), false)
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.match "a2xhcmE=" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('a2xhcmE='), false)
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.match "a2xhcmE" -> true`, assert => {
-    assert.equal(match('a2xhcmE'), true)
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.match "a2xhcmE" -> true`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('a2xhcmE'), true)
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.match "cGV0ZXI_Xw" -> true`, assert => {
-    assert.equal(match('cGV0ZXI_Xw'), true)
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.match "cGV0ZXI_Xw" -> true`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI_Xw'), true)
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.match "cGV0ZXI/Xw" -> false`, assert => {
-    assert.equal(match('cGV0ZXI/Xw'), false)
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.match "cGV0ZXI/Xw" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI/Xw'), false)
+        assert.end()
+      }
+    )
+  )
 
-  test(`(${env}) base64u.match "cGV0ZXI/Xw" -> false`, assert => {
-    assert.equal(match('cGV0ZXI/Xw'), false)
-    assert.end()
-  })
+  test(
+    `(${env}) base64u.match "cGV0ZXI/Xw" -> false`,
+    assert => runEnv(
+      assert,
+      assert => {
+        assert.equal(match('cGV0ZXI/Xw'), false)
+        assert.end()
+      }
+    )
+  )
 }
 
 // Test Node.JS path
-testSeries('node')
+testSeries(
+  'node',
+  (assert, asserationFn) => {
+    asserationFn(assert)
+  }
+)
 
 // Test (emulated) Browser window global variable
-global.window = require('abab')
-testSeries('browser')
+testSeries(
+  'browser',
+  (assert, asserationFn) => {
+    global.window = abab
+    asserationFn(assert)
+    global.window = undefined
+  }
+)

--- a/lib/utils/base64u.test.js
+++ b/lib/utils/base64u.test.js
@@ -1,0 +1,58 @@
+import test from 'tape'
+import { encode, decode, match } from './base64u'
+
+[
+  {
+    string: 'heidi',
+    base64u: 'aGVpZGk'
+  },
+  {
+    string: 'peter?_',
+    base64u: 'cGV0ZXI_Xw' // Not urlsafe: cGV0ZXI/Xw
+  },
+  {
+    string: 'öhi&øπ',
+    base64u: 'w7ZoaSbDuM-A' // Not urlsafe: w7ZoaSbDuM+A
+  }
+]
+  .forEach(({ title, string, base64u }) => {
+    test(`base64 ${string} <-> ${base64u}`, assert => {
+      const encoded = encode(string)
+      assert.equal(encoded, base64u)
+
+      const decoded = decode(encoded)
+      assert.equal(decoded, string)
+
+      assert.end()
+    })
+  })
+
+test(`base64u.decode w/ block padding "="`, assert => {
+  assert.equal(decode('a2xhcmE='), 'klara')
+  assert.end()
+})
+
+test(`base64u.decode w/o block padding "="`, assert => {
+  assert.equal(decode('a2xhcmE'), 'klara')
+  assert.end()
+})
+
+test(`base64u.match "a2xhcmE=" -> false`, assert => {
+  assert.equal(match('a2xhcmE='), false)
+  assert.end()
+})
+
+test(`base64u.match "a2xhcmE" -> true`, assert => {
+  assert.equal(match('a2xhcmE'), true)
+  assert.end()
+})
+
+test(`base64u.match "cGV0ZXI_Xw" -> true`, assert => {
+  assert.equal(match('cGV0ZXI_Xw'), true)
+  assert.end()
+})
+
+test(`base64u.match "cGV0ZXI/Xw" -> false`, assert => {
+  assert.equal(match('cGV0ZXI/Xw'), false)
+  assert.end()
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -9727,11 +9727,6 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
-    "urlsafe-base64": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
-      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
-    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,12 @@
         "through": "2.3.8"
       }
     },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9727,6 +9727,11 @@
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
       "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
+    "urlsafe-base64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/urlsafe-base64/-/urlsafe-base64-1.0.0.tgz",
+      "integrity": "sha1-I/iQaabGL0bPOh07ABac77kL4MY="
+    },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "react-maskedinput": "^4.0.1",
     "react-textarea-autosize": "^5.1.0",
     "subscriptions-transport-ws": "^0.9.1",
-    "urlsafe-base64": "^1.0.0",
     "uuid": "^3.1.0",
     "valid-url": "^1.0.9",
     "validator": "^9.4.1"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     }
   },
   "devDependencies": {
+    "abab": "^2.0.0",
     "babel-tape-runner": "^2.0.1",
     "cross-env": "^5.1.1",
     "enzyme": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "react-maskedinput": "^4.0.1",
     "react-textarea-autosize": "^5.1.0",
     "subscriptions-transport-ws": "^0.9.1",
+    "urlsafe-base64": "^1.0.0",
     "uuid": "^3.1.0",
     "valid-url": "^1.0.9",
     "validator": "^9.4.1"


### PR DESCRIPTION
Ensures a passed string is decoded if it recognizes string as valid base64 chars in `SignIn` component.

A future version of backend will provide a URL with `email=<base64-encoded email>` instead of `email=<email>`. Latter let to double-encoding conflicts in some email clients, and resulted in URLs being invalid:

`heidi@wiese.tld` is encoded to `heidi%40wiese.tld` (`@` => `%40`). Some email clients would re-encode and generate a link with `heidi%2540wiese.tld` (`%` => `%25`).

Introduces [urlsafe-base64](https://www.npmjs.com/package/urlsafe-base64) as a dependency.