### PR TITLE
Handle app authentication

### DIFF
--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -61,11 +61,45 @@ const styles = {
 class SignIn extends Component {
   constructor (props) {
     super(props)
+
     this.state = {
       email: props.email || '',
       polling: false,
       loading: false,
       success: undefined
+    }
+
+    this.onFormSubmit = (event) => {
+      event.preventDefault()
+
+      const { loading, error, email } = this.state
+      const { signIn, context, acceptedConsents } = this.props
+
+      if (error) {
+        this.setState(() => ({ dirty: true }))
+        return
+      }
+
+      if (loading) {
+        return
+      }
+
+      this.setState(() => ({ loading: true }))
+
+      signIn(email, context, acceptedConsents)
+        .then(({data}) => {
+          this.setState(() => ({
+            polling: true,
+            loading: false,
+            phrase: data.signIn.phrase
+          }))
+        })
+        .catch(error => {
+          this.setState(() => ({
+            serverError: error,
+            loading: false
+          }))
+        })
     }
   }
 
@@ -112,39 +146,9 @@ class SignIn extends Component {
       return <span>{success}</span>
     }
 
-    const submitForm = (event) => {
-      event.preventDefault()
-      if (error) {
-        this.setState(() => ({
-          dirty: true
-        }))
-        return
-      }
-      if (loading) {
-        return
-      }
-      this.setState(() => ({
-        loading: true
-      }))
-      this.props.signIn(email, this.props.context, this.props.acceptedConsents)
-        .then(({data}) => {
-          this.setState(() => ({
-            polling: true,
-            loading: false,
-            phrase: data.signIn.phrase
-          }))
-        })
-        .catch(error => {
-          this.setState(() => ({
-            serverError: error,
-            loading: false
-          }))
-        })
-    }
-
     return (
       <div>
-        <form onSubmit={submitForm}>
+        <form onSubmit={this.onFormSubmit}>
           <div {...styles.form}>
             <div {...styles.input}>
               <Field

--- a/lib/apollo/appWorkerLink.js
+++ b/lib/apollo/appWorkerLink.js
@@ -1,0 +1,141 @@
+import { ApolloLink, Observable } from 'apollo-link'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+
+export const hasSubscriptionOperation = ({ query: { definitions } }) => (
+  definitions.some(
+    ({ kind, operation }) =>
+      kind === 'OperationDefinition' && operation === 'subscription'
+  )
+)
+
+const GQL_MESSAGES_TYPES = ['start', 'data', 'stop', 'error', 'complete']
+
+// WebSocket compliant interface to handle subscriptions via app worker
+class WorkerInterface {
+  constructor (url, protocol) {
+    this.url = url
+    this.protocol = protocol
+    this.readyState = WorkerInterface.OPEN
+    this.onMessageCallback = null
+  }
+
+  send (serializedMessage) {
+    window.postMessage(serializedMessage, '*')
+  }
+
+  close () {
+    document.removeEventListener('message', this.onMessageCallback)
+  }
+
+  onMessage (fn) {
+    return ({ data }) => {
+      const d = JSON.parse(data)
+
+      if (GQL_MESSAGES_TYPES.includes(d.type)) {
+        fn({ data })
+      }
+    }
+  }
+
+  set onmessage (fn) {
+    this.onMessageCallback = this.onMessage(fn)
+
+    document.addEventListener('message', this.onMessageCallback)
+  }
+}
+
+WorkerInterface.CLOSED = 'CLOSED'
+WorkerInterface.OPEN = 'OPEN'
+WorkerInterface.CONNECTING = 'CONNECTING'
+
+// Keep track of queries and mutations
+let operationIds = 0
+
+// Apollo link implementation to resolve queries and mutations via app worker
+class PromiseWorkerLink extends ApolloLink {
+  constructor () {
+    super()
+    this.callbacks = {}
+    this.onMessage = this.onMessage.bind(this)
+    this.postMessage = this.postMessage.bind(this)
+
+    document.addEventListener('message', this.onMessage)
+  }
+
+  onMessage (event) {
+    const operation = JSON.parse(event.data)
+
+    // Ignore subscriptions events. SubscriptionWorkerLink will take care of them
+    if (GQL_MESSAGES_TYPES.includes(operation.type)) return
+
+    const callback = this.callbacks[operation.id]
+
+    if (callback) {
+      callback(operation.payload)
+
+      delete this.callbacks[operation.id]
+    } else {
+      window.postMessage(JSON.stringify({
+        type: 'warning',
+        data: {
+          error: 'Unknown operation id',
+          id: operation.id,
+          operation
+        }
+      }), '*')
+    }
+  }
+
+  postMessage (id, operation) {
+    return new Promise((resolve, reject) => {
+      this.callbacks[id] = result => {
+        resolve(result)
+      }
+
+      window.postMessage(JSON.stringify({
+        type: 'graphql',
+        data: {
+          id,
+          payload: operation
+        }
+      }), '*')
+    })
+  }
+
+  request (operation) {
+    const id = operationIds++
+
+    return new Observable(observer => {
+      // Sends operation to be processed in app "worker"
+      this.postMessage(id, operation).then(response => {
+        observer.next(response)
+        observer.complete()
+      })
+    })
+  }
+}
+
+// Apollo link implementation to resolve subscriptions via app worker
+class SubscriptionWorkerLink extends ApolloLink {
+  constructor () {
+    super()
+    this.subscriptionClient = new SubscriptionClient(null, {}, WorkerInterface)
+  }
+
+  request (operation) {
+    return this.subscriptionClient.request(operation)
+  }
+}
+
+// Create app worker link instance
+// Uses both promise or subscription links based on operation type
+export const createAppWorkerLink = () => {
+  const promiseWorkerLink = new PromiseWorkerLink()
+  const subscriptionWorkerLink = new SubscriptionWorkerLink()
+
+  return ApolloLink.split(
+    hasSubscriptionOperation,
+    subscriptionWorkerLink,
+    promiseWorkerLink
+  )
+}

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -6,7 +6,9 @@ import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemo
 
 import fetch from 'isomorphic-unfetch'
 
-import {API_URL, API_WS_URL, API_AUTHORIZATION_HEADER, SSR_API_URL} from '../constants'
+import { API_URL, API_WS_URL, API_AUTHORIZATION_HEADER, SSR_API_URL } from '../constants'
+import { inNativeAppBrowser } from '../withInNativeApp'
+import { createAppWorkerLink, hasSubscriptionOperation } from './appWorkerLink'
 
 let apolloClient = null
 
@@ -48,12 +50,6 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   }
 })
 
