### PR TITLE
Resolve graphql calls app side

### DIFF
--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -7,7 +7,6 @@ import isEmail from 'validator/lib/isEmail'
 
 import { Router, Link } from '../../lib/routes'
 import withT from '../../lib/withT'
-import { inNativeAppBrowser } from '../../lib/withInNativeApp'
 
 import ErrorMessage from '../ErrorMessage'
 import RawHtmlElements from '../RawHtmlElements'
@@ -73,7 +72,8 @@ class SignIn extends Component {
     this.onFormSubmit = (event) => {
       event.preventDefault()
 
-      const { loading, error } = this.state
+      const { loading, error, email } = this.state
+      const { signIn, context, acceptedConsents } = this.props
 
       if (error) {
         this.setState(() => ({ dirty: true }))
@@ -85,20 +85,6 @@ class SignIn extends Component {
       }
 
       this.setState(() => ({ loading: true }))
-
-      if (inNativeAppBrowser) {
-        window.postMessage(JSON.stringify({
-          type: 'test'
-        }), '*')
-        this.signInApp()
-      } else {
-        this.signInBrowser()
-      }
-    }
-
-    this.signInBrowser = () => {
-      const { email } = this.state
-      const { signIn, context, acceptedConsents } = this.props
 
       signIn(email, context, acceptedConsents)
         .then(({data}) => {
@@ -114,26 +100,6 @@ class SignIn extends Component {
             loading: false
           }))
         })
-    }
-
-    this.signInApp = () => {
-      const { email } = this.state
-      const { context, acceptedConsents } = this.props
-
-      // Let the app do the auth
-      window.postMessage(JSON.stringify({
-        type: 'signin',
-        data: { email, context, consents: acceptedConsents }
-      }), '*')
-
-      // Wait for phrase to start polling
-      document.addEventListener('message', event => {
-        this.setState(() => ({
-          polling: true,
-          loading: false,
-          phrase: event.data
-        }))
-      }, { once: true })
     }
   }
 

--- a/lib/apollo/appWorkerLink.js
+++ b/lib/apollo/appWorkerLink.js
@@ -1,6 +1,5 @@
 import { ApolloLink, Observable } from 'apollo-link'
 import { SubscriptionClient } from 'subscriptions-transport-ws'
