### PR TITLE
app.json for heroku's CI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,3 +49,7 @@ PAYPAL_DONATE_LINK=https://www.sandbox.paypal.com/cgi-bin/webscr?cmd=_s-xclick&h
 # SG_LOGO_VIEWBOX=
 # SG_BRAND_MARK_PATH=
 # SG_BRAND_MARK_VIEWBOX=
+
+
+# If the API is HTTP basic-auth protected, you can generate a basic authorization header with ``Basic ${(new Buffer('user:password')).toString('base64')}`` in Node.js and use it with `API_AUTHORIZATION_HEADER`.
+# API_AUTHORIZATION_HEADER=

--- a/app.json
+++ b/app.json
@@ -1,0 +1,73 @@
+{
+  "name": "republik-frontend",
+  "scripts": {},
+  "env": {
+    "API_URL": "",
+    "API_WS_URL": "",
+    "PAYPAL_BUSINESS": "",
+    "PAYPAL_DONATE_LINK": "",
+    "PAYPAL_FORM_ACTION": "",
+    "PF_FORM_ACTION": "",
+    "PF_PSPID": "",
+    "PIWIK_SITE_ID": "",
+    "PIWIK_URL_BASE": "",
+    "PUBLIC_BASE_URL": "",
+    "STRIPE_PUBLISHABLE_KEY": "",
+    "ASSETS_SERVER_BASE_URL": {
+      "required": true
+    },
+    "BASIC_AUTH_PASS": {
+      "generator": "secret"
+    },
+    "BASIC_AUTH_REALM": {
+      "required": true
+    },
+    "BASIC_AUTH_USER": "itisfun",
+    "CDN_FRONTEND_BASE_URL": {
+      "required": true
+    },
+    "CROWDFUNDING_NAME": {
+      "required": true
+    },
+    "DISCUSSION_POLL_INTERVAL_MS": {
+      "required": true
+    },
+    "ERROR_PAGE_URL": {
+      "required": true
+    },
+    "MAINTENANCE_PAGE_URL": {
+      "required": true
+    },
+    "SG_BRAND_MARK_PATH": {
+      "required": true
+    },
+    "SG_BRAND_MARK_VIEWBOX": {
+      "required": true
+    },
+    "SG_COLORS": {
+      "required": true
+    },
+    "SG_FONT_FACES": {
+      "required": true
+    },
+    "SG_FONT_FAMILIES": {
+      "required": true
+    },
+    "SG_LOGO_PATH": {
+      "required": true
+    },
+    "SG_LOGO_VIEWBOX": {
+      "required": true
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1
+    }
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -6,7 +6,7 @@ import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemo
 
 import fetch from 'isomorphic-unfetch'
 
-import {API_URL, API_WS_URL} from '../constants'
+import {API_URL, API_WS_URL, API_AUTHORIZATION_HEADER} from '../constants'
 
 let apolloClient = null
 
@@ -60,7 +60,8 @@ function create (initialState = {}, headers = {}) {
     credentials: 'include',
     headers: {
       cookie: headers.cookie,
-      accept: headers.accept
+      accept: headers.accept,
+      Authorization: API_AUTHORIZATION_HEADER
     }
   })
 


### PR DESCRIPTION
this would allow to deploy [review apps](https://devcenter.heroku.com/articles/github-integration-review-apps#review-apps) including sensible env inheritance from staging. requiring manual setup for the missing but mandatory envs (API_URL, PUBLIC_BASE_URL, etc.)
More manual work to setup a review app is necessary: Do to our cookie sharing, working with herokuapp.com domains is not possible. But adding a custom domain name, with a shared subdomain space for the fe and backend is easy enough. The following settings were tested:
- backend: api.featureX.republik.black
- frontend: featureX.republik.black
- cookie-domain: featureX.republik.black

I'd opt to not create review apps automatically, but create them through the heroku ui, if desired.
Steps to initially deploy a fe and be review app:
for each [fe, be]
- deploy the brach from the review-app column
- set a domain in the newly created app ((api.)featureX.republik.black)
- add the CNAME record to cloudflare ((api.)featureX.republik.black => (api.)featureX.republik.black.herokudns.com)
- activate SSL

be ENVs:
```
FRONTEND_BASE_URL=https://featureX.republik.black (only necessary for working email links)
COOKIE_DOMAIN=featureX.republik.black
CORS_WHITELIST_URL=https://featureX.republik.black,https://admin.featureX.republik.black
AUTH_USER_PASS=test
AUTH_USER_PASS=secret
DATABASE_URL=copy from staging if desired
REDIS=copy from staging if desired
ELASTIC_URL=copy from staging if desired
```

fe ENVs:
```
API_URL=https://api.featureX.republik.black/graphql
API_WS_URL=wss://api.featureX.republik.black/graphql
PUBLIC_BASE_URL=featureX.republik.black
CDN_FRONTEND_BASE_URL=
AUTH_USER_PASS=test
AUTH_USER_PASS=secret
API_AUTHORIZATION_HEADER=`Basic ${(new Buffer('test:secret')).toString('base64')}`
```

After that setup pushes to the brach are auto deployed to the configured app and available under featureX.republik.black (secured by basic-auth per default).
It requires manualy work, but for > 1-week feature branches it might be worth the effort. These steps could be automated in post-deploy scripts.

Security considerations in combination with auto deploy and DATABASE_URL=staging:
everybody who has push access to https://github.com/orbiting can push into a review-app-enabled PR/branch and thus could extract staging DB information.

review apps in the backend:
<img width="1251" alt="screen shot 2018-05-09 at 03 12 29" src="https://user-images.githubusercontent.com/3500621/39790560-1b067fea-5337-11e8-9fdc-101f87309a9a.png">
