### PR TITLE
allow to only submit name when not a customer

### DIFF
--- a/components/Account/UpdateMe.js
+++ b/components/Account/UpdateMe.js
@@ -1,13 +1,13 @@
-import React, {Component} from 'react'
+import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
-import {intersperse} from '../../lib/utils/helpers'
+import { intersperse } from '../../lib/utils/helpers'
 import Loader from '../Loader'
-import {errorToString} from '../../lib/utils/errors'
-import {swissTime} from '../../lib/utils/format'
+import { errorToString } from '../../lib/utils/errors'
+import { swissTime } from '../../lib/utils/format'
 
 import withT from '../../lib/withT'
-import AddressForm, {COUNTRIES, fields as addressFields} from './AddressForm'
+import AddressForm, { COUNTRIES, fields as addressFields } from './AddressForm'
 
 import {
   InlineSpinner, Interaction, Label, Button, A, colors
@@ -15,10 +15,12 @@ import {
 
 import FieldSet from '../FieldSet'
 
-const {H2, P} = Interaction
+const { H2, P } = Interaction
 
 const birthdayFormat = '%d.%m.%Y'
 const birthdayParse = swissTime.parse(birthdayFormat)
+
+const DEFAULT_COUNTRY = COUNTRIES[0]
 
 const fields = (t, acceptedStatue) => [
   {
@@ -49,7 +51,7 @@ const fields = (t, acceptedStatue) => [
       return (
         (
           (
-            value.trim().length &&
+            !!value.trim().length &&
             (
               parsedDate === null ||
               parsedDate > (new Date()) ||
@@ -90,6 +92,23 @@ const getValues = (me) => {
   }
 }
 
+const isEmptyAddress = (values, me) => {
+  const addressString = [
+    values.name,
+    values.line1,
+    values.line2,
+    values.postalCode,
+    values.city,
+    values.country
+  ].join('').trim()
+  const emptyAddressString = [
+    me.name,
+    DEFAULT_COUNTRY
+  ].join('').trim()
+
+  return addressString === emptyAddressString
+}
+
 class UpdateMe extends Component {
   constructor (props) {
     super(props)
@@ -97,7 +116,7 @@ class UpdateMe extends Component {
       isEditing: false,
       showErrors: false,
       values: {
-        country: COUNTRIES[0]
+        country: DEFAULT_COUNTRY
       },
       errors: {},
       dirty: {}
@@ -116,10 +135,14 @@ class UpdateMe extends Component {
   autoEdit () {
     if (this.props.me && !this.checked) {
       this.checked = true
-      const {t} = this.props
+      const { t, acceptedStatue, hasMemberships, me } = this.props
 
       const errors = FieldSet.utils.getErrors(
-        fields(t).concat(addressFields(t)),
+        fields(t, acceptedStatue).concat(
+          hasMemberships || me.address
+            ? addressFields(t)
+            : []
+        ),
         getValues(this.props.me)
       )
 
@@ -141,161 +164,177 @@ class UpdateMe extends Component {
       loading,
       error,
       style,
-      acceptedStatue
+      acceptedStatue,
+      hasMemberships
     } = this.props
     const {
       values, dirty, errors,
       updating, isEditing
     } = this.state
 
-    const errorMessages = Object.keys(errors)
-      .map(key => errors[key])
-      .filter(Boolean)
     return (
-      <Loader loading={loading || !me} error={error} render={() => (
-        <div style={style}>
-          {!isEditing ? (
-            <div>
-              <H2 style={{marginBottom: 30}}>{t('Account/Update/title')}</H2>
-              <P>
-                {intersperse(
-                  [
-                    me.name,
-                    me.phoneNumber
-                  ].filter(Boolean),
-                  (_, i) => <br key={i} />
-                )}
-              </P>
-              {!!me.birthday && <P>
-                <Label key='birthday'>{t('Account/Update/birthday/label')}</Label><br />
-                {me.birthday}
-              </P>}
-              <P>
-                <Label>{t('Account/Update/address/label')}</Label><br />
-              </P>
-              <P>
-                {!!me.address && intersperse(
-                  [
-                    me.address.name,
-                    me.address.line1,
-                    me.address.line2,
-                    `${me.address.postalCode} ${me.address.city}`,
-                    me.address.country
-                  ].filter(Boolean),
-                  (_, i) => <br key={i} />
-                )}
-              </P>
-              <br />
-              <A href='#' onClick={(e) => {
-                e.preventDefault()
-                this.startEditing()
-              }}>{t('Account/Update/edit')}</A>
-            </div>
-          ) : (
-            <div>
-              <H2>{t('Account/Update/title')}</H2>
-              <br />
-              <FieldSet
-                values={values}
-                errors={errors}
-                dirty={dirty}
-                onChange={(fields) => {
-                  this.setState(FieldSet.utils.mergeFields(fields))
-                }}
-                fields={fields(t, acceptedStatue)} />
-              <Label style={{marginTop: -8, display: 'block'}}>
-                {t('Account/Update/birthday/hint/plain')}
-              </Label>
-              <br /><br />
-              <br />
-              <AddressForm
-                values={values}
-                errors={errors}
-                dirty={dirty}
-                onChange={(fields) => {
-                  this.setState(FieldSet.utils.mergeFields(fields))
-                }} />
-              <br />
-              <br />
-              <br />
-              {updating ? (
-                <div style={{textAlign: 'center'}}>
-                  <InlineSpinner />
-                  <br />
-                  {t('Account/Update/updating')}
-                </div>
-              ) : (
-                <div>
-                  {!!this.state.showErrors && errorMessages.length > 0 && (
-                    <div style={{color: colors.error, marginBottom: 40}}>
-                      {t('pledge/submit/error/title')}<br />
-                      <ul>
-                        {errorMessages.map((error, i) => (
-                          <li key={i}>{error}</li>
-                        ))}
-                      </ul>
-                    </div>
+      <Loader loading={loading || !me} error={error} render={() => {
+        const meFields = fields(t, acceptedStatue)
+        let errorFilter = () => true
+        if (!hasMemberships && !me.address && isEmptyAddress(values, me)) {
+          errorFilter = key => meFields.find(field => field.name === key)
+        }
+
+        const errorMessages = Object.keys(errors)
+          .filter(errorFilter)
+          .map(key => errors[key])
+          .filter(Boolean)
+
+        return (
+          <div style={style}>
+            {!isEditing ? (
+              <div>
+                <H2 style={{marginBottom: 30}}>{t('Account/Update/title')}</H2>
+                <P>
+                  {intersperse(
+                    [
+                      me.name,
+                      me.phoneNumber
+                    ].filter(Boolean),
+                    (_, i) => <br key={i} />
                   )}
-                  {!!this.state.error && (
-                    <div style={{color: colors.error, marginBottom: 40}}>
-                      {this.state.error}
-                    </div>
-                  )}
-                  <div style={{opacity: errorMessages.length ? 0.5 : 1}}>
-                    <Button onClick={() => {
-                      if (errorMessages.length) {
-                        this.setState((state) => Object.keys(state.errors).reduce(
-                          (nextState, key) => {
-                            nextState.dirty[key] = true
-                            return nextState
-                          },
-                          {
-                            showErrors: true,
-                            dirty: {}
-                          }
-                        ))
-                        return
-                      }
-                      this.setState(() => ({updating: true}))
-                      this.props.update({
-                        firstName: values.firstName,
-                        lastName: values.lastName,
-                        phoneNumber: values.phoneNumber,
-                        birthday: values.birthday && values.birthday.length
-                          ? values.birthday.trim()
-                          : null,
-                        address: {
-                          name: values.name,
-                          line1: values.line1,
-                          line2: values.line2,
-                          postalCode: values.postalCode,
-                          city: values.city,
-                          country: values.country
-                        }
-                      }).then(() => {
-                        this.setState(() => ({
-                          updating: false,
-                          isEditing: false
-                        }))
-                      }).catch((error) => {
-                        this.setState(() => ({
-                          updating: false,
-                          error: errorToString(error)
-                        }))
-                      })
-                    }}>{t('Account/Update/submit')}</Button>
+                </P>
+                {!!me.birthday && <P>
+                  <Label key='birthday'>{t('Account/Update/birthday/label')}</Label><br />
+                  {me.birthday}
+                </P>}
+                {!!me.address && <Fragment>
+                  <P>
+                    <Label>{t('Account/Update/address/label')}</Label><br />
+                  </P>
+                  <P>
+                    {intersperse(
+                      [
+                        me.address.name,
+                        me.address.line1,
+                        me.address.line2,
+                        `${me.address.postalCode} ${me.address.city}`,
+                        me.address.country
+                      ].filter(Boolean),
+                      (_, i) => <br key={i} />
+                    )}
+                  </P>
+                </Fragment>}
+                <br />
+                <A href='#' onClick={(e) => {
+                  e.preventDefault()
+                  this.startEditing()
+                }}>{t('Account/Update/edit')}</A>
+              </div>
+            ) : (
+              <div>
+                <H2>{t('Account/Update/title')}</H2>
+                <br />
+                <FieldSet
+                  values={values}
+                  errors={errors}
+                  dirty={dirty}
+                  onChange={(fields) => {
+                    this.setState(FieldSet.utils.mergeFields(fields))
+                  }}
+                  fields={meFields} />
+                <Label style={{marginTop: -8, display: 'block'}}>
+                  {t('Account/Update/birthday/hint/plain')}
+                </Label>
+                <br /><br />
+                <br />
+                <AddressForm
+                  values={values}
+                  errors={errors}
+                  dirty={dirty}
+                  onChange={(fields) => {
+                    this.setState(FieldSet.utils.mergeFields(fields))
+                  }} />
+                <br />
+                <br />
+                <br />
+                {updating ? (
+                  <div style={{textAlign: 'center'}}>
+                    <InlineSpinner />
+                    <br />
+                    {t('Account/Update/updating')}
                   </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )} />
+                ) : (
+                  <div>
+                    {!!this.state.showErrors && errorMessages.length > 0 && (
+                      <div style={{color: colors.error, marginBottom: 40}}>
+                        {t('pledge/submit/error/title')}<br />
+                        <ul>
+                          {errorMessages.map((error, i) => (
+                            <li key={i}>{error}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+                    {!!this.state.error && (
+                      <div style={{color: colors.error, marginBottom: 40}}>
+                        {this.state.error}
+                      </div>
+                    )}
+                    <div style={{opacity: errorMessages.length ? 0.5 : 1}}>
+                      <Button onClick={() => {
+                        if (errorMessages.length) {
+                          this.setState((state) => Object.keys(state.errors).reduce(
+                            (nextState, key) => {
+                              nextState.dirty[key] = true
+                              return nextState
+                            },
+                            {
+                              showErrors: true,
+                              dirty: {}
+                            }
+                          ))
+                          return
+                        }
+                        this.setState(() => ({updating: true}))
+
+                        this.props.update({
+                          firstName: values.firstName,
+                          lastName: values.lastName,
+                          phoneNumber: values.phoneNumber,
+                          birthday: values.birthday && values.birthday.length
+                            ? values.birthday.trim()
+                            : null,
+                          address: isEmptyAddress(values, me)
+                            ? undefined
+                            : {
+                              name: values.name,
+                              line1: values.line1,
+                              line2: values.line2,
+                              postalCode: values.postalCode,
+                              city: values.city,
+                              country: values.country
+                            }
+                        }).then(() => {
+                          this.setState(() => ({
+                            updating: false,
+                            isEditing: false
+                          }))
+                        }).catch((error) => {
+                          this.setState(() => ({
+                            updating: false,
+                            error: errorToString(error)
+                          }))
+                        })
+                      }}>{t('Account/Update/submit')}</Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        )
+      }} />
     )
   }
 }
 
-const mutation = gql`mutation updateMe($birthday: Date, $firstName: String!, $lastName: String!, $phoneNumber: String, $address: AddressInput!) {
+const mutation = gql`mutation updateMe($birthday: Date, $firstName: String!, $lastName: String!, $phoneNumber: String, $address: AddressInput) {
   updateMe(birthday: $birthday, firstName: $firstName, lastName: $lastName, phoneNumber: $phoneNumber, address: $address) {
     id
   }

--- a/components/Account/index.js
+++ b/components/Account/index.js
@@ -128,7 +128,7 @@ class Account extends Component {
                 </AccountAnchor>
 
                 <AccountAnchor id='account'>
-                  <UpdateMe acceptedStatue={acceptedStatue} />
+                  <UpdateMe acceptedStatue={acceptedStatue} hasMemberships={hasMemberships} />
                 </AccountAnchor>
 
                 {!inNativeIOSApp &&


### PR DESCRIPTION
Had to re-indent the form. Essentially this change allows someone without a membership (but e.g. with member role) to just set a name without providing an address. UX is not ideal but it works—quick fix for now.