### PR TITLE
new design for Rubriken

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -99,6 +99,7 @@ const getDocument = gql`
         template
         path
         title
+        kind
         description
         image
         facebookDescription
@@ -360,7 +361,8 @@ class ArticlePage extends Component {
         ? meta
         : meta.format && meta.format.meta
     )
-    const formatColor = formatMeta && formatMeta.color
+    const formatColor = formatMeta && (formatMeta.color || colors[formatMeta.kind])
+    console.log('ffff', formatMeta)
 
     const audioSource = showAudioPlayer ? meta && meta.audioSource : null
 

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -362,7 +362,6 @@ class ArticlePage extends Component {
         : meta.format && meta.format.meta
     )
     const formatColor = formatMeta && (formatMeta.color || colors[formatMeta.kind])
-    console.log('ffff', formatMeta)
 
     const audioSource = showAudioPlayer ? meta && meta.audioSource : null
 

--- a/components/Feed/Format.js
+++ b/components/Feed/Format.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 
-import { Center, TeaserFeed, Interaction, Loader } from '@project-r/styleguide'
+import { Center, TeaserFeed, Interaction, Loader, colors } from '@project-r/styleguide'
 import Link from '../Link/Href'
 
 import withT from '../../lib/withT'
@@ -54,6 +54,7 @@ const Feed = ({ t, data: { loading, error, documents } }) => (
             documents.nodes.map(doc => (
               <TeaserFeed
                 {...doc.meta}
+                formatColor={colors.text}
                 Link={Link}
                 key={doc.meta.path}
               />

--- a/components/Feed/Format.js
+++ b/components/Feed/Format.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 
-import { Center, TeaserFeed, Interaction, Loader, colors } from '@project-r/styleguide'
+import { Center, TeaserFeed, Interaction, Loader } from '@project-r/styleguide'
 import Link from '../Link/Href'
 
 import withT from '../../lib/withT'
@@ -54,7 +54,6 @@ const Feed = ({ t, data: { loading, error, documents } }) => (
             documents.nodes.map(doc => (
               <TeaserFeed
                 {...doc.meta}
-                formatColor={colors.text}
                 Link={Link}
                 key={doc.meta.path}
               />

--- a/components/Formats/FormatTag.js
+++ b/components/Formats/FormatTag.js
@@ -1,0 +1,60 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+import Link from '../Link/Href'
+
+import {
+  fontStyles,
+  mediaQueries
+} from '@project-r/styleguide'
+
+const styles = {
+  container: css({
+    ...fontStyles.sansSerifMedium16,
+    display: 'inline-block',
+    padding: 0,
+    cursor: 'pointer',
+    margin: '0 10px 5px 0',
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifMedium19,
+      margin: '0 20px 5px 0'
+    }
+  }),
+  count: css({
+    ...fontStyles.sansSerifMedium12,
+    color: '#b4b4b4',
+    marginLeft: 5,
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifMedium14
+    }
+  }),
+  link: css({
+    textDecoration: 'none'
+  })
+}
+
+class FormatTag extends Component {
+  render () {
+    const { label, count, color, path } = this.props
+    if (!count) return null
+    return (
+      <div {...styles.container}>
+        <Link href={path} passHref>
+          <a {...styles.link} href={path} style={{ color }}>
+            {label}
+            <span {...styles.count}>{count}</span>
+          </a>
+        </Link>
+      </div>
+    )
+  }
+}
+
+FormatTag.propTypes = {
+  label: PropTypes.string.isRequired,
+  count: PropTypes.number.isRequired,
+  color: PropTypes.string,
+  path: PropTypes.string
+}
+
+export default FormatTag

--- a/components/Formats/GroupedFormats.js
+++ b/components/Formats/GroupedFormats.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import { css } from 'glamor'
-import { keys, nest, values } from 'd3-collection'
+import { nest } from 'd3-collection'
 import gql from 'graphql-tag'
 import Loader from '../../components/Loader'
 import withT from '../../lib/withT'
@@ -73,27 +73,26 @@ class GroupedFormats extends Component {
         render={() => {
           const sections = nest()
             .key(d => d['meta']['kind'])
-            .object(documents.nodes)
+            .entries(documents.nodes)
+            .filter(d => d.values.length)
 
           return (
             <Fragment>
-              {keys(sections).map(sectionKey => <Fragment>
-                {sections[sectionKey].length > 0 && (
-                  <section {...styles.section} key={sectionKey}>
-                    <h2 {...styles.h2}>
-                      {t(`formats/title/${sectionKey}`)}
-                    </h2>
-                    {values(sections[sectionKey]).map(doc => (
-                      <FormatTag
-                        color={getColorFromMeta(doc.meta)}
-                        path={doc.meta.path}
-                        label={doc.meta.title}
-                        count={doc.linkedDocuments.totalCount}
-                        key={doc.meta.path} />
-                    ))}
-                  </section>)
-                }
-              </Fragment>)}
+              {sections.map(({key, values}) => (
+                <section {...styles.section} key={key}>
+                  <h2 {...styles.h2}>
+                    {t(`formats/title/${key}`)}
+                  </h2>
+                  {values.map(doc => (
+                    <FormatTag
+                      color={getColorFromMeta(doc.meta)}
+                      path={doc.meta.path}
+                      label={doc.meta.title}
+                      count={doc.linkedDocuments.totalCount}
+                      key={doc.meta.path} />
+                  ))}
+                </section>
+              ))}
             </Fragment>
           )
         }}

--- a/components/Formats/GroupedFormats.js
+++ b/components/Formats/GroupedFormats.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
+import { ascending } from 'd3-array'
 import { css } from 'glamor'
 import { nest } from 'd3-collection'
 import gql from 'graphql-tag'
@@ -73,6 +74,7 @@ class GroupedFormats extends Component {
         render={() => {
           const sections = nest()
             .key(d => d['meta']['kind'])
+            .sortValues((a, b) => ascending(a.meta.title, b.meta.title))
             .entries(documents.nodes)
             .filter(d => d.values.length)
 

--- a/components/Formats/GroupedFormats.js
+++ b/components/Formats/GroupedFormats.js
@@ -57,6 +57,13 @@ const getFormats = gql`
   }
 `
 
+const sectionOrder = [
+  'editorial',
+  'feuilleton',
+  'scribble',
+  'meta'
+]
+
 const getColorFromMeta = meta => {
   const formatMeta = meta.format && meta.format.meta
   const color = meta.color || (formatMeta && formatMeta.color)
@@ -74,6 +81,7 @@ class GroupedFormats extends Component {
         render={() => {
           const sections = nest()
             .key(d => d['meta']['kind'])
+            .sortKeys((a, b) => ascending(sectionOrder.indexOf(a), sectionOrder.indexOf(b)))
             .sortValues((a, b) => ascending(a.meta.title, b.meta.title))
             .entries(documents.nodes)
             .filter(d => d.values.length)

--- a/components/Formats/GroupedFormats.js
+++ b/components/Formats/GroupedFormats.js
@@ -1,0 +1,105 @@
+import React, { Component, Fragment } from 'react'
+import { graphql, compose } from 'react-apollo'
+import { css } from 'glamor'
+import { keys, nest, values } from 'd3-collection'
+import gql from 'graphql-tag'
+import Loader from '../../components/Loader'
+import withT from '../../lib/withT'
+
+import FormatTag from './FormatTag'
+
+import {
+  colors,
+  fontStyles,
+  mediaQueries
+} from '@project-r/styleguide'
+
+const styles = {
+  h2: css({
+    ...fontStyles.sansSerifRegular13,
+    color: '#979797',
+    margin: '0 0 15px 0',
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifRegular16,
+      margin: '12px 0 15px 0'
+    }
+  }),
+  section: css({
+    marginBottom: '25px',
+    [mediaQueries.mUp]: {
+      marginBottom: '30px',
+      '& + &': {
+        borderTop: `1px solid ${colors.divider}`
+      }
+    }
+  })
+}
+
+const getFormats = gql`
+  query getFormats {
+    documents(template: "format", feed: true) {
+      nodes {
+        meta {
+          template
+          kind
+          title
+          description
+          path
+          color
+          publishDate
+        }
+        linkedDocuments {
+          totalCount
+        }
+      }
+    }
+  }
+`
+
+const getColorFromMeta = meta => {
+  const formatMeta = meta.format && meta.format.meta
+  const color = meta.color || (formatMeta && formatMeta.color)
+  const kind = meta.kind || (formatMeta && formatMeta.kind)
+  return color || colors[kind]
+}
+
+class GroupedFormats extends Component {
+  render () {
+    const { data: { loading, error, documents }, t } = this.props
+    return (
+      <Loader
+        loading={loading}
+        error={error}
+        render={() => {
+          const sections = nest()
+            .key(d => d['meta']['kind'])
+            .object(documents.nodes)
+
+          return (
+            <Fragment>
+              {keys(sections).map(sectionKey => <Fragment>
+                {sections[sectionKey].length > 0 && (
+                  <section {...styles.section} key={sectionKey}>
+                    <h2 {...styles.h2}>
+                      {t(`formats/title/${sectionKey}`)}
+                    </h2>
+                    {values(sections[sectionKey]).map(doc => (
+                      <FormatTag
+                        color={getColorFromMeta(doc.meta)}
+                        path={doc.meta.path}
+                        label={doc.meta.title}
+                        count={doc.linkedDocuments.totalCount}
+                        key={doc.meta.path} />
+                    ))}
+                  </section>)
+                }
+              </Fragment>)}
+            </Fragment>
+          )
+        }}
+      />
+    )
+  }
+}
+
+export default compose(withT, graphql(getFormats))(GroupedFormats)

--- a/components/Formats/Latest.js
+++ b/components/Formats/Latest.js
@@ -104,7 +104,6 @@ const Latest = ({ t, data: { loading, error, documents }, loadMore, hasMore }) =
               {t('formats/loadMore')}
             </button>
           )}
-
         </Fragment>
       )
     }}

--- a/components/Formats/Latest.js
+++ b/components/Formats/Latest.js
@@ -1,0 +1,141 @@
+import React, { Fragment } from 'react'
+import { graphql, compose } from 'react-apollo'
+import { css } from 'glamor'
+import gql from 'graphql-tag'
+
+import { TeaserFeed, Loader, colors, fontStyles, linkRule, mediaQueries } from '@project-r/styleguide'
+import Link from '../Link/Href'
+
+import withT from '../../lib/withT'
+
+const styles = {
+  container: css({
+    paddingTop: 0
+  }),
+  results: css({
+    paddingTop: 60
+  }),
+  countPreloaded: css({
+    paddingBottom: '15px',
+    ...fontStyles.sansSerifRegular16,
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifRegular21
+    }
+  }),
+  countLoaded: css({
+    borderTop: `1px solid ${colors.text}`,
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: '15px 0',
+    textAlign: 'left',
+    ...fontStyles.sansSerifRegular16,
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifRegular21
+    }
+  }),
+  button: css({
+    ...fontStyles.sansSerifRegular21,
+    outline: 'none',
+    WebkitAppearance: 'none',
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    padding: 0,
+    margin: '0 auto 0',
+    display: 'block'
+  })
+}
+
+const getFeedDocuments = gql`
+query getFeedDocuments($cursor: String) {
+  documents(feed: true, hasFormat: true, first: 10, after: $cursor) {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    nodes {
+      meta {
+        credits
+        title
+        description
+        publishDate
+        path
+        template
+        format {
+          meta {
+            path
+            title
+            color
+            kind
+          }
+        }
+      }
+    }
+  }
+}
+`
+
+const Latest = ({ t, data: { loading, error, documents }, loadMore, hasMore }) => (
+  <Loader
+    loading={loading}
+    error={error}
+    render={() => {
+      const { pageInfo } = documents
+
+      return (
+        <Fragment>
+          {documents &&
+            documents.nodes
+              .map(doc => (
+                <TeaserFeed
+                  {...doc.meta}
+                  Link={Link}
+                  key={doc.meta.path}
+                />
+              ))}
+          {pageInfo.hasNextPage && (
+            <button
+              {...styles.button}
+              {...linkRule}
+              onClick={() => {
+                loadMore({ after: pageInfo.endCursor })
+              }}
+            >
+              {t('formats/loadMore')}
+            </button>
+          )}
+
+        </Fragment>
+      )
+    }}
+  />
+)
+
+export default compose(
+  withT,
+  graphql(getFeedDocuments, {
+    props: ({ data, ownProps }) => ({
+      data,
+      loadMore: ({ after }) =>
+        data.fetchMore({
+          variables: {
+            cursor: after
+          },
+          updateQuery: (previousResult, { fetchMoreResult, queryVariables }) => {
+            const nodes = [
+              ...previousResult.documents.nodes,
+              ...fetchMoreResult.documents.nodes
+            ]
+            return {
+              ...fetchMoreResult,
+              documents: {
+                ...fetchMoreResult.documents,
+                nodes
+              }
+            }
+          }
+        })
+    })
+  }
+  )
+)(Latest)

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -1,19 +1,14 @@
-import React, { Component, Fragment } from 'react'
-import { graphql, compose } from 'react-apollo'
+import React, { Component } from 'react'
+import { compose } from 'react-apollo'
 import { css } from 'glamor'
-import { keys, nest, values } from 'd3-collection'
-import gql from 'graphql-tag'
-import Loader from '../../components/Loader'
 import withT from '../../lib/withT'
 
-import FormatTag from './FormatTag'
+import GroupedFormats from './GroupedFormats'
 import Latest from './Latest'
 
 import {
   Center,
   Interaction,
-  colors,
-  fontStyles,
   mediaQueries
 } from '@project-r/styleguide'
 
@@ -30,96 +25,22 @@ const styles = {
     [mediaQueries.mUp]: {
       margin: '100px 0 40px 0'
     }
-  }),
-  h2: css({
-    ...fontStyles.sansSerifRegular13,
-    color: '#979797',
-    margin: '0 0 15px 0',
-    [mediaQueries.mUp]: {
-      ...fontStyles.sansSerifRegular16,
-      margin: '12px 0 15px 0'
-    }
-  }),
-  section: css({
-    marginBottom: '25px',
-    [mediaQueries.mUp]: {
-      marginBottom: '30px',
-      '& + &': {
-        borderTop: `1px solid ${colors.divider}`
-      }
-    }
   })
-}
-
-const getFormats = gql`
-  query getFormats {
-    documents(template: "format", feed: true) {
-      nodes {
-        meta {
-          template
-          kind
-          title
-          description
-          path
-          color
-          publishDate
-        }
-        linkedDocuments {
-          totalCount
-        }
-      }
-    }
-  }
-`
-
-const getColorFromMeta = meta => {
-  const formatMeta = meta.format && meta.format.meta
-  const color = meta.color || (formatMeta && formatMeta.color)
-  const kind = meta.kind || (formatMeta && formatMeta.kind)
-  return color || colors[kind]
 }
 
 class Formats extends Component {
   render () {
-    const { data: { loading, error, documents }, t } = this.props
+    const { t } = this.props
     return (
-      <Loader
-        loading={loading}
-        error={error}
-        render={() => {
-          const sections = nest()
-            .key(d => d['meta']['kind'])
-            .object(documents.nodes)
-
-          return (
-            <Center {...styles.container}>
-              {keys(sections).map(sectionKey => <Fragment>
-                {sections[sectionKey].length > 0 && (
-                  <section {...styles.section} key={sectionKey}>
-                    <h2 {...styles.h2}>
-                      {t(`formats/title/${sectionKey}`)}
-                    </h2>
-                    {values(sections[sectionKey]).map(doc => (
-                      <FormatTag
-                        color={getColorFromMeta(doc.meta)}
-                        path={doc.meta.path}
-                        label={doc.meta.title}
-                        count={doc.linkedDocuments.totalCount}
-                        key={doc.meta.path} />
-                    ))}
-                  </section>)
-                }
-              </Fragment>)}
-              <Interaction.H2 {...styles.latest}>
-                {t('formats/latest')}
-              </Interaction.H2>
-              <Latest />
-            </Center>
-          )
-        }}
-      />
+      <Center {...styles.container}>
+        <GroupedFormats />
+        <Interaction.H2 {...styles.latest}>
+          {t('formats/latest')}
+        </Interaction.H2>
+        <Latest />
+      </Center>
     )
   }
 }
 
-export default compose(withT, graphql(getFormats))(Formats)
+export default compose(withT)(Formats)

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -1,4 +1,4 @@
-import React, { Component, section } from 'react'
+import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import { css } from 'glamor'
 import { keys, nest, values } from 'd3-collection'
@@ -93,21 +93,23 @@ class Formats extends Component {
 
           return (
             <Center {...styles.container}>
-              {keys(sections).map(sectionKey => (
-                <section {...styles.section} key={sectionKey}>
-                  <h2 {...styles.h2}>
-                    {t(`formats/title/${sectionKey}`)}
-                  </h2>
-                  {values(sections[sectionKey]).map(doc => (
-                    <FormatTag
-                      color={getColorFromMeta(doc.meta)}
-                      path={doc.meta.path}
-                      label={doc.meta.title}
-                      count={doc.children.totalCount}
-                      key={doc.meta.path} />
-                  ))}
-                </section>
-              ))}
+              {keys(sections).map(sectionKey => <Fragment>
+                {sections[sectionKey].length > 0 && (
+                  <section {...styles.section} key={sectionKey}>
+                    <h2 {...styles.h2}>
+                      {t(`formats/title/${sectionKey}`)}
+                    </h2>
+                    {values(sections[sectionKey]).map(doc => (
+                      <FormatTag
+                        color={getColorFromMeta(doc.meta)}
+                        path={doc.meta.path}
+                        label={doc.meta.title}
+                        count={doc.children.totalCount}
+                        key={doc.meta.path} />
+                    ))}
+                  </section>)
+                }
+              </Fragment>)}
               <Interaction.H2 {...styles.latest}>
                 {t('formats/latest')}
               </Interaction.H2>

--- a/components/Formats/index.js
+++ b/components/Formats/index.js
@@ -64,7 +64,7 @@ const getFormats = gql`
           color
           publishDate
         }
