### PR TITLE
Fix SSR

### DIFF
--- a/components/Feed/index.js
+++ b/components/Feed/index.js
@@ -58,7 +58,7 @@ const getDocuments = gql`
       id
     }
     documents(feed: true, first: 50, after: $cursor) {
-      totalCount 
+      totalCount
       pageInfo {
         endCursor
         hasNextPage

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -10,7 +10,6 @@ function getComponentDisplayName (Component) {
 
 // save headers in a global when receiving them in the browser
 let savedHeaders
-export const HttpHeaderContext = React.createContext({})
 
 export default ComposedComponent => {
   class WithData extends React.Component {
@@ -48,9 +47,7 @@ export default ComposedComponent => {
           // Run all GraphQL queries
           await getDataFromTree(
             <ApolloProvider client={apollo}>
-              <HttpHeaderContext.Provider value={headers}>
-                <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} headers={headers} />
-              </HttpHeaderContext.Provider>
+              <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} />
             </ApolloProvider>
           )
         } catch (error) {
@@ -83,13 +80,14 @@ export default ComposedComponent => {
       }
     }
 
+    getChildContext () {
+      return { headers: this.props.headers || savedHeaders }
+    }
+
     render () {
-      const headers = this.props.headers || savedHeaders
       return (
         <ApolloProvider client={this.apollo}>
-          <HttpHeaderContext.Provider value={headers}>
-            <ComposedComponent {...this.props} />
-          </HttpHeaderContext.Provider>
+          <ComposedComponent {...this.props} />
         </ApolloProvider>
       )
     }
@@ -98,8 +96,13 @@ export default ComposedComponent => {
   WithData.displayName = `WithData(${getComponentDisplayName(
     ComposedComponent
   )})`
+
   WithData.propTypes = {
     serverState: PropTypes.object.isRequired
+  }
+
+  WithData.childContextTypes = {
+    headers: PropTypes.object
   }
 
   return WithData

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { HttpHeaderContext } from './apollo/withData'
+import PropTypes from 'prop-types'
 
 export const matchUserAgent = value => value && value.match(/RepublikApp/)
 
@@ -7,7 +7,12 @@ export const inNativeAppBrowser = process.browser && matchUserAgent(navigator.us
 
 export const runInNativeAppBrowser = inNativeAppBrowser
   ? callback => callback()
-  : () => {}
+  : () => {
+    window.postMessage(JSON.stringify({
+      type: 'log',
+      data: 'Oops'
+    }), '*')
+  }
 
 const nativeLog = (value) => {
   window.postMessage(JSON.stringify({
@@ -18,12 +23,25 @@ const nativeLog = (value) => {
 
 export const log = inNativeAppBrowser ? nativeLog : console.log
 
-const withInNativeApp = WrappedComponent => props => {
-  return (
-    <HttpHeaderContext.Consumer>
-      {headers => <WrappedComponent inNativeApp={matchUserAgent(headers.userAgent)} {...props} />}
-    </HttpHeaderContext.Consumer>
-  )
+const withInNativeApp = WrappedComponent => {
+  class WithInNativeApp extends React.Component {
+    render () {
+      const headers = this.context.headers || {}
+
+      return (
+        <WrappedComponent
+          inNativeApp={matchUserAgent(headers.userAgent)}
+          {...this.props}
+        />
+      )
+    }
+  }
+
+  WithInNativeApp.contextTypes = {
+    headers: PropTypes.object
+  }
+
+  return WithInNativeApp
 }
 
 export default withInNativeApp

--- a/pages/feed.js
+++ b/pages/feed.js
@@ -9,14 +9,14 @@ import withT from '../lib/withT'
 
 import { CDN_FRONTEND_BASE_URL } from '../lib/constants'
 
-const FeedPage = ({ url, me, t }) => {
+const FeedPage = ({ url, me, t, headers }) => {
   const meta = {
     title: t('pages/feed/title'),
     image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`
   }
 
   return (
-    <Frame raw url={url} meta={meta}>
+    <Frame raw url={url} meta={meta} headers={headers}>
       <Feed />
     </Frame>
   )

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -10,7 +10,15 @@ import withMembership from '../components/Auth/withMembership'
 import { Router } from '../lib/routes'
 
 class SigninPage extends Component {
+  componentDidMount () {
+    this.redirectUser()
+  }
+
   componentDidUpdate () {
+    this.redirectUser()
+  }
+
+  redirectUser () {
     const { isMember, me } = this.props
     if (isMember) {
       Router.pushRoute('index')


### PR DESCRIPTION
@tpreusse I found out that SSR was broken in `app` branch. This is _possibly_ the cause of the misbehaviors we observed in the past about server request. When I was requesting the feed page directly, the query was not being resolved server side, but client side. I went back into git history and I saw that this was introduced here: https://github.com/orbiting/republik-frontend/pull/113/commits/b354549afb595d0859ff67bbcc2c340ccfa0dddf 

I tried several fixes but all seemed to conclude that the new React context API was not behaving well when SSR. This PR implements the very same thing but using the last context API, which I confirmed it works.

I can show you this in practice tomorrow and discuss about it