-const hasSubscriptionOperation = ({ query: { definitions } }) =>
-  definitions.some(
-    ({ kind, operation }) =>
-      kind === 'OperationDefinition' && operation === 'subscription'
-  )
-
 function create (initialState = {}, headers = {}) {
   const http = new HttpLink({
     uri: process.browser ? API_URL : SSR_API_URL,
@@ -66,17 +62,19 @@ function create (initialState = {}, headers = {}) {
   })
 
   const link = process.browser
-    ? ApolloLink.split(
-      hasSubscriptionOperation,
-      new WebSocketLink({
-        uri: API_WS_URL,
-        options: {
-          reconnect: true,
-          timeout: 50000
-        }
-      }),
-      http
-    )
+    ? inNativeAppBrowser
+      ? createAppWorkerLink()
+      : ApolloLink.split(
+        hasSubscriptionOperation,
+        new WebSocketLink({
+          uri: API_WS_URL,
+          options: {
+            reconnect: true,
+            timeout: 50000
+          }
+        }),
+        http
+      )
     : http
 
   return new ApolloClient({

--- a/lib/apollo/withMe.js
+++ b/lib/apollo/withMe.js
@@ -1,6 +1,5 @@
 import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
-import { runInApp } from '../withInNativeApp'
 
 export const meQuery = gql`
   query me {
@@ -20,25 +19,8 @@ export const meQuery = gql`
   }
 `
 
-let lastMe
-const notifyApp = me => {
-  if (me === lastMe) return
-
-  window.postMessage(JSON.stringify({
-    type: 'session',
-    data: me
-  }), '*')
-
-  lastMe = me
-}
-
 export default graphql(meQuery, {
-  props: ({ data }) => {
-    // Notify native app about session state
-    runInApp(() => { notifyApp(data.me) })
-
-    return {
-      me: data.me
-    }
-  }
+  props: ({ data }) => ({
+    me: data.me
+  })
 })

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,6 +1,7 @@
 import 'core-js/fn/array/from'
 import 'core-js/fn/array/find'
 import 'core-js/fn/array/find-index'
+import 'core-js/fn/array/includes'
 import 'core-js/fn/object/assign'
 import 'core-js/fn/string/starts-with'
 import 'core-js/es6/set'

--- a/lib/utils/runInApp.js
+++ b/lib/utils/runInApp.js
@@ -1,6 +1,0 @@
-// TODO: Add `navigator.userAgent.match(/RepublikApp/)` check when implementing userAgent
-const runInApp = process.browser
-  ? callback => callback()
-  : () => {}
-
-export default runInApp

--- a/lib/utils/runInApp.js
+++ b/lib/utils/runInApp.js
@@ -1,0 +1,6 @@
+// TODO: Add `navigator.userAgent.match(/RepublikApp/)` check when implementing userAgent
+const runInApp = process.browser
+  ? callback => callback()
+  : () => {}
+
+export default runInApp

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -3,9 +3,20 @@ import { HttpHeaderContext } from './apollo/withData'
 
 export const matchUserAgent = value => value && value.match(/RepublikApp/)
 
-export const runInApp = process.browser && matchUserAgent(navigator.userAgent)
+export const inNativeAppBrowser = process.browser && matchUserAgent(navigator.userAgent)
+
+export const runInNativeAppBrowser = inNativeAppBrowser
   ? callback => callback()
   : () => {}
+
+const nativeLog = (value) => {
+  window.postMessage(JSON.stringify({
+    type: 'log',
+    data: value
+  }), '*')
+}
+
+export const log = inNativeAppBrowser ? nativeLog : console.log
 
 const withInNativeApp = WrappedComponent => props => {
   return (


### PR DESCRIPTION
This PR introduces:

- If user is in browser, signin flow is exactly as before
- If user is in app, the web sends a notification so it can handle the auth there
- Waits for the app to send the phrase, and starts polling as before