### PR TITLE
add event tracking for share buttons

### DIFF
--- a/components/ActionBar/ShareOverlay.js
+++ b/components/ActionBar/ShareOverlay.js
@@ -32,6 +32,15 @@ const styles = {
   })
 }
 
+const onShareClick = (name, value) => {
+  window._paq.push([
+    'trackEvent',
+    'share',
+    name,
+    value
+  ])
+}
+
 const ShareOverlay = ({
   t,
   title,
@@ -101,7 +110,10 @@ const ShareOverlay = ({
                 key={props.icon}
                 fill={fill}
                 size={32}
-                onClick={onClose}
+                onClick={() => {
+                  onShareClick(props.icon, url)
+                  onClose && onClose()
+                }}
                 stacked
                 {...props}
               >

--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -16,6 +16,15 @@ const styles = {
   })
 }
 
+const onActionBarClick = (name, value) => {
+  window._paq.push([
+    'trackEvent',
+    'ActionBar',
+    name,
+    value
+  ])
+}
+
 class ActionBar extends Component {
   constructor (props) {
     super(props)
@@ -60,6 +69,7 @@ class ActionBar extends Component {
           }
           e.preventDefault()
           this.toggleShare()
+          onActionBarClick('share', url)
         },
         title: t('article/actionbar/share')
       },


### PR DESCRIPTION
This will give us an idea on how often the share button is clicked in the action bar, and how often the individual share buttons are clicked on the share overlay.