### PR TITLE
handle 404s and redirects properly when not logged in

### DIFF
--- a/components/Auth/withMembership.js
+++ b/components/Auth/withMembership.js
@@ -9,7 +9,7 @@ import { Interaction, linkRule } from '@project-r/styleguide'
 
 import withAuthorization, { PageCenter } from './withAuthorization'
 
-const UnauthorizedPage = withT(({t, me, url, roles = []}) => (
+export const UnauthorizedPage = withT(({t, me, url, roles = []}) => (
   <Frame url={url} raw>
     <PageCenter>
       {!me ? (

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -44,6 +44,6 @@ routes
   .add('format', '/format/:slug', 'article')
   .add('dossier', '/dossier/:slug', 'article')
   .add('article', '/:year(\\d{4})/:month(\\d{2})/:day(\\d{2})/:slug/:suffix(diskussion)?')
-  // .add('front', '/:slug')
+  .add('front', '/:slug')
 
 module.exports = routes

--- a/pages/front.js
+++ b/pages/front.js
@@ -1,9 +1,31 @@
 import { compose } from 'react-apollo'
+import Frame from '../components/Frame'
 import Front from '../components/Front'
 import withData from '../lib/apollo/withData'
-import { enforceMembership } from '../components/Auth/withMembership'
+import withMembership, { UnauthorizedPage } from '../components/Auth/withMembership'
+import StatusError from '../components/StatusError'
+
+const KNOWN_PATHS = ['/feuilleton']
+
+const FrontPage = (props) => {
+  if (props.isMember) {
+    return <Front {...props} />
+  }
+  const { url } = props
+  if (KNOWN_PATHS.indexOf(url.asPath.split('?')[0]) !== -1) {
+    return <UnauthorizedPage {...props} />
+  }
+  return (
+    <Frame raw url={url}>
+      <StatusError
+        url={url}
+        statusCode={404}
+        serverContext={props.serverContext} />
+    </Frame>
+  )
+}
 
 export default compose(
   withData,
-  enforceMembership
-)(Front)
+  withMembership
+)(FrontPage)


### PR DESCRIPTION
We accidentally broke redirects and 404s (single path segment ones) with the front route for users that are not signed in. I've added extra logic to handle those cases and at the same time show an unauthorised page for publicly know front urls.

404:
<img width="1386" alt="screen shot 2018-08-15 at 17 17 41" src="https://user-images.githubusercontent.com/410211/44156250-c6b0374e-a0af-11e8-83ed-885c71109728.png">

Unauthorised:
<img width="1386" alt="screen shot 2018-08-15 at 17 17 39" src="https://user-images.githubusercontent.com/410211/44156699-d582f206-a0b0-11e8-9910-52753128b9c8.png">
