### PR TITLE
Validate Email

### DIFF
--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-05-10T11:18:14.881Z",
+  "updated": "2018-05-10T11:49:43.108Z",
   "title": "live",
   "data": [
     {
@@ -2480,7 +2480,7 @@
     },
     {
       "key": "notifications/invalid-email/text",
-      "value": "Der von Ihnen aufgerufene Link enthält eine ungültige E-Mail-Adresse: «<b>{email}</b>».<br /><br />Es könnte sein das die Zeichenkodierung beim Übertragen korrumpiert wurde. Bitte versuchen Sie es mit einem anderen E-Mail-Programm.<br /><br />Und melden Sie uns, unter welchen Umständen dies passiert ist: <a href=\"mailto:kontakt@republik.ch?subject=Korrumpierte%20E-Mail-Adresse\">kontakt@republik.ch</a>."
+      "value": "Der von Ihnen aufgerufene Link enthält eine ungültige E-Mail-Adresse: «<b>{email}</b>».<br /><br />Es könnte sein dass die Zeichenkodierung beim Übertragen korrumpiert wurde. Bitte versuchen Sie es mit einem anderen E-Mail-Programm.<br /><br />Und melden Sie uns, unter welchen Umständen dies passiert ist: <a href=\"mailto:kontakt@republik.ch?subject=Korrumpierte%20E-Mail-Adresse\">kontakt@republik.ch</a>."
     },
     {
       "key": "notifications/unavailable/title",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-05-04T11:14:56.281Z",
+  "updated": "2018-05-10T11:18:14.881Z",
   "title": "live",
   "data": [
     {
@@ -2473,6 +2473,14 @@
     {
       "key": "notifications/invalid-token/text",
       "value": "Der von Ihnen aufgerufene Link ist nicht gültig. Links zur Anmeldung sind nur einmal gültig."
+    },
+    {
+      "key": "notifications/invalid-email/title",
+      "value": "Ungültige E-Mail-Adresse"
+    },
+    {
+      "key": "notifications/invalid-email/text",
+      "value": "Der von Ihnen aufgerufene Link enthält eine ungültige E-Mail-Adresse: «<b>{email}</b>».<br /><br />Es könnte sein das die Zeichenkodierung beim Übertragen korrumpiert wurde. Bitte versuchen Sie es mit einem anderen E-Mail-Programm.<br /><br />Und melden Sie uns, unter welchen Umständen dies passiert ist: <a href=\"mailto:kontakt@republik.ch?subject=Korrumpierte%20E-Mail-Adresse\">kontakt@republik.ch</a>."
     },
     {
       "key": "notifications/unavailable/title",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-05-10T11:49:43.108Z",
+  "updated": "2018-05-10T11:56:09.438Z",
   "title": "live",
   "data": [
     {
@@ -2480,7 +2480,7 @@
     },
     {
       "key": "notifications/invalid-email/text",
-      "value": "Der von Ihnen aufgerufene Link enthält eine ungültige E-Mail-Adresse: «<b>{email}</b>».<br /><br />Es könnte sein dass die Zeichenkodierung beim Übertragen korrumpiert wurde. Bitte versuchen Sie es mit einem anderen E-Mail-Programm.<br /><br />Und melden Sie uns, unter welchen Umständen dies passiert ist: <a href=\"mailto:kontakt@republik.ch?subject=Korrumpierte%20E-Mail-Adresse\">kontakt@republik.ch</a>."
+      "value": "Der von Ihnen aufgerufene Link enthält eine ungültige E-Mail-Adresse: «<b>{email}</b>».<br /><br />Es könnte sein, dass die Zeichenkodierung beim Übertragen korrumpiert wurde. Bitte versuchen Sie es mit einem anderen E-Mail-Programm.<br /><br />Und melden Sie uns, unter welchen Umständen dies passiert ist: <a href=\"mailto:kontakt@republik.ch?subject=Korrumpierte%20E-Mail-Adresse\">kontakt@republik.ch</a>."
     },
     {
       "key": "notifications/unavailable/title",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -13,8 +13,7 @@ export default class MyDocument extends Document {
     return {
       ...page,
       ...styles,
-      env: require('../lib/constants'),
-      shouldTrackPiwik: pathname !== '/notifications'
+      env: require('../lib/constants')
     }
   }
   constructor (props) {
@@ -27,9 +26,8 @@ export default class MyDocument extends Document {
   render () {
     const { css, env: {
       PIWIK_URL_BASE, PIWIK_SITE_ID, PUBLIC_BASE_URL
-    }, shouldTrackPiwik } = this.props
+    } } = this.props
     const piwik = (
-      shouldTrackPiwik &&
       !!PIWIK_URL_BASE &&
       !!PIWIK_SITE_ID
     )

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -126,7 +126,6 @@ const Page = withT(({ url: { query, query: { context, token } }, t }) => {
           )}
         </div>
       </NarrowContainer>
-      <script dangerouslySetInnerHTML={{__html: `_paq.push(['trackPageView']);`}} />
     </div>
   )
 })

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import { css } from 'glamor'
 import Head from 'next/head'
+import isEmail from 'validator/lib/isEmail'
 
 import withData from '../lib/apollo/withData'
 import withT from '../lib/withT'
 import { intersperse } from '../lib/utils/helpers'
 import { Link } from '../lib/routes'
-import { match, decode } from '../lib/utils/base64u'
+import * as base64u from '../lib/utils/base64u'
 
 import Me from '../components/Auth/Me'
 import TokenAuthorization from '../components/Auth/TokenAuthorization'
@@ -44,7 +45,7 @@ const hasCurtain = !!CURTAIN_MESSAGE
 
 const {H1, P} = Interaction
 
-const Page = withT(({ url: { query: { type, context, email, token } }, t }) => {
+const Page = withT(({ url: { query, query: { context, token } }, t }) => {
   const links = [
     context === 'pledge' && {
       route: 'account',
@@ -52,13 +53,28 @@ const Page = withT(({ url: { query: { type, context, email, token } }, t }) => {
     }
   ].filter(Boolean)
 
+  let { type, email } = query
+  if (email !== undefined) {
+    try {
+      if (base64u.match(email)) {
+        email = base64u.decode(email)
+      }
+    } catch (e) {}
+
+    if (!isEmail(email)) {
+      type = 'invalid-email'
+      email = ''
+    }
+  }
+
   const displayTokenAuthorization = type === 'token-authorization'
   const displayMe = (
-    type === 'invalid-token' &&
+    (
+      type === 'invalid-token' ||
+      type === 'invalid-email'
+    ) &&
     (['signIn', 'pledge', 'authorization'].indexOf(context) !== -1)
   )
-
-  const safeEmail = email && (match(email) ? decode(email) : email)
 
   return (
     <div>
@@ -83,13 +99,13 @@ const Page = withT(({ url: { query: { type, context, email, token } }, t }) => {
             ? (
               <div {...styles.me}>
                 <TokenAuthorization
-                  email={safeEmail}
+                  email={email}
                   token={token}
                 />
               </div>
             )
             : <RawHtml type={P} dangerouslySetInnerHTML={{
-              __html: t(`notifications/${type}/text`, undefined, '')
+              __html: t(`notifications/${type}/text`, query, '')
             }} />
           }
           {displayMe && (


### PR DESCRIPTION
<img width="1001" alt="screen shot 2018-05-10 at 13 21 00" src="https://user-images.githubusercontent.com/410211/39867722-878f97da-5456-11e8-8e88-bfa775a25dec.png">

This should ensure links with invalid email addresses, from manipulated base64u string or just plain invalid normal strings, do not explode and explain what went wrong. And ask the user to report it.

Also includes a fix for the tracking setup. Currently the disabling of piwik in `pages/_document.js` lead to the whole visit, that starts at the notification page, not being tracked (introduced here https://github.com/orbiting/republik-frontend/commit/61f026a41798be600f3e0b762494f03757edb802). Now it only does not track the notification page (with sensitiv url information).