### PR TITLE
Redirect /feuilleton to index page if user is not logged in

### DIFF
--- a/pages/front.js
+++ b/pages/front.js
@@ -1,31 +1,85 @@
+import { Component } from 'react'
 import { compose } from 'react-apollo'
+
+import { Loader } from '@project-r/styleguide'
+
+import { Router, routes } from '../lib/routes'
 import Frame from '../components/Frame'
 import Front from '../components/Front'
+import StatusError from '../components/StatusError'
+
 import withData from '../lib/apollo/withData'
 import withMembership, { UnauthorizedPage } from '../components/Auth/withMembership'
-import StatusError from '../components/StatusError'
+import withInNativeApp from '../lib/withInNativeApp'
 
 const KNOWN_PATHS = ['/feuilleton']
 
-const FrontPage = (props) => {
-  if (props.isMember) {
-    return <Front {...props} />
+const isPathKnown = (url) => {
+  return KNOWN_PATHS.indexOf(url.asPath.split('?')[0]) !== -1
+}
+
+class FrontPage extends Component {
+  componentDidMount () {
+    this.redirectUser()
   }
-  const { url } = props
-  if (KNOWN_PATHS.indexOf(url.asPath.split('?')[0]) !== -1) {
-    return <UnauthorizedPage {...props} />
+
+  componentDidUpdate () {
+    this.redirectUser()
   }
-  return (
-    <Frame raw url={url}>
-      <StatusError
-        url={url}
-        statusCode={404}
-        serverContext={props.serverContext} />
-    </Frame>
-  )
+
+  redirectUser () {
+    const { url, isMember, inNativeIOSApp, serverContext } = this.props
+
+    if (isPathKnown(url) && !isMember && !inNativeIOSApp) {
+      if (serverContext) {
+        const indexPath = routes
+          .filter(r => r.name === 'index')
+          .shift()
+          .toPath()
+
+        serverContext.res.redirect(302, indexPath)
+        serverContext.res.end()
+      } else {
+        Router.pushRoute('index')
+      }
+    }
+  }
+
+  render () {
+    const { url, isMember, inNativeIOSApp, serverContext } = this.props
+
+    if (isMember) {
+      return <Front {...this.props} />
+    }
+
+    if (isPathKnown(url)) {
+      if (inNativeIOSApp) {
+        return <UnauthorizedPage {...this.props} />
+      }
+
+      // ... render Loader while redirect action is pushed to Router
+      return (
+        <Frame raw url={url}>
+          <Loader loading style={{minHeight: 'calc(100vh - 80px)'}} />
+        </Frame>
+      )
+    }
+
+    // If path is neither known (nor is user a member), render a 404 Not Found
+    // status page.
+    return (
+      <Frame raw url={url}>
+        <StatusError
+          url={url}
+          statusCode={404}
+          serverContext={serverContext} />
+      </Frame>
+    )
+  }
 }
 
 export default compose(
   withData,
-  withMembership
+  withMembership,
+  withInNativeApp
 )(FrontPage)


### PR DESCRIPTION
Redirect /feuilleton to index page if user is not logged in. In case we recognize an iOS Republik-App, UnauthorizedPage is render.

Flow implemented is as follows:
1. If user is a member, render `Front` component.
2. If path is known (but user is not a member)...
    1. ... render `UnauthorizedPage` component if we recognize an iOS Republik-App
    2. ... render `Loader` component while redirect is pushed to router and requires a few moments to kick in.
3. If path is neither known (nor is user a member), render a 404 Not Found status page.

Caveats:
- `Loader` component there to avoid a moment for having render a 404 Not Found status page while router did not complete redirect yet.
- Not sure if lifecylces `componentDidMount` and `componentDidUpdate` indeed need and would.

This Pull Request is based on [redirect functionality in pages/signin.js]( https://github.com/orbiting/republik-frontend/blob/master/pages/signin.js#L16-L33)