-        children {
+        linkedDocuments {
           totalCount
         }
       }
@@ -104,7 +104,7 @@ class Formats extends Component {
                         color={getColorFromMeta(doc.meta)}
                         path={doc.meta.path}
                         label={doc.meta.title}
-                        count={doc.children.totalCount}
+                        count={doc.linkedDocuments.totalCount}
                         key={doc.meta.path} />
                     ))}
                   </section>)

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-08-24T13:26:38.006Z",
+  "updated": "2018-08-27T11:57:06.953Z",
   "title": "live",
   "data": [
     {
@@ -796,7 +796,7 @@
     },
     {
       "key": "account/newsletterSubscriptions/DAILY/frequency",
-      "value": "montags, dienstags, mittwochs und freitags"
+      "value": "montags, dienstags, mittwochs, donnerstags, freitags"
     },
     {
       "key": "account/newsletterSubscriptions/WEEKLY/label",
@@ -1293,6 +1293,10 @@
     {
       "key": "header/nav/search/aria",
       "value": "Suche"
+    },
+    {
+      "key": "header/back",
+      "value": "zurück"
     },
     {
       "key": "header/logo/feed/aria",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "5.91.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.91.0.tgz",
-      "integrity": "sha512-zijw/FqQXicIvUfYeaEtArKc7nswFCr/ZJTCdXIsg5LJctZ0VY3CR31vbBUmHUfXy0VIOkJ1qWGjyVYdr7XHRQ==",
+      "version": "5.92.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.92.0.tgz",
+      "integrity": "sha512-tXzCCL0SJeI6+xRAILLEfDEiuH3BjTGCOtIa/83CecA+Zvw1Y2061550ReWEIG64TNv3SEYyyHwk8VkPoan5ZA==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "webpack-bundle-analyzer": "^2.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^5.91.0",
+    "@project-r/styleguide": "^5.92.0",
     "apollo-cache-inmemory": "^1.1.4",
     "apollo-client": "^2.0.4",
     "apollo-fetch": "^0.7.0",


### PR DESCRIPTION
Depends on https://github.com/orbiting/styleguide/pull/164
Depends on https://github.com/orbiting/backends/pull/90

Examples using default format color, except for "Daniels Testformat" with a yellow color set in Publikator.

### Desktop
<img width="961" alt="screen shot 2018-08-27 at 15 34 54" src="https://user-images.githubusercontent.com/23520051/44662732-f024ae80-aa0e-11e8-907d-c0b66caacdd2.png">

### Mobile
<img width="439" alt="screen shot 2018-08-27 at 15 35 40" src="https://user-images.githubusercontent.com/23520051/44662747-f7e45300-aa0e-11e8-9457-c81f50b39efd.png">
<img width="433" alt="screen shot 2018-08-27 at 15 38 23" src="https://user-images.githubusercontent.com/23520051/44662861-4265cf80-aa0f-11e8-99dc-3b2873044884.png">


