### PR TITLE
fix(Feed): Fetch up to first 100 documents

### DIFF
--- a/components/Feed/Format.js
+++ b/components/Feed/Format.js
@@ -12,7 +12,7 @@ import { WithoutMembership } from '../Auth/withMembership'
 
 const getFeedDocuments = gql`
 query getFeedDocuments($formatId: String!) {
-  documents(format: $formatId) {
+  documents(format: $formatId, first: 100) {
     totalCount
     nodes {
       meta {


### PR DESCRIPTION
This Pull Request enables a format's feed to fetch up to a 100 documents.

It tackles a problem which [only listed first 40 documents linked to a format on a formats page](https://republik.ch/format/nahr). As of Aug 8, 2018, a `documents` query returns 40 documents per default.

This quick fix will obviously run into it's limitation if there is more than a 100 documents to list on a formats fee. Since it helps mitigating a currently problem, it seems fair enough.

Long run would require some form of pagination, infinite scrolling.

Also: 🍌 