### PR TITLE
memberStats (marketing page and paynote)

### DIFF
--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -27,7 +27,7 @@ const WithoutMembershipBox = ({children, style}) => (
 
 const query = gql`
 query payNoteMembershipStats {
-  membershipStats {
+  memberStats {
     count
   }
 }
@@ -36,7 +36,7 @@ query payNoteMembershipStats {
 export const Before = compose(
   withT,
   graphql(query)
-)(({ t, data: { membershipStats } }) => (
+)(({ t, data: { memberStats } }) => (
   <WithoutMembershipBox>
     <Interaction.P>
       {t.elements('article/payNote/before', {
@@ -46,7 +46,7 @@ export const Before = compose(
           </Link>
         ),
         count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
-          (membershipStats && membershipStats.count) || 18000
+          (memberStats && memberStats.count) || 18000
         )}</span>
       })}
     </Interaction.P>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -173,11 +173,11 @@ const MarketingPage = ({ me, t, crowdfundingName, data }) => (
           <P {...styles.text}>
             <RawHtml
               dangerouslySetInnerHTML={{
-                __html: t('marketing/intro', {count: countFormat(data.membershipStats.count)})
+                __html: t('marketing/intro', {count: countFormat(data.memberStats.count)})
               }}
-          />
+            />
           </P>
-      )} />
+        )} />
       </Container>
       <Container style={{ maxWidth: MAX_WIDTH }} key='more'>
         <div {...styles.more}>
@@ -200,8 +200,8 @@ const MarketingPage = ({ me, t, crowdfundingName, data }) => (
 )
 
 const query = gql`
-query membershipStats {
-  membershipStats {
+query memberStats {
+  memberStats {
     count
   }
 }


### PR DESCRIPTION
this PR uses `memberStats` instead of `membershipStats` on the marketing page and in the payNote banner.