### PR TITLE
fix(RelatedEpisodes): episode image should take precedence over a document's meta image

### DIFF
--- a/components/Article/RelatedEpisodes.js
+++ b/components/Article/RelatedEpisodes.js
@@ -24,7 +24,7 @@ const Tile = ({ t, episode, index, LinkComponent = DefaultLink }) => {
   const label = episode && episode.label
   const meta = episode && episode.document && episode.document.meta
   const route = meta && meta.path
-  const image = (meta && meta.image) || (episode && episode.image)
+  const image = (episode && episode.image) || (meta && meta.image)
   const align = image ? {align: 'top'} : {}
 
   if (route) {


### PR DESCRIPTION
Even when all episode images are uploaded in the same dimensions on the master, the image uploaded in the master's meta section may have a different dimension and currently shows up instead of the desired image:

<img width="618" alt="screen shot 2018-06-20 at 12 41 34" src="https://user-images.githubusercontent.com/23520051/41653726-4b1bc6e2-7487-11e8-86e0-8aef57d555f6.png">
