### PR TITLE
fix: Remove line clamp in profile comment teasers

### DIFF
--- a/components/Profile/Comments.js
+++ b/components/Profile/Comments.js
@@ -27,7 +27,6 @@ const Comments = ({ t, comments }) => {
             content={comment.content}
             timeago={timeagoFromNow(t, comment.createdAt)}
             commentUrl={discussion.documentPath && `${discussion.documentPath}?focus=${comment.id}`}
-            lineClamp={3}
             t={t}
           />
         )


### PR DESCRIPTION
Line clamping as [provided by styleguide](https://github.com/orbiting/styleguide/blob/master/src/components/CommentTeaser/CommentTeaser.js#L28-L33) appears not to be working for WebKit browsers as it does hide entire content.

Until decided whether to use comment `preview.string` or find cross-browser solution, line clamping in profile comments is disabled.