### PR TITLE
always show back button on iOS when not on nav bar page

### DIFF
--- a/components/Frame/LoadingBar.js
+++ b/components/Frame/LoadingBar.js
@@ -28,9 +28,14 @@ class LoadingBar extends Component {
     }
   }
   componentDidMount () {
-    Router.onRouteChangeStart = () => {
+    Router.onRouteChangeStart = (url) => {
       clearTimeout(this.timeout)
       this.setState({ loading: true, progress: 0.02 })
+
+      const { onRouteChangeStart } = this.props
+      if (onRouteChangeStart) {
+        onRouteChangeStart(url)
+      }
     }
     Router.onRouteChangeComplete = url => {
       clearTimeout(this.timeout)


### PR DESCRIPTION
This get's ride of back button flickers and the `undefined` state.

The default feed was previously set in the native implementation.