### PR TITLE
Forward Cookies returned by GraphQL API when SSR

### DIFF
--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -49,7 +49,20 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   }
 })
 
-function create (initialState = {}, headers = {}) {
+const withResponseIntercepter = ({ onResponse }) => new ApolloLink((operation, forward) => {
+  return forward(operation).map(result => {
+    const context = operation.getContext()
+    if (context.response) {
+      onResponse(context.response)
+    }
+    return result
+  })
+})
+
+const createLink = (headers = {}, onResponse = () => {}) => {
+  if (inNativeAppBrowser) {
+    return createAppWorkerLink()
+  }
   const http = new HttpLink({
     uri: process.browser ? API_URL : SSR_API_URL,
     credentials: 'include',
@@ -59,22 +72,30 @@ function create (initialState = {}, headers = {}) {
       Authorization: API_AUTHORIZATION_HEADER
     }
   })
+  if (process.browser) {
+    return ApolloLink.split(
+      hasSubscriptionOperation,
+      new WebSocketLink({
+        uri: API_WS_URL,
+        options: {
+          reconnect: true,
+          timeout: 50000
+        }
+      }),
+      http
+    )
+  }
+  // Link used for SSR
+  return ApolloLink.from([
+    withResponseIntercepter({
+      onResponse
+    }),
+    http
+  ])
+}
 
-  const link = process.browser
-    ? inNativeAppBrowser
-      ? createAppWorkerLink()
-      : ApolloLink.split(
-        hasSubscriptionOperation,
-        new WebSocketLink({
-          uri: API_WS_URL,
-          options: {
-            reconnect: true,
-            timeout: 50000
-          }
-        }),
-        http
-      )
-    : http
+function create (initialState = {}, headers = {}, onResponse) {
+  const link = createLink(headers, onResponse)
 
   return new ApolloClient({
     connectToDevTools: process.browser,
@@ -89,16 +110,16 @@ function create (initialState = {}, headers = {}) {
 
 let globalApolloClient = null
 
-export default function initApollo (initialState, headers) {
+export default function initApollo (initialState, headers, onResponse) {
   // Make sure to create a new client for every server-side request so that data
   // isn't shared between connections (which would be bad)
   if (!process.browser) {
-    return create(initialState, headers)
+    return create(initialState, headers, onResponse)
   }
 
   // Reuse client on the client-side
   if (!globalApolloClient) {
-    globalApolloClient = create(initialState, headers)
+    globalApolloClient = create(initialState, headers, onResponse)
 
     // Post current user data to native app
     const data = globalApolloClient.readQuery({ query: meQuery })

--- a/lib/apollo/initApollo.js
+++ b/lib/apollo/initApollo.js
@@ -49,7 +49,7 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
   }
 })
 
-const withResponseIntercepter = ({ onResponse }) => new ApolloLink((operation, forward) => {
+const withResponseInterceptor = ({ onResponse }) => new ApolloLink((operation, forward) => {
   return forward(operation).map(result => {
     const context = operation.getContext()
     if (context.response) {
@@ -87,7 +87,7 @@ const createLink = (headers = {}, onResponse = () => {}) => {
   }
   // Link used for SSR
   return ApolloLink.from([
-    withResponseIntercepter({
+    withResponseInterceptor({
       onResponse
     }),
     http

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -35,8 +35,15 @@ export default ComposedComponent => {
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
       if (!process.browser) {
-        // Server-side we initialize apollo with all headers (including cookie)
-        const apollo = initApollo(undefined, ctx.req.headers)
+        // Server-side we initialize apollo
+        // - with all headers, including cookie
+        // - and forward cookies back retrieved from backend responses
+        const apollo = initApollo(undefined, ctx.req.headers, response => {
+          const cookie = response.headers.get('Set-Cookie')
+          if (cookie) {
+            ctx.res.set('Set-Cookie', cookie)
+          }
+        })
         // Provide the `url` prop data in case a GraphQL query uses it
         const url = {
           query: ctx.query,

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -38,9 +38,11 @@ export default ComposedComponent => {
         // Server-side we initialize a fresh apollo with all headers (including cookie)
         // and forward cookies from backend responses to the user
         const apollo = initApollo(undefined, ctx.req.headers, response => {
-          const cookie = response.headers.get('Set-Cookie')
-          if (cookie) {
-            ctx.res.set('Set-Cookie', cookie)
+          // headers.raw() is a node-fetch specific API and apparently the only way to get multiple cookies
+          // https://github.com/bitinn/node-fetch/issues/251
+          const cookies = response.headers.raw()['set-cookie']
+          if (cookies) {
+            ctx.res.set('Set-Cookie', cookies)
           }
         })
         // Provide the `url` prop data in case a GraphQL query uses it

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -35,9 +35,8 @@ export default ComposedComponent => {
       // Run all GraphQL queries in the component tree
       // and extract the resulting data
       if (!process.browser) {
-        // Server-side we initialize apollo
-        // - with all headers, including cookie
-        // - and forward cookies back retrieved from backend responses
+        // Server-side we initialize a fresh apollo with all headers (including cookie)
+        // and forward cookies from backend responses to the user
         const apollo = initApollo(undefined, ctx.req.headers, response => {
           const cookie = response.headers.get('Set-Cookie')
           if (cookie) {


### PR DESCRIPTION
A interceptor link to forward cookies from GraphQL responses from the backend.

This allows the cookie to propagate to WKWebView in the app. And roll the cookie on the web without a client side request to the API (e.g. only clicking on Newsletter links and never interaction on the site).