### PR TITLE
Fix feed sticky headers on app

### DIFF
--- a/components/constants.js
+++ b/components/constants.js
@@ -1,5 +1,7 @@
-export const HEADER_HEIGHT = 70
-export const HEADER_HEIGHT_MOBILE = 45
+import { inNativeAppBrowser } from '../lib/withInNativeApp'
+
+export const HEADER_HEIGHT = inNativeAppBrowser ? 0 : 70
+export const HEADER_HEIGHT_MOBILE = inNativeAppBrowser ? 0 : 45
 export const TESTIMONIAL_IMAGE_SIZE = 238
 export const CONTENT_PADDING = 60
 


### PR DESCRIPTION
Native app hides web nav in replacement for a built-in one. Because of that, sticky headers were looking like the following image instead of going right to the top of the screen

![simulator screen shot - iphone x - 2018-06-19 at 09 57 12](https://user-images.githubusercontent.com/5600341/41584277-2e08101e-73a7-11e8-9c20-852222820c16.png)
