### PR TITLE
Formalize Push Route as a Message

### DIFF
--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -259,16 +259,6 @@ class Header extends Component {
       this.onScroll()
     }
 
-    this.onMessage = e => {
-      const message = JSON.parse(e.data)
-      switch (message.type) {
-        case 'open-menu':
-          return this.setState({ expanded: true })
-        case 'close-menu':
-          return this.setState({ expanded: false })
-      }
-    }
-
     this.close = () => {
       this.setState({ expanded: false })
     }
@@ -277,7 +267,6 @@ class Header extends Component {
   componentDidMount () {
     window.addEventListener('scroll', this.onScroll)
     window.addEventListener('resize', this.measure)
-    document.addEventListener('message', this.onMessage)
     this.measure()
 
     const withoutSticky = !isPositionStickySupported()
@@ -293,7 +282,6 @@ class Header extends Component {
   componentWillUnmount () {
     window.removeEventListener('scroll', this.onScroll)
     window.removeEventListener('resize', this.measure)
-    document.removeEventListener('message', this.onMessage)
   }
 
   componentWillReceiveProps (nextProps) {

--- a/lib/apollo/withData.js
+++ b/lib/apollo/withData.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { ApolloProvider, getDataFromTree } from 'react-apollo'
 import initApollo from './initApollo'
-import { Router } from '../../lib/routes'
 import { HeadersProvider } from '../../lib/withHeaders'
 
 // Gets the display name of a JSX component for dev tools
@@ -82,12 +81,6 @@ export default ComposedComponent => {
         this.props.serverState,
         this.props.headers
       )
-    }
-
-    componentDidMount () {
-      // Make router accessible in a global way
-      // Useful in app to redirect page client-side
-      window.Router = Router
     }
 
     render () {

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import withHeaders from './withHeaders'
+import { Router } from './routes'
 
 export const matchUserAgent = value => value && !!value.match(/RepublikApp/)
 const matchIOSUserAgent = value => value && !!value.match(/iPad|iPhone|iPod/)
@@ -11,9 +12,27 @@ export const runInNativeAppBrowser = inNativeAppBrowser
   ? callback => callback()
   : () => {}
 
-// Monkey patch window.postMessage to fix native app webview issues
-// Ref: https://github.com/facebook/react-native/issues/11594
 runInNativeAppBrowser(() => {
+  // Accept push-route and scroll-to-top from app
+  document.addEventListener('message', function (event) {
+    let message
+    try {
+      message = JSON.parse(event.data)
+    } catch (error) {
+      message = {}
+    }
+
+    if (message.type === 'scroll-to-top') {
+      window.scrollTo(0, 0)
+    } else if (message.type === 'push-route') {
+      Router.pushRoute(message.url).then(() => {
+        window.scrollTo(0, 0)
+      })
+    }
+  })
+
+  // Monkey patch window.postMessage to fix native app webview issues
+  // Ref: https://github.com/facebook/react-native/issues/11594
   let isReactNativePostMessageReady = !!window.originalPostMessage
   const queue = []
 


### PR DESCRIPTION
Stops exposing the next-routes Router and instead handle a `push-route` message here.

Also cleans up unused, leftover message code in the header.

Depends on https://github.com/orbiting/app/pull/155