### PR TITLE
refactor headers context

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -17,7 +17,7 @@ import Discussion from '../Discussion/Discussion'
 import DiscussionIconLink from '../Discussion/IconLink'
 import Feed from '../Feed/Format'
 import StatusError from '../StatusError'
-import SSRCachingBoundary, { webpCacheKey } from '../SSRCachingBoundary'
+import SSRCachingBoundary from '../SSRCachingBoundary'
 import withMembership from '../Auth/withMembership'
 import ArticleGallery from './ArticleGallery'
 
@@ -440,7 +440,7 @@ class ArticlePage extends Component {
                   article={article}
                   onClose={this.togglePdf} />}
               <ArticleGallery article={article}>
-                <SSRCachingBoundary cacheKey={webpCacheKey(this.props.headers, article.id)}>
+                <SSRCachingBoundary cacheKey={article.id}>
                   {() => renderMdast({
                     ...article.content,
                     format: meta.format

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -12,7 +12,7 @@ import withT from '../../lib/withT'
 import Loader from '../Loader'
 import Frame from '../Frame'
 import Link from '../Link/Href'
-import SSRCachingBoundary, { webpCacheKey } from '../SSRCachingBoundary'
+import SSRCachingBoundary from '../SSRCachingBoundary'
 
 import { renderMdast } from 'mdast-react-render'
 
@@ -95,7 +95,7 @@ class Front extends Component {
                 <InlineSpinner size={28} />
               </div>
             }>
-            <SSRCachingBoundary key='content' cacheKey={webpCacheKey(this.props.headers, front.id)}>
+            <SSRCachingBoundary key='content' cacheKey={front.id}>
               {() => renderMdast({
                 type: 'root',
                 children: front.children.nodes.map(v => v.body)

--- a/components/SSRCachingBoundary/index.js
+++ b/components/SSRCachingBoundary/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import withHeaders from '../../lib/withHeaders'
 
 let getHtml
 if (!process.browser) {
@@ -19,17 +20,21 @@ if (!process.browser) {
   }
 }
 
-export const webpCacheKey = (headers = {}, baseKey) => {
-  return headers.accept && headers.accept.indexOf('image/webp') !== -1
-  ? `${baseKey}webp`
-  : baseKey
+const webpCacheKey = (headers, baseKey) => {
+  if (!headers) {
+    console.warn('[SSRCache] headers missing!')
+  }
+  return headers && headers.accept && headers.accept.indexOf('image/webp') !== -1
+    ? `${baseKey}webp`
+    : baseKey
 }
 
-const SSRCachingBoundary = ({cacheKey, children}) => getHtml
+const SSRCachingBoundary = withHeaders(({cacheKey, headers, children}) => getHtml
   ? <div dangerouslySetInnerHTML={{
-    __html: getHtml(cacheKey, children)
+    __html: getHtml(webpCacheKey(headers, cacheKey), children)
   }} />
   : <div>{children()}</div>
+)
 
 SSRCachingBoundary.propTypes = {
   cacheKey: PropTypes.string.isRequired,

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -3,14 +3,12 @@ import PropTypes from 'prop-types'
 import { ApolloProvider, getDataFromTree } from 'react-apollo'
 import initApollo from './initApollo'
 import { Router } from '../../lib/routes'
+import { HeadersProvider } from '../../lib/withHeaders'
 
 // Gets the display name of a JSX component for dev tools
 function getComponentDisplayName (Component) {
   return Component.displayName || Component.name || 'Unknown'
 }
-
-// save headers in a global when receiving them in the browser
-let savedHeaders
 
 export default ComposedComponent => {
   class WithData extends React.Component {
@@ -56,7 +54,9 @@ export default ComposedComponent => {
           // Run all GraphQL queries
           await getDataFromTree(
             <ApolloProvider client={apollo}>
-              <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} />
+              <HeadersProvider headers={headers}>
+                <ComposedComponent url={url} {...composedInitialProps} serverContext={ctx} />
+              </HeadersProvider>
             </ApolloProvider>
           )
         } catch (error) {
@@ -82,11 +82,6 @@ export default ComposedComponent => {
         this.props.serverState,
         this.props.headers
       )
-      // write headers to a global when the first page renders in the client
-      // - browser only to ensure that it isn't shared between connections (which would be bad)
-      if (process.browser && this.props.headers) {
-        savedHeaders = this.props.headers
-      }
     }
 
     componentDidMount () {
@@ -95,14 +90,12 @@ export default ComposedComponent => {
       window.Router = Router
     }
 
-    getChildContext () {
-      return { headers: this.props.headers || savedHeaders }
-    }
-
     render () {
       return (
         <ApolloProvider client={this.apollo}>
-          <ComposedComponent {...this.props} />
+          <HeadersProvider headers={this.props.headers}>
+            <ComposedComponent {...this.props} />
+          </HeadersProvider>
         </ApolloProvider>
       )
     }
@@ -114,10 +107,6 @@ export default ComposedComponent => {
 
   WithData.propTypes = {
     serverState: PropTypes.object.isRequired
-  }
-
-  WithData.childContextTypes = {
-    headers: PropTypes.object
   }
 
   return WithData

--- a/lib/withHeaders.js
+++ b/lib/withHeaders.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+// save headers in a global when receiving them in the browser
+let savedHeaders
+
+export class HeadersProvider extends Component {
+  constructor (props, ...rest) {
+    super(props, ...rest)
+    // write headers to a global when the first page renders in the client
+    // - browser only to ensure that it isn't shared between connections (which would be bad)
+    if (process.browser && props.headers) {
+      savedHeaders = props.headers
+    }
+  }
+  getChildContext () {
+    return {
+      headers: this.props.headers || savedHeaders
+    }
+  }
+  render () {
+    return this.props.children
+  }
+}
+
+HeadersProvider.childContextTypes = {
+  headers: PropTypes.object
+}
+
+const withHeaders = WrappedComponent => {
+  const WithHeaders = (props, context) => (
+    <WrappedComponent {...props} headers={context.headers} />
+  )
+
+  WithHeaders.contextTypes = {
+    headers: PropTypes.object
+  }
+
+  return WithHeaders
+}
+
+export default withHeaders

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import withHeaders from './withHeaders'
 
 export const matchUserAgent = value => value && !!value.match(/RepublikApp/)
 
@@ -50,24 +51,18 @@ const nativeLog = (value) => {
 export const log = inNativeAppBrowser ? nativeLog : console.log
 
 const withInNativeApp = WrappedComponent => {
-  class WithInNativeApp extends React.Component {
-    render () {
-      const headers = this.context.headers || {}
-
-      return (
-        <WrappedComponent
-          inNativeApp={matchUserAgent(headers.userAgent) || inNativeAppBrowser}
-          {...this.props}
-        />
-      )
-    }
-  }
+  const WithInNativeApp = ({ headers, ...props }) => (
+    <WrappedComponent
+      inNativeApp={matchUserAgent(headers.userAgent) || inNativeAppBrowser}
+      {...props}
+    />
+  )
 
   WithInNativeApp.contextTypes = {
     headers: PropTypes.object
   }
 
-  return WithInNativeApp
+  return withHeaders(WithInNativeApp)
 }
 
 export default withInNativeApp

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,10 +16,10 @@ import {
 
 const PLEDGE_CROWDFUNDING_NAME = SALES_UP || CROWDFUNDING_NAME
 
-const IndexPage = ({ url, t, isMember, headers }) => {
+const IndexPage = ({ url, t, isMember }) => {
   if (isMember) {
     // does it's own meta
-    return <Front url={url} headers={headers} />
+    return <Front url={url} />
   }
   const meta = {
     pageTitle: t('pages/index/pageTitle'),


### PR DESCRIPTION
During the app development header forwarding while SSR rendering broke. The cause is:
https://github.com/orbiting/republik-frontend/pull/113/files#diff-48f0b1cfd3e6107afd6863bf94c306c2L44

This was accidentally removed during back and forth between switching to the new React v16.4 context, keeping it as is and introducing headers to the context for the app only.

To avoid this going forward I've refactored everything to use a headers HOC which can be implemented in various way (currently legacy context API). This is now used for app and SSR caching.