-import { API_WS_URL } from '../constants'
 
 export const hasSubscriptionOperation = ({ query: { definitions } }) => (
   definitions.some(
@@ -9,26 +8,39 @@ export const hasSubscriptionOperation = ({ query: { definitions } }) => (
   )
 )
 
+const GQL_MESSAGES_TYPES = ['start', 'data', 'stop', 'error', 'complete']
+
 // WebSocket compliant interface to handle subscriptions via app worker
 class WorkerInterface {
   constructor (url, protocol) {
     this.url = url
     this.protocol = protocol
     this.readyState = WorkerInterface.OPEN
+    this.onMessageCallback = null
   }
 
   send (serializedMessage) {
     window.postMessage(serializedMessage, '*')
   }
 
-  set onmessage (fn) {
-    document.addEventListener('message', ({ data }) => {
+  close () {
+    document.removeEventListener('message', this.onMessageCallback)
+  }
+
+  onMessage (fn) {
+    return ({ data }) => {
       const d = JSON.parse(data)
 
-      if (d.type === 'start' || d.type === 'data') {
+      if (GQL_MESSAGES_TYPES.includes(d.type)) {
         fn({ data })
       }
-    })
+    }
+  }
+
+  set onmessage (fn) {
+    this.onMessageCallback = this.onMessage(fn)
+
+    document.addEventListener('message', this.onMessageCallback)
   }
 }
 
@@ -90,9 +102,9 @@ class PromiseWorkerLink extends ApolloLink {
 
 // Apollo link implementation to resolve subscriptions via app worker
 class SubscriptionWorkerLink extends ApolloLink {
-  constructor ({ uri, options }) {
+  constructor () {
     super()
-    this.subscriptionClient = new SubscriptionClient(uri, options, WorkerInterface)
+    this.subscriptionClient = new SubscriptionClient(null, {}, WorkerInterface)
   }
 
   request (operation) {
@@ -104,13 +116,7 @@ class SubscriptionWorkerLink extends ApolloLink {
 // Uses both promise or subscription links based on operation type
 export const createAppWorkerLink = () => {
   const promiseWorkerLink = new PromiseWorkerLink()
-  const subscriptionWorkerLink = new SubscriptionWorkerLink({
-    uri: API_WS_URL,
-    options: {
-      reconnect: true,
-      timeout: 50000
-    }
-  })
+  const subscriptionWorkerLink = new SubscriptionWorkerLink()
 
   return ApolloLink.split(
     hasSubscriptionOperation,

--- a/lib/apollo/appWorkerLink.js
+++ b/lib/apollo/appWorkerLink.js
@@ -64,10 +64,25 @@ class PromiseWorkerLink extends ApolloLink {
 
   onMessage (event) {
     const operation = JSON.parse(event.data)
+
+    // Ignore subscriptions events. SubscriptionWorkerLink will take care of them
+    if (GQL_MESSAGES_TYPES.includes(operation.type)) return
+
     const callback = this.callbacks[operation.id]
 
     if (callback) {
-      callback(operation)
+      callback(operation.payload)
+
+      delete this.callbacks[operation.id]
+    } else {
+      window.postMessage(JSON.stringify({
+        type: 'warning',
+        data: {
+          error: 'Unknown operation id',
+          id: operation.id,
+          operation
+        }
+      }), '*')
     }
   }
 

--- a/lib/apollo/appWorkerLink.js
+++ b/lib/apollo/appWorkerLink.js
@@ -1,0 +1,120 @@
+import { ApolloLink, Observable } from 'apollo-link'
+import { SubscriptionClient } from 'subscriptions-transport-ws'
+import { API_WS_URL } from '../constants'
+
+export const hasSubscriptionOperation = ({ query: { definitions } }) => (
+  definitions.some(
+    ({ kind, operation }) =>
+      kind === 'OperationDefinition' && operation === 'subscription'
+  )
+)
+
+// WebSocket compliant interface to handle subscriptions via app worker
+class WorkerInterface {
+  constructor (url, protocol) {
+    this.url = url
+    this.protocol = protocol
+    this.readyState = WorkerInterface.OPEN
+  }
+
+  send (serializedMessage) {
+    window.postMessage(serializedMessage, '*')
+  }
+
+  set onmessage (fn) {
+    document.addEventListener('message', ({ data }) => {
+      const d = JSON.parse(data)
+
+      if (d.type === 'start' || d.type === 'data') {
+        fn({ data })
+      }
+    })
+  }
+}
+
+WorkerInterface.CLOSED = 'CLOSED'
+WorkerInterface.OPEN = 'OPEN'
+WorkerInterface.CONNECTING = 'CONNECTING'
+
+// Keep track of queries and mutations
+let operationIds = 0
+
+// Apollo link implementation to resolve queries and mutations via app worker
+class PromiseWorkerLink extends ApolloLink {
+  constructor () {
+    super()
+    this.callbacks = {}
+    this.onMessage = this.onMessage.bind(this)
+    this.postMessage = this.postMessage.bind(this)
+
+    document.addEventListener('message', this.onMessage)
+  }
+
+  onMessage (event) {
+    const operation = JSON.parse(event.data)
+    const callback = this.callbacks[operation.id]
+
+    if (callback) {
+      callback(operation)
+    }
+  }
+
+  postMessage (id, operation) {
+    return new Promise((resolve, reject) => {
+      this.callbacks[id] = result => {
+        resolve(result)
+      }
+
+      window.postMessage(JSON.stringify({
+        type: 'graphql',
+        data: {
+          id,
+          payload: operation
+        }
+      }), '*')
+    })
+  }
+
+  request (operation) {
+    const id = operationIds++
+
+    return new Observable(observer => {
+      // Sends operation to be processed in app "worker"
+      this.postMessage(id, operation).then(response => {
+        observer.next(response)
+        observer.complete()
+      })
+    })
+  }
+}
+
+// Apollo link implementation to resolve subscriptions via app worker
+class SubscriptionWorkerLink extends ApolloLink {
+  constructor ({ uri, options }) {
+    super()
+    this.subscriptionClient = new SubscriptionClient(uri, options, WorkerInterface)
+  }
+
+  request (operation) {
+    return this.subscriptionClient.request(operation)
+  }
+}
+
+// Create app worker link instance
+// Uses both promise or subscription links based on operation type
+export const createAppWorkerLink = () => {
+  const promiseWorkerLink = new PromiseWorkerLink()
+  const subscriptionWorkerLink = new SubscriptionWorkerLink({
+    uri: API_WS_URL,
+    options: {
+      reconnect: true,
+      timeout: 50000
+    }
+  })
+
+  return ApolloLink.split(
+    hasSubscriptionOperation,
+    subscriptionWorkerLink,
+    promiseWorkerLink
+  )
+}

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -1,13 +1,14 @@
 import ApolloClient from 'apollo-client'
-import { ApolloLink, Observable } from 'apollo-link'
+import { ApolloLink } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
 import { WebSocketLink } from 'apollo-link-ws'
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
 
 import fetch from 'isomorphic-unfetch'
 
-import {API_URL, API_WS_URL, API_AUTHORIZATION_HEADER} from '../constants'
+import { API_URL, API_WS_URL, API_AUTHORIZATION_HEADER } from '../constants'
 import { inNativeAppBrowser } from '../withInNativeApp'
+import { createAppWorkerLink, hasSubscriptionOperation } from './appWorkerLink'
 
 let apolloClient = null
 
@@ -49,59 +50,6 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   }
 })
 
-const hasSubscriptionOperation = ({ query: { definitions } }) =>
-  definitions.some(
-    ({ kind, operation }) =>
-      kind === 'OperationDefinition' && operation === 'subscription'
-  )
-
-let operationIds = 0
-
-class AppLink extends ApolloLink {
-  constructor () {
-    super()
-    this.callbacks = {}
-    this.onMessage = this.onMessage.bind(this)
-    this.postMessage = this.postMessage.bind(this)
-
-    document.addEventListener('message', this.onMessage)
-  }
-
-  onMessage (event) {
-    const operation = JSON.parse(event.data)
-    const callback = this.callbacks[operation.id]
-
-    if (callback) {
-      callback(event.data)
-    }
-  }
-
-  postMessage (operation) {
-    return new Promise((resolve, reject) => {
-      this.callbacks[operation.id] = result => {
-        resolve(JSON.parse(result))
-      }
-
-      window.postMessage(JSON.stringify({
-        type: 'graphql',
-        data: operation
-      }), '*')
-    })
-  }
-
-  request (operation) {
-    operation.id = operationIds++
-
-    return new Observable(observer => {
-      // Sends operation to be processed in app "worker"
-      this.postMessage(operation).then(response => {
-        observer.next(response)
-        observer.complete()
-      })
-    })
-  }
-}
-
 function create (initialState = {}, headers = {}) {
   const http = new HttpLink({
     uri: API_URL,
@@ -114,17 +62,19 @@ function create (initialState = {}, headers = {}) {
   })
 
   const link = process.browser
-    ? ApolloLink.split(
-      hasSubscriptionOperation,
-      new WebSocketLink({
-        uri: API_WS_URL,
-        options: {
-          reconnect: true,
-          timeout: 50000
-        }
-      }),
-      inNativeAppBrowser ? new AppLink() : http
-    )
+    ? inNativeAppBrowser
+      ? createAppWorkerLink()
+      : ApolloLink.split(
+        hasSubscriptionOperation,
+        new WebSocketLink({
+          uri: API_WS_URL,
+          options: {
+            reconnect: true,
+            timeout: 50000
+          }
+        }),
+        http
+      )
     : http
 
   return new ApolloClient({

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -55,21 +55,49 @@ const hasSubscriptionOperation = ({ query: { definitions } }) =>
       kind === 'OperationDefinition' && operation === 'subscription'
   )
 
+let operationIds = 0
+
 class AppLink extends ApolloLink {
-  request (operation) {
-    return new Observable(observer => {
-      // Sends operation to be processed in app "worker"
+  constructor () {
+    super()
+    this.callbacks = {}
+    this.onMessage = this.onMessage.bind(this)
+    this.postMessage = this.postMessage.bind(this)
+
+    document.addEventListener('message', this.onMessage)
+  }
+
+  onMessage (event) {
+    const operation = JSON.parse(event.data)
+    const callback = this.callbacks[operation.id]
+
+    if (callback) {
+      callback(event.data)
+    }
+  }
+
+  postMessage (operation) {
+    return new Promise((resolve, reject) => {
+      this.callbacks[operation.id] = result => {
+        resolve(JSON.parse(result))
+      }
+
       window.postMessage(JSON.stringify({
         type: 'graphql',
         data: operation
-      }))
+      }), '*')
+    })
+  }
 
-      // Listens to response.
-      // This is not reliable at all, since it can colide with another call. Just a PoC for now
-      document.addEventListener('message', event => {
-        observer.next(JSON.parse(event.data))
+  request (operation) {
+    operation.id = operationIds++
+
+    return new Observable(observer => {
+      // Sends operation to be processed in app "worker"
+      this.postMessage(operation).then(response => {
+        observer.next(response)
         observer.complete()
-      }, { once: true })
+      })
     })
   }
 }

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -1,5 +1,5 @@
 import ApolloClient from 'apollo-client'
-import { ApolloLink } from 'apollo-link'
+import { ApolloLink, Observable } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
 import { WebSocketLink } from 'apollo-link-ws'
 import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
@@ -7,6 +7,7 @@ import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemo
 import fetch from 'isomorphic-unfetch'
 
 import {API_URL, API_WS_URL, API_AUTHORIZATION_HEADER} from '../constants'
+import { inNativeAppBrowser } from '../withInNativeApp'
 
 let apolloClient = null
 
@@ -54,6 +55,25 @@ const hasSubscriptionOperation = ({ query: { definitions } }) =>
       kind === 'OperationDefinition' && operation === 'subscription'
   )
 
+class AppLink extends ApolloLink {
+  request (operation) {
+    return new Observable(observer => {
+      // Sends operation to be processed in app "worker"
+      window.postMessage(JSON.stringify({
+        type: 'graphql',
+        data: operation
+      }))
+
+      // Listens to response.
+      // This is not reliable at all, since it can colide with another call. Just a PoC for now
+      document.addEventListener('message', event => {
+        observer.next(JSON.parse(event.data))
+        observer.complete()
+      }, { once: true })
+    })
+  }
+}
+
 function create (initialState = {}, headers = {}) {
   const http = new HttpLink({
     uri: API_URL,
@@ -75,7 +95,7 @@ function create (initialState = {}, headers = {}) {
           timeout: 50000
         }
       }),
-      http
+      inNativeAppBrowser ? new AppLink() : http
     )
     : http
 

--- a/lib/apollo/withMe.js
+++ b/lib/apollo/withMe.js
@@ -1,6 +1,5 @@
 import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
-import { runInNativeAppBrowser } from '../withInNativeApp'
 
 export const meQuery = gql`
   query me {
@@ -20,25 +19,8 @@ export const meQuery = gql`
   }
 `
 
-let lastMe
-const notifyApp = me => {
-  if (me === lastMe) return
-
-  window.postMessage(JSON.stringify({
-    type: 'session',
-    data: me
-  }), '*')
-
-  lastMe = me
-}
-
 export default graphql(meQuery, {
-  props: ({ data }) => {
-    // Notify native app about session state
-    runInNativeAppBrowser(() => { notifyApp(data.me) })
-
-    return {
-      me: data.me
-    }
-  }
+  props: ({ data }) => ({
+    me: data.me
+  })
 })

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -9,6 +9,15 @@ export const runInNativeAppBrowser = inNativeAppBrowser
   ? callback => callback()
   : () => {}
 
+const nativeLog = (value) => {
+  window.postMessage(JSON.stringify({
+    type: 'log',
+    data: value
+  }), '*')
+}
+
+export const log = inNativeAppBrowser ? nativeLog : console.log
+
 const withInNativeApp = WrappedComponent => props => {
   return (
     <HttpHeaderContext.Consumer>


### PR DESCRIPTION
@tpreusse Proof of concept of the idea you proposed about resolving graphql queries app side.

**What this does**
- Undo special signin handling
- Prevent using `HTTPLink` in app (I would then refactor the nested ternary conditionals) 
- Implement `AppLink` (name might change) that instead of resolving the request, it sends it to app
- Listens for response

It's the first time I implement an ApolloLink, so maybe you have enhancements  we can do in mind 😄 

I don't know yet which would be the best approach of correctly bind the message posting and response. Maybe you have thought about it.

Related to https://github.com/orbiting/app/pull/39