### PR TITLE
fix(StickySection): undesired width jump on initial load on mobile

### DIFF
--- a/components/Feed/StickySection.js
+++ b/components/Feed/StickySection.js
@@ -92,6 +92,7 @@ class StickySection extends Component {
   render () {
     const { children, label } = this.props
     const { sticky, width, isMedium } = this.state
+
     return (
       <section ref={this.setSectionRef}>
         <div {...style.header}>
@@ -100,7 +101,7 @@ class StickySection extends Component {
             {...(sticky && style.sticky)}
             style={{
               position: sticky ? 'fixed' : 'relative',
-              width: isMedium ? width : SIDEBAR_WIDTH
+              width: isMedium ? width : (width ? SIDEBAR_WIDTH : '100%')
             }}>
             {
               label


### PR DESCRIPTION
This initial width jump on mobile has bothered me for a while:
![screen recording](https://user-images.githubusercontent.com/23520051/42815923-35155f46-89c9-11e8-862f-a2819e70309d.gif)

This is a proposal for a fix. Looks good to me on desktop and mobile, but let me know if you have a better idea.
