### PR TITLE
fix comment submit not possible in IE11

### DIFF
--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -1,6 +1,7 @@
 import 'core-js/fn/array/from'
 import 'core-js/fn/array/find'
 import 'core-js/fn/array/find-index'
+import 'core-js/fn/object/assign'
 import 'core-js/fn/string/starts-with'
 import 'core-js/es6/set'
 import 'core-js/es6/map'


### PR DESCRIPTION
This Object.assign() is causing the issue:
<img width="1333" alt="screen shot 2018-06-11 at 16 25 27" src="https://user-images.githubusercontent.com/23520051/41240016-cbfd0702-6d99-11e8-9418-be8735664e90.png">

With the polyfill, it finally works:
<img width="1164" alt="screen shot 2018-06-11 at 17 03 17" src="https://user-images.githubusercontent.com/23520051/41240049-dfc0e1d2-6d99-11e8-8f6c-90c92f73cfdd.png">
