### PR TITLE
Störer 2.0

### DIFF
--- a/components/ActionBar/ShareOverlay.js
+++ b/components/ActionBar/ShareOverlay.js
@@ -12,6 +12,7 @@ import IconLink from '../IconLink'
 import MdClose from 'react-icons/lib/md/close'
 
 import withT from '../../lib/withT'
+import track from '../../lib/piwik'
 
 const styles = {
   buttonGroup: css({
@@ -30,15 +31,6 @@ const styles = {
       display: 'none'
     }
   })
-}
-
-const onShareClick = (name, value) => {
-  window._paq.push([
-    'trackEvent',
-    'share',
-    name,
-    value
-  ])
 }
 
 const ShareOverlay = ({
@@ -111,7 +103,12 @@ const ShareOverlay = ({
                 fill={fill}
                 size={32}
                 onClick={() => {
-                  onShareClick(props.icon, url)
+                  track([
+                    'trackEvent',
+                    'share',
+                    props.icon,
+                    url
+                  ])
                   onClose && onClose()
                 }}
                 stacked

--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -7,6 +7,7 @@ import IconLink from '../IconLink'
 import ShareOverlay from './ShareOverlay'
 import withT from '../../lib/withT'
 import { postMessage } from '../../lib/withInNativeApp'
+import track from '../../lib/piwik'
 
 import { colors } from '@project-r/styleguide'
 
@@ -16,15 +17,6 @@ const styles = {
       display: 'none'
     }
   })
-}
-
-const onActionBarClick = (name, value) => {
-  window._paq.push([
-    'trackEvent',
-    'ActionBar',
-    name,
-    value
-  ])
 }
 
 class ActionBar extends Component {
@@ -81,7 +73,12 @@ class ActionBar extends Component {
             e.target.blur()
           } else {
             this.toggleShare()
-            onActionBarClick('share', url)
+            track([
+              'trackEvent',
+              'ActionBar',
+              'share',
+              url
+            ])
           }
         },
         title: t('article/actionbar/share')

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import { css } from 'glamor'
+import withT from '../../lib/withT'
+
+import Close from 'react-icons/lib/md/close'
+import {
+  Center,
+  mediaQueries
+} from '@project-r/styleguide'
+import { negativeColors } from '../Frame/Footer'
+import {
+  ZINDEX_BOTTOM_PANEL,
+  HEADER_HEIGHT,
+  HEADER_HEIGHT_MOBILE
+} from '../constants'
+
+const PADDING = 15
+const IOS_BOTTOM_HOT_AREA = 44
+
+const styles = {
+  container: css({
+    backgroundColor: negativeColors.primaryBg,
+    color: negativeColors.text,
+    position: 'fixed',
+    zIndex: ZINDEX_BOTTOM_PANEL,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    paddingBottom: `${IOS_BOTTOM_HOT_AREA - PADDING}px`, // Center comes with bottom padding.
+    opacity: 0,
+    textRendering: 'optimizeLegibility',
+    WebkitFontSmoothing: 'antialiased',
+    visibility: 'hidden',
+    transition: 'opacity 0.2s ease-in-out, visibility 0s linear 0.2s',
+    '&[aria-expanded=true]': {
+      opacity: 1,
+      visibility: 'visible',
+      transition: 'opacity 0.2s ease-in-out'
+    },
+    maxHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE}px)`,
+    [mediaQueries.mUp]: {
+      maxHeight: `calc(100vh - ${HEADER_HEIGHT}px)`
+    }
+  }),
+  closeContainer: css({
+    height: '40px',
+    position: 'absolute',
+    top: 0,
+    right: 0
+  }),
+  close: css({
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    outline: 'none',
+    WebkitAppearance: 'none',
+    padding: '12px',
+    [mediaQueries.mUp]: {
+      padding: `${PADDING}px`
+    }
+  })
+}
+
+class BottomPanel extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      expanded: true
+    }
+
+    this.close = () => {
+      this.setState({ expanded: false })
+    }
+  }
+
+  render () {
+    const { t, children, expanded } = this.props
+
+    return (
+      <div aria-expanded={expanded && this.state.expanded} {...styles.container}>
+        <div {...styles.closeContainer}>
+          <button
+            {...styles.close}
+            onClick={this.close}
+            title={t('article/bottomPanel/close')}
+          >
+            <Close size={32} fill={negativeColors.lightText} />
+          </button>
+        </div>
+        <Center>
+          {children}
+        </Center>
+      </div>
+    )
+  }
+}
+
+BottomPanel.propTypes = {
+  t: PropTypes.func.isRequired,
+  children: PropTypes.node,
+  expanded: PropTypes.bool
+}
+
+export default withT(BottomPanel)

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -10,9 +10,7 @@ import {
 } from '@project-r/styleguide'
 import { negativeColors } from '../Frame/Footer'
 import {
-  ZINDEX_BOTTOM_PANEL,
-  HEADER_HEIGHT,
-  HEADER_HEIGHT_MOBILE
+  ZINDEX_BOTTOM_PANEL
 } from '../constants'
 
 const PADDING = 15
@@ -38,10 +36,8 @@ const styles = {
       visibility: 'visible',
       transition: 'opacity 0.2s ease-in-out'
     },
-    maxHeight: `calc(100vh - ${HEADER_HEIGHT_MOBILE}px)`,
-    [mediaQueries.mUp]: {
-      maxHeight: `calc(100vh - ${HEADER_HEIGHT}px)`
-    }
+    maxHeight: '50vh',
+    overflow: 'scroll'
   }),
   closeContainer: css({
     height: '40px',
@@ -55,7 +51,7 @@ const styles = {
     cursor: 'pointer',
     outline: 'none',
     WebkitAppearance: 'none',
-    padding: '12px',
+    padding: '10px',
     [mediaQueries.mUp]: {
       padding: `${PADDING}px`
     }

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -81,7 +81,6 @@ class BottomPanel extends Component {
       <div aria-expanded={expanded && this.state.expanded} {...styles.container} style={{ paddingBottom }}>
         <div {...styles.closeContainer}>
           <button
-            tabIndex={-1}
             {...styles.close}
             onClick={this.close}
             title={t('article/bottomPanel/close')}

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -38,7 +38,7 @@ const styles = {
       transition: 'opacity 0.2s ease-in-out'
     },
     maxHeight: '50vh',
-    overflow: 'scroll'
+    overflow: 'hidden'
   }),
   closeContainer: css({
     height: '40px',
@@ -81,6 +81,7 @@ class BottomPanel extends Component {
       <div aria-expanded={expanded && this.state.expanded} {...styles.container} style={{ paddingBottom }}>
         <div {...styles.closeContainer}>
           <button
+            tabIndex={-1}
             {...styles.close}
             onClick={this.close}
             title={t('article/bottomPanel/close')}

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { compose } from 'react-apollo'
 import { css } from 'glamor'
-import withInNativeApp from '../../lib/withInNativeApp'
 import withT from '../../lib/withT'
 
 import Close from 'react-icons/lib/md/close'
@@ -46,15 +45,46 @@ const styles = {
     top: 0,
     right: 0
   }),
-  close: css({
+  plainButton: css({
     border: 'none',
     background: 'transparent',
     cursor: 'pointer',
     outline: 'none',
-    WebkitAppearance: 'none',
+    WebkitAppearance: 'none'
+  }),
+  close: css({
     padding: '10px',
     [mediaQueries.mUp]: {
       padding: `${PADDING}px`
+    }
+  }),
+  textContainer: css({
+    maxHeight: `calc(50vh - 60px - ${IOS_BOTTOM_HOT_AREA}px)`,
+    padding: PADDING,
+    overflow: 'auto'
+  }),
+  actions: css({
+    position: 'relative',
+    boxShadow: `0 -5px ${PADDING - 5}px ${negativeColors.primaryBg}`,
+    paddingLeft: PADDING,
+    paddingRight: PADDING,
+    [mediaQueries.onlyS]: {
+      display: 'flex',
+      flexDirection: 'column'
+    },
+    [mediaQueries.mUp]: {
+      paddingBottom: PADDING + 5
+    }
+  }),
+  later: css({
+    display: 'none',
+    [mediaQueries.onlyS]: {
+      padding: 12,
+      height: IOS_BOTTOM_HOT_AREA,
+      paddingBottom: PADDING,
+      display: 'block',
+      textAlign: 'center',
+      color: negativeColors.text
     }
   })
 }
@@ -72,15 +102,13 @@ class BottomPanel extends Component {
   }
 
   render () {
-    const { t, inNativeIOSApp, children, expanded } = this.props
-    const paddingBottom = inNativeIOSApp
-      ? undefined
-      : `${IOS_BOTTOM_HOT_AREA - PADDING}px` // Center comes with bottom padding.
+    const { t, children, button, expanded } = this.props
 
     return (
-      <div aria-expanded={expanded && this.state.expanded} {...styles.container} style={{ paddingBottom }}>
+      <div aria-expanded={expanded && this.state.expanded} {...styles.container}>
         <div {...styles.closeContainer}>
           <button
+            {...styles.plainButton}
             {...styles.close}
             onClick={this.close}
             title={t('article/bottomPanel/close')}
@@ -88,8 +116,20 @@ class BottomPanel extends Component {
             <Close size={32} fill={negativeColors.lightText} />
           </button>
         </div>
-        <Center>
-          {children}
+        <Center style={{padding: 0}}>
+          <div {...styles.textContainer}>
+            {children}
+          </div>
+          <div {...styles.actions}>
+            {button}
+            <button
+              {...styles.later}
+              {...styles.plainButton}
+              onClick={this.close}
+            >
+              {t('article/bottomPanel/actions/later')}
+            </button>
+          </div>
         </Center>
       </div>
     )
@@ -98,12 +138,10 @@ class BottomPanel extends Component {
 
 BottomPanel.propTypes = {
   t: PropTypes.func.isRequired,
-  inNativeIOSApp: PropTypes.bool,
   children: PropTypes.node,
   expanded: PropTypes.bool
 }
 
 export default compose(
-  withT,
-  withInNativeApp
+  withT
 )(BottomPanel)

--- a/components/Article/BottomPanel.js
+++ b/components/Article/BottomPanel.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { compose } from 'react-apollo'
 import { css } from 'glamor'
+import withInNativeApp from '../../lib/withInNativeApp'
 import withT from '../../lib/withT'
 
 import Close from 'react-icons/lib/md/close'
@@ -25,7 +27,6 @@ const styles = {
     bottom: 0,
     left: 0,
     right: 0,
-    paddingBottom: `${IOS_BOTTOM_HOT_AREA - PADDING}px`, // Center comes with bottom padding.
     opacity: 0,
     textRendering: 'optimizeLegibility',
     WebkitFontSmoothing: 'antialiased',
@@ -71,10 +72,13 @@ class BottomPanel extends Component {
   }
 
   render () {
-    const { t, children, expanded } = this.props
+    const { t, inNativeIOSApp, children, expanded } = this.props
+    const paddingBottom = inNativeIOSApp
+      ? undefined
+      : `${IOS_BOTTOM_HOT_AREA - PADDING}px` // Center comes with bottom padding.
 
     return (
-      <div aria-expanded={expanded && this.state.expanded} {...styles.container}>
+      <div aria-expanded={expanded && this.state.expanded} {...styles.container} style={{ paddingBottom }}>
         <div {...styles.closeContainer}>
           <button
             {...styles.close}
@@ -94,8 +98,12 @@ class BottomPanel extends Component {
 
 BottomPanel.propTypes = {
   t: PropTypes.func.isRequired,
+  inNativeIOSApp: PropTypes.bool,
   children: PropTypes.node,
   expanded: PropTypes.bool
 }
 
-export default withT(BottomPanel)
+export default compose(
+  withT,
+  withInNativeApp
+)(BottomPanel)

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -428,10 +428,11 @@ class ArticlePage extends Component {
           }
 
           const isFormat = meta.template === 'format'
+          const isNewsletterSource = url.query.utm_source && url.query.utm_source === 'newsletter'
 
           return (
             <Fragment>
-              {!isFormat && (
+              {!isFormat && !isNewsletterSource && (
                 <PayNote.Before
                   isSeries={!!series}
                   index={randomPayNoteIndex}

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -18,7 +18,7 @@ import DiscussionIconLink from '../Discussion/IconLink'
 import Feed from '../Feed/Format'
 import StatusError from '../StatusError'
 import SSRCachingBoundary from '../SSRCachingBoundary'
-import withMembership, { WithMembership } from '../Auth/withMembership'
+import withMembership from '../Auth/withMembership'
 import ArticleGallery from './ArticleGallery'
 
 import {
@@ -463,7 +463,7 @@ class ArticlePage extends Component {
                   mute={!!url.query.mute}
                   url={url} />
               </Center>}
-              <WithMembership render={() => (
+              {isMember && (
                 <Fragment>
                   {meta.template === 'article' && <Center>
                     <div ref={this.bottomBarRef} {...styles.bar}>
@@ -471,17 +471,17 @@ class ArticlePage extends Component {
                     </div>
                   </Center>}
                 </Fragment>
-              )} />
+              )}
               {isMember && episodes && <RelatedEpisodes episodes={episodes} path={meta.path} />}
               {isFormat && <Feed formatId={article.id} />}
-              <WithMembership render={() => (
+              {isMember && (
                 <Fragment>
                   <br />
                   <br />
                   <br />
                   <br />
                 </Fragment>
-              )} />
+              )}
             </Fragment>
           )
         }} />

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -356,7 +356,7 @@ class ArticlePage extends Component {
   }
 
   render () {
-    const { url, t, data, data: {article}, isMember, payNoteIndex } = this.props
+    const { url, t, data, data: {article}, isMember } = this.props
 
     const { meta, actionBar, schema, showAudioPlayer, isAwayFromBottomBar } = this.state
 
@@ -425,13 +425,15 @@ class ArticlePage extends Component {
 
           const isFormat = meta.template === 'format'
           const isNewsletterSource = url.query.utm_source && url.query.utm_source === 'newsletter'
+          const payNoteVariation = series
+            ? 'series'
+            : this.props.payNoteVariation
 
           return (
             <Fragment>
               {!isFormat && !isNewsletterSource && (
                 <PayNote.Before
-                  isSeries={!!series}
-                  index={payNoteIndex}
+                  variation={payNoteVariation}
                   expanded={isAwayFromBottomBar} />
               )}
               {this.state.showPdf &&
@@ -448,8 +450,7 @@ class ArticlePage extends Component {
               </ArticleGallery>
               {!isFormat && (
                 <PayNote.After
-                  isSeries={!!series}
-                  index={payNoteIndex}
+                  variation={payNoteVariation}
                   bottomBarRef={this.bottomBarRef} />
               )}
               {meta.discussionId && <Center>
@@ -501,7 +502,7 @@ const ComposedPage = compose(
 
 ComposedPage.getInitialProps = () => {
   return {
-    payNoteIndex: Math.floor(Math.random() * PayNote.NUM_VARIATIONS)
+    payNoteVariation: PayNote.getRandomVariation()
   }
 }
 

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -48,9 +48,6 @@ const schemaCreators = {
   editorialNewsletter: createNewsletterSchema
 }
 
-// The total number of paynote translation variations in lib/translations.json
-const numPayNoteVariations = 9
-
 const getSchemaCreator = template => {
   const key = template || Object.keys(schemaCreators)[0]
   const schema = schemaCreators[key]
@@ -205,7 +202,6 @@ class ArticlePage extends Component {
       showSecondary: false,
       showAudioPlayer: false,
       isAwayFromBottomBar: true,
-      randomPayNoteIndex: Math.floor(Math.random() * numPayNoteVariations),
       ...this.deriveStateFromProps(props)
     }
 
@@ -360,9 +356,9 @@ class ArticlePage extends Component {
   }
 
   render () {
-    const { url, t, data, data: {article}, isMember } = this.props
+    const { url, t, data, data: {article}, isMember, payNoteIndex } = this.props
 
-    const { meta, actionBar, schema, showAudioPlayer, randomPayNoteIndex, isAwayFromBottomBar } = this.state
+    const { meta, actionBar, schema, showAudioPlayer, isAwayFromBottomBar } = this.state
 
     const series = meta && meta.series
     const episodes = series && series.episodes
@@ -435,7 +431,7 @@ class ArticlePage extends Component {
               {!isFormat && !isNewsletterSource && (
                 <PayNote.Before
                   isSeries={!!series}
-                  index={randomPayNoteIndex}
+                  index={payNoteIndex}
                   expanded={isAwayFromBottomBar} />
               )}
               {this.state.showPdf &&
@@ -453,7 +449,7 @@ class ArticlePage extends Component {
               {!isFormat && (
                 <PayNote.After
                   isSeries={!!series}
-                  index={randomPayNoteIndex}
+                  index={payNoteIndex}
                   bottomBarRef={this.bottomBarRef} />
               )}
               {meta.discussionId && <Center>
@@ -490,7 +486,7 @@ class ArticlePage extends Component {
   }
 }
 
-export default compose(
+const ComposedPage = compose(
   withT,
   withMembership,
   withInNativeApp,
@@ -502,3 +498,11 @@ export default compose(
     })
   })
 )(ArticlePage)
+
+ComposedPage.getInitialProps = () => {
+  return {
+    payNoteIndex: Math.floor(Math.random() * PayNote.NUM_VARIATIONS)
+  }
+}
+
+export default ComposedPage

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -49,7 +49,7 @@ const schemaCreators = {
 }
 
 // The total number of paynote translation variations in lib/translations.json
-const numPayNoteVariations = 4
+const numPayNoteVariations = 9
 
 const getSchemaCreator = template => {
   const key = template || Object.keys(schemaCreators)[0]

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -21,6 +21,8 @@ import {
   mediaQueries
 } from '@project-r/styleguide'
 
+import { negativeColors } from '../Frame/Footer'
+
 const styles = {
   actions: css({
     display: 'flex',
@@ -45,9 +47,19 @@ const styles = {
       ...fontStyles.sansSerifRegular21
     }
   }),
-  afterContainer: css({
+  secondaryContainer: css({
     padding: '15px 0',
     backgroundColor: colors.secondaryBg,
+    [mediaQueries.mUp]: {
+      padding: '30px 0'
+    }
+  }),
+  blackContainer: css({
+    backgroundColor: negativeColors.primaryBg,
+    color: negativeColors.text,
+    textRendering: 'optimizeLegibility',
+    WebkitFontSmoothing: 'antialiased',
+    padding: '15px 0',
     [mediaQueries.mUp]: {
       padding: '30px 0'
     }
@@ -80,35 +92,50 @@ query payNoteMembershipStats {
 // The total number of paynote translation variations in lib/translations.json
 export const NUM_VARIATIONS = 9
 
+const CountSpan = ({ memberStats }) => (
+  <span style={{whiteSpace: 'nowrap'}}>{countFormat(
+    (memberStats && memberStats.count) || 20000
+  )}</span>
+)
+
 export const Before = compose(
   withT,
   graphql(query),
   withInNativeApp
 )(({ t, data: { memberStats }, isSeries, inNativeIOSApp, index, expanded }) => (
   <WithoutMembership render={() => {
-    const translationPrefix = !inNativeIOSApp && isSeries
+    if (inNativeIOSApp) {
+      return (
+        <div {...styles.blackContainer}>
+          <Center>
+            <Interaction.P style={{color: 'inherit'}}>
+              {t.elements('article/payNote/before/ios', {
+                count: <CountSpan key='count' memberStats={memberStats} />
+              })}
+            </Interaction.P>
+          </Center>
+        </div>
+      )
+    }
+    const translationPrefix = isSeries
       ? 'article/payNote/series'
       : `article/payNote/${index}`
     return (
       <BottomPanel expanded={expanded}>
         <div {...styles.beforeContent}>
           <p {...styles.beforeParagraph}>
-            {t.elements(inNativeIOSApp ? 'article/payNote/before/ios' : `${translationPrefix}/before`, {
-              count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
-                (memberStats && memberStats.count) || 20000
-              )}</span>
+            {t.elements(`${translationPrefix}/before`, {
+              count: <CountSpan key='count' memberStats={memberStats} />
             })}
           </p>
         </div>
-        {!inNativeIOSApp && (
-          <div {...styles.actions}>
-            <Link key='buy' route='pledge'>
-              <Button primary style={multiLineButtonStyle}>
-                {t(`${translationPrefix}/before/buy/button`)}
-              </Button>
-            </Link>
-          </div>
-        )}
+        <div {...styles.actions}>
+          <Link key='buy' route='pledge'>
+            <Button primary style={multiLineButtonStyle}>
+              {t(`${translationPrefix}/before/buy/button`)}
+            </Button>
+          </Link>
+        </div>
       </BottomPanel>
     )
   }} />
@@ -125,16 +152,14 @@ export const After = compose(
       ? 'article/payNote/series'
       : `article/payNote/${index}`
     return (
-      <div {...styles.afterContainer}>
+      <div {...styles.secondaryContainer}>
         <Center>
           <Interaction.H3 style={{ marginBottom: 15 }}>
             {t(`${translationPrefix}/after/title`)}
           </Interaction.H3>
           <Interaction.P>
             {t.elements(inNativeIOSApp ? 'article/payNote/after/ios' : `${translationPrefix}/after`, {
-              count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
-                (memberStats && memberStats.count) || 20000
-              )}</span>
+              count: <CountSpan key='count' memberStats={memberStats} />
             })}
           </Interaction.P>
           <br />

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -134,7 +134,7 @@ export const Before = compose(
     }
     const translationPrefix = `article/payNote/${variation}`
     return (
-      <BottomPanel expanded={expanded} button={(
+      <BottomPanel expanded={expanded} variation={variation} button={(
         <Button primary style={multiLineButtonStyle} onClick={trackEventOnClick(
           ['PayNote', 'pledge panel', variation],
           () => {

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -32,7 +32,7 @@ const styles = {
     }
   }),
   beforeContent: css({
-    paddingRight: '30px',
+    paddingRight: '25px',
     [mediaQueries.mUp]: {
       paddingRight: 0
     }

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -27,7 +27,6 @@ const styles = {
   actions: css({
     display: 'flex',
     flexDirection: 'column',
-    marginTop: 15,
     [mediaQueries.mUp]: {
       alignItems: 'center',
       flexDirection: 'row'
@@ -121,20 +120,19 @@ export const Before = compose(
       ? 'article/payNote/series'
       : `article/payNote/${index}`
     return (
-      <BottomPanel expanded={expanded}>
+      <BottomPanel expanded={expanded} button={(
+        <Link route='pledge'>
+          <Button primary style={multiLineButtonStyle}>
+            {t(`${translationPrefix}/before/buy/button`)}
+          </Button>
+        </Link>
+      )}>
         <div {...styles.beforeContent}>
           <p {...styles.beforeParagraph}>
             {t.elements(`${translationPrefix}/before`, {
               count: <CountSpan key='count' membershipStats={membershipStats} />
             })}
           </p>
-        </div>
-        <div {...styles.actions}>
-          <Link key='buy' route='pledge'>
-            <Button primary style={multiLineButtonStyle}>
-              {t(`${translationPrefix}/before/buy/button`)}
-            </Button>
-          </Link>
         </div>
       </BottomPanel>
     )

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -56,6 +56,11 @@ const styles = {
   })
 }
 
+const multiLineButtonStyle = {
+  height: 'auto',
+  minHeight: '60px'
+}
+
 const query = gql`
 query payNoteMembershipStats {
   memberStats {
@@ -79,14 +84,14 @@ export const Before = compose(
           <Interaction.P style={{ color: 'inherit' }}>
             {t.elements(`${translationPrefix}/before${inNativeIOSApp ? '/ios' : ''}`, {
               count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
-                (memberStats && memberStats.count) || 18000
+                (memberStats && memberStats.count) || 20000
               )}</span>
             })}
           </Interaction.P>
         </div>
         {!inNativeIOSApp && (
           <div {...styles.actions}>
-            <Button primary style={{ height: 'auto', minHeight: '60px' }}>
+            <Button primary style={multiLineButtonStyle}>
               <Link key='buy' route='pledge'>
                 <a {...linkRule} style={{ color: 'inherit' }}>
                   {t(`${translationPrefix}/before/buy/button`)}
@@ -119,7 +124,7 @@ export const After = compose(
           <Interaction.P>
             {t.elements(`${translationPrefix}/after${inNativeIOSApp ? '/ios' : ''}`, {
               count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
-                (memberStats && memberStats.count) || 18000
+                (memberStats && memberStats.count) || 20000
               )}</span>
             })}
           </Interaction.P>
@@ -127,7 +132,7 @@ export const After = compose(
           <div {...styles.actions} ref={bottomBarRef}>
             {!inNativeIOSApp && (
               <Fragment>
-                <Button primary style={{ height: 'auto', minHeight: '60px' }}>
+                <Button primary style={multiLineButtonStyle}>
                   <Link key='buy' route='pledge'>
                     <a {...linkRule} style={{ color: 'inherit' }}>
                       {t(`${translationPrefix}/after/buy/button`)}

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -7,10 +7,11 @@ import { css } from 'glamor'
 import { WithoutMembership } from '../Auth/withMembership'
 import withMe from '../../lib/apollo/withMe'
 import withT from '../../lib/withT'
-import { Link } from '../../lib/routes'
+import { trackEventOnClick } from '../../lib/piwik'
+import { Router, routes } from '../../lib/routes'
 import { countFormat } from '../../lib/utils/format'
 import withInNativeApp from '../../lib/withInNativeApp'
-import BottomPanel from './BottomPanel'
+import BottomPanel from './PayNoteBottomPanel'
 
 import {
   Button,
@@ -134,11 +135,14 @@ export const Before = compose(
     const translationPrefix = `article/payNote/${variation}`
     return (
       <BottomPanel expanded={expanded} button={(
-        <Link route='pledge'>
-          <Button primary style={multiLineButtonStyle}>
-            {t(`${translationPrefix}/before/buy/button`)}
-          </Button>
-        </Link>
+        <Button primary style={multiLineButtonStyle} onClick={trackEventOnClick(
+          ['PayNote', 'pledge panel', variation],
+          () => {
+            Router.pushRoute('pledge').then(() => window.scrollTo(0, 0))
+          }
+        )}>
+          {t(`${translationPrefix}/before/buy/button`)}
+        </Button>
       )}>
         <div {...styles.beforeContent}>
           <p {...styles.beforeParagraph}>
@@ -183,20 +187,28 @@ export const After = compose(
               </Interaction.P>
               <br />
               <div {...styles.actions} ref={bottomBarRef}>
-                <Link key='buy' route='pledge'>
-                  <Button primary style={multiLineButtonStyle}>
-                    {t(`${translationPrefix}/after/buy/button`)}
-                  </Button>
-                </Link>
+                <Button primary style={multiLineButtonStyle} onClick={trackEventOnClick(
+                  ['PayNote', 'pledge after', variation],
+                  () => {
+                    Router.pushRoute('pledge').then(() => window.scrollTo(0, 0))
+                  }
+                )}>
+                  {t(`${translationPrefix}/after/buy/button`)}
+                </Button>
                 {!me && (
                   <div {...styles.aside}>
                     {t.elements('article/payNote/secondaryAction/text', {
                       link: (
-                        <Link key='preview' route='preview'>
-                          <a {...linkRule} style={{whiteSpace: 'nowrap'}}>
-                            {t('article/payNote/secondaryAction/linkText')}
-                          </a>
-                        </Link>
+                        <a key='preview' {...linkRule} style={{whiteSpace: 'nowrap'}}
+                          href={routes.find(r => r.name === 'preview').toPath()}
+                          onClick={trackEventOnClick(
+                            ['PayNote', 'preview after', variation],
+                            () => {
+                              Router.pushRoute('preview').then(() => window.scrollTo(0, 0))
+                            }
+                          )}>
+                          {t('article/payNote/secondaryAction/linkText')}
+                        </a>
                       )
                     })}
                   </div>

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -77,6 +77,9 @@ query payNoteMembershipStats {
 }
 `
 
+// The total number of paynote translation variations in lib/translations.json
+export const NUM_VARIATIONS = 9
+
 export const Before = compose(
   withT,
   graphql(query),

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
 import gql from 'graphql-tag'
 import { graphql, compose } from 'react-apollo'
 import { css } from 'glamor'
@@ -88,8 +89,22 @@ query payNoteMembershipStats {
 }
 `
 
-// The total number of paynote translation variations in lib/translations.json
-export const NUM_VARIATIONS = 9
+const ACTIVE_VARIATIONS = [
+  '180920-v1',
+  '180920-v2',
+  '180920-v3',
+  '180920-v4',
+  '180920-v5',
+  '180920-v6',
+  '180920-v7',
+  '180920-v8',
+  '180920-v9'
+]
+
+export const getRandomVariation = () => {
+  const randomIndex = Math.floor(Math.random() * ACTIVE_VARIATIONS.length)
+  return ACTIVE_VARIATIONS[randomIndex]
+}
 
 const CountSpan = ({ membershipStats }) => (
   <span style={{whiteSpace: 'nowrap'}}>{countFormat(
@@ -101,7 +116,7 @@ export const Before = compose(
   withT,
   graphql(query),
   withInNativeApp
-)(({ t, data: { membershipStats }, isSeries, inNativeIOSApp, index, expanded }) => (
+)(({ t, data: { membershipStats }, inNativeIOSApp, variation, expanded }) => (
   <WithoutMembership render={() => {
     if (inNativeIOSApp) {
       return (
@@ -116,9 +131,7 @@ export const Before = compose(
         </div>
       )
     }
-    const translationPrefix = isSeries
-      ? 'article/payNote/series'
-      : `article/payNote/${index}`
+    const translationPrefix = `article/payNote/${variation}`
     return (
       <BottomPanel expanded={expanded} button={(
         <Link route='pledge'>
@@ -144,11 +157,9 @@ export const After = compose(
   withMe,
   graphql(query),
   withInNativeApp
-)(({ t, me, data: { membershipStats }, isSeries, inNativeIOSApp, index, bottomBarRef }) => (
+)(({ t, me, data: { membershipStats }, inNativeIOSApp, variation, bottomBarRef }) => (
   <WithoutMembership render={() => {
-    const translationPrefix = isSeries
-      ? 'article/payNote/series'
-      : `article/payNote/${index}`
+    const translationPrefix = `article/payNote/${variation}`
     return (
       <div {...styles.secondaryContainer}>
         <Center>
@@ -198,3 +209,7 @@ export const After = compose(
     )
   }} />
 ))
+
+Before.propTypes = After.propTypes = {
+  variation: PropTypes.oneOf(ACTIVE_VARIATIONS.concat('series')).isRequired
+}

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -39,7 +39,8 @@ const styles = {
   }),
   beforeParagraph: css({
     margin: 0,
-    ...fontStyles.sansSerifRegular15,
+    ...fontStyles.sansSerifRegular14,
+    lineHeight: '20px',
     [mediaQueries.mUp]: {
       ...fontStyles.sansSerifRegular21
     }

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -101,9 +101,9 @@ export const Before = compose(
           <div {...styles.actions}>
             <Button primary style={multiLineButtonStyle}>
               <Link key='buy' route='pledge'>
-                <a {...linkRule} style={{ color: 'inherit' }}>
+                <span {...linkRule} style={{ color: 'inherit' }}>
                   {t(`${translationPrefix}/before/buy/button`)}
-                </a>
+                </span>
               </Link>
             </Button>
           </div>
@@ -142,9 +142,9 @@ export const After = compose(
               <Fragment>
                 <Button primary style={multiLineButtonStyle}>
                   <Link key='buy' route='pledge'>
-                    <a {...linkRule} style={{ color: 'inherit' }}>
+                    <span {...linkRule} style={{ color: 'inherit' }}>
                       {t(`${translationPrefix}/after/buy/button`)}
-                    </a>
+                    </span>
                   </Link>
                 </Button>
                 {!me && (
@@ -152,9 +152,9 @@ export const After = compose(
                     {t.elements('article/payNote/secondaryAction/text', {
                       link: (
                         <Link key='preview' route='preview'>
-                          <a {...linkRule} style={{whiteSpace: 'nowrap'}}>
+                          <span {...linkRule} style={{whiteSpace: 'nowrap'}}>
                             {t('article/payNote/secondaryAction/linkText')}
-                          </a>
+                          </span>
                         </Link>
                       )
                     })}

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -99,13 +99,11 @@ export const Before = compose(
         </div>
         {!inNativeIOSApp && (
           <div {...styles.actions}>
-            <Button primary style={multiLineButtonStyle}>
-              <Link key='buy' route='pledge'>
-                <span {...linkRule} style={{ color: 'inherit' }}>
-                  {t(`${translationPrefix}/before/buy/button`)}
-                </span>
-              </Link>
-            </Button>
+            <Link key='buy' route='pledge'>
+              <Button primary style={multiLineButtonStyle}>
+                {t(`${translationPrefix}/before/buy/button`)}
+              </Button>
+            </Link>
           </div>
         )}
       </BottomPanel>
@@ -140,21 +138,19 @@ export const After = compose(
           <div {...styles.actions} ref={bottomBarRef}>
             {!inNativeIOSApp && (
               <Fragment>
-                <Button primary style={multiLineButtonStyle}>
-                  <Link key='buy' route='pledge'>
-                    <span {...linkRule} style={{ color: 'inherit' }}>
-                      {t(`${translationPrefix}/after/buy/button`)}
-                    </span>
-                  </Link>
-                </Button>
+                <Link key='buy' route='pledge'>
+                  <Button primary style={multiLineButtonStyle}>
+                    {t(`${translationPrefix}/after/buy/button`)}
+                  </Button>
+                </Link>
                 {!me && (
                   <div {...styles.aside}>
                     {t.elements('article/payNote/secondaryAction/text', {
                       link: (
                         <Link key='preview' route='preview'>
-                          <span {...linkRule} style={{whiteSpace: 'nowrap'}}>
+                          <a {...linkRule} style={{whiteSpace: 'nowrap'}}>
                             {t('article/payNote/secondaryAction/linkText')}
-                          </span>
+                          </a>
                         </Link>
                       )
                     })}

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -37,6 +37,13 @@ const styles = {
       paddingRight: 0
     }
   }),
+  beforeParagraph: css({
+    margin: 0,
+    ...fontStyles.sansSerifRegular15,
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifRegular21
+    }
+  }),
   afterContainer: css({
     padding: '15px 0',
     backgroundColor: colors.secondaryBg,
@@ -81,13 +88,13 @@ export const Before = compose(
     return (
       <BottomPanel expanded={expanded}>
         <div {...styles.beforeContent}>
-          <Interaction.P style={{ color: 'inherit' }}>
+          <p {...styles.beforeParagraph}>
             {t.elements(`${translationPrefix}/before${inNativeIOSApp ? '/ios' : ''}`, {
               count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
                 (memberStats && memberStats.count) || 20000
               )}</span>
             })}
-          </Interaction.P>
+          </p>
         </div>
         {!inNativeIOSApp && (
           <div {...styles.actions}>

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -90,7 +90,7 @@ export const Before = compose(
       <BottomPanel expanded={expanded}>
         <div {...styles.beforeContent}>
           <p {...styles.beforeParagraph}>
-            {t.elements(`${translationPrefix}/before${inNativeIOSApp ? '/ios' : ''}`, {
+            {t.elements(inNativeIOSApp ? 'article/payNote/before/ios' : `${translationPrefix}/before`, {
               count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
                 (memberStats && memberStats.count) || 20000
               )}</span>
@@ -130,7 +130,7 @@ export const After = compose(
             {t(`${translationPrefix}/after/title`)}
           </Interaction.H3>
           <Interaction.P>
-            {t.elements(`${translationPrefix}/after${inNativeIOSApp ? '/ios' : ''}`, {
+            {t.elements(inNativeIOSApp ? 'article/payNote/after/ios' : `${translationPrefix}/after`, {
               count: <span style={{whiteSpace: 'nowrap'}} key='count'>{countFormat(
                 (memberStats && memberStats.count) || 20000
               )}</span>

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -83,7 +83,7 @@ const multiLineButtonStyle = {
 
 const query = gql`
 query payNoteMembershipStats {
-  memberStats {
+  membershipStats {
     count
   }
 }
@@ -92,9 +92,9 @@ query payNoteMembershipStats {
 // The total number of paynote translation variations in lib/translations.json
 export const NUM_VARIATIONS = 9
 
-const CountSpan = ({ memberStats }) => (
+const CountSpan = ({ membershipStats }) => (
   <span style={{whiteSpace: 'nowrap'}}>{countFormat(
-    (memberStats && memberStats.count) || 20000
+    (membershipStats && membershipStats.count) || 20000
   )}</span>
 )
 
@@ -102,7 +102,7 @@ export const Before = compose(
   withT,
   graphql(query),
   withInNativeApp
-)(({ t, data: { memberStats }, isSeries, inNativeIOSApp, index, expanded }) => (
+)(({ t, data: { membershipStats }, isSeries, inNativeIOSApp, index, expanded }) => (
   <WithoutMembership render={() => {
     if (inNativeIOSApp) {
       return (
@@ -110,7 +110,7 @@ export const Before = compose(
           <Center>
             <Interaction.P style={{color: 'inherit'}}>
               {t.elements('article/payNote/before/ios', {
-                count: <CountSpan key='count' memberStats={memberStats} />
+                count: <CountSpan key='count' membershipStats={membershipStats} />
               })}
             </Interaction.P>
           </Center>
@@ -125,7 +125,7 @@ export const Before = compose(
         <div {...styles.beforeContent}>
           <p {...styles.beforeParagraph}>
             {t.elements(`${translationPrefix}/before`, {
-              count: <CountSpan key='count' memberStats={memberStats} />
+              count: <CountSpan key='count' membershipStats={membershipStats} />
             })}
           </p>
         </div>
@@ -146,7 +146,7 @@ export const After = compose(
   withMe,
   graphql(query),
   withInNativeApp
-)(({ t, me, data: { memberStats }, isSeries, inNativeIOSApp, index, bottomBarRef }) => (
+)(({ t, me, data: { membershipStats }, isSeries, inNativeIOSApp, index, bottomBarRef }) => (
   <WithoutMembership render={() => {
     const translationPrefix = isSeries
       ? 'article/payNote/series'
@@ -158,7 +158,7 @@ export const After = compose(
             <div ref={bottomBarRef}>
               <Interaction.P>
                 {t.elements('article/payNote/after/ios', {
-                  count: <CountSpan key='count' memberStats={memberStats} />
+                  count: <CountSpan key='count' membershipStats={membershipStats} />
                 })}
               </Interaction.P>
             </div>
@@ -169,7 +169,7 @@ export const After = compose(
               </Interaction.H3>
               <Interaction.P>
                 {t.elements(`${translationPrefix}/after`, {
-                  count: <CountSpan key='count' memberStats={memberStats} />
+                  count: <CountSpan key='count' membershipStats={membershipStats} />
                 })}
               </Interaction.P>
               <br />

--- a/components/Article/PayNote.js
+++ b/components/Article/PayNote.js
@@ -148,24 +148,32 @@ export const After = compose(
   withInNativeApp
 )(({ t, me, data: { memberStats }, isSeries, inNativeIOSApp, index, bottomBarRef }) => (
   <WithoutMembership render={() => {
-    const translationPrefix = !inNativeIOSApp && isSeries
+    const translationPrefix = isSeries
       ? 'article/payNote/series'
       : `article/payNote/${index}`
     return (
       <div {...styles.secondaryContainer}>
         <Center>
-          <Interaction.H3 style={{ marginBottom: 15 }}>
-            {t(`${translationPrefix}/after/title`)}
-          </Interaction.H3>
-          <Interaction.P>
-            {t.elements(inNativeIOSApp ? 'article/payNote/after/ios' : `${translationPrefix}/after`, {
-              count: <CountSpan key='count' memberStats={memberStats} />
-            })}
-          </Interaction.P>
-          <br />
-          <div {...styles.actions} ref={bottomBarRef}>
-            {!inNativeIOSApp && (
-              <Fragment>
+          {inNativeIOSApp ? (
+            <div ref={bottomBarRef}>
+              <Interaction.P>
+                {t.elements('article/payNote/after/ios', {
+                  count: <CountSpan key='count' memberStats={memberStats} />
+                })}
+              </Interaction.P>
+            </div>
+          ) : (
+            <Fragment>
+              <Interaction.H3 style={{ marginBottom: 15 }}>
+                {t(`${translationPrefix}/after/title`)}
+              </Interaction.H3>
+              <Interaction.P>
+                {t.elements(`${translationPrefix}/after`, {
+                  count: <CountSpan key='count' memberStats={memberStats} />
+                })}
+              </Interaction.P>
+              <br />
+              <div {...styles.actions} ref={bottomBarRef}>
                 <Link key='buy' route='pledge'>
                   <Button primary style={multiLineButtonStyle}>
                     {t(`${translationPrefix}/after/buy/button`)}
@@ -184,9 +192,9 @@ export const After = compose(
                     })}
                   </div>
                 )}
-              </Fragment>
-            )}
-          </div>
+              </div>
+            </Fragment>
+          )}
         </Center>
       </div>
     )

--- a/components/Article/PayNoteBottomPanel.js
+++ b/components/Article/PayNoteBottomPanel.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { compose } from 'react-apollo'
 import { css } from 'glamor'
 import withT from '../../lib/withT'
+import { trackEventOnClick } from '../../lib/piwik'
 
 import Close from 'react-icons/lib/md/close'
 import {
@@ -110,8 +111,8 @@ class BottomPanel extends Component {
           <button
             {...styles.plainButton}
             {...styles.close}
-            onClick={this.close}
-            title={t('article/bottomPanel/close')}
+            onClick={trackEventOnClick(['PayNote', 'close panel', 'x'], this.close)}
+            title={t('article/payNote/bottomPanel/close')}
           >
             <Close size={32} fill={negativeColors.lightText} />
           </button>
@@ -125,9 +126,9 @@ class BottomPanel extends Component {
             <button
               {...styles.later}
               {...styles.plainButton}
-              onClick={this.close}
+              onClick={trackEventOnClick(['PayNote', 'close panel', 'later'], this.close)}
             >
-              {t('article/bottomPanel/actions/later')}
+              {t('article/payNote/bottomPanel/actions/later')}
             </button>
           </div>
         </Center>

--- a/components/Article/PayNoteBottomPanel.js
+++ b/components/Article/PayNoteBottomPanel.js
@@ -103,7 +103,7 @@ class BottomPanel extends Component {
   }
 
   render () {
-    const { t, children, button, expanded } = this.props
+    const { t, children, button, expanded, variation } = this.props
 
     return (
       <div aria-expanded={expanded && this.state.expanded} {...styles.container}>
@@ -111,7 +111,7 @@ class BottomPanel extends Component {
           <button
             {...styles.plainButton}
             {...styles.close}
-            onClick={trackEventOnClick(['PayNote', 'close panel', 'x'], this.close)}
+            onClick={trackEventOnClick(['PayNote', 'close panel', variation], this.close)}
             title={t('article/payNote/bottomPanel/close')}
           >
             <Close size={32} fill={negativeColors.lightText} />
@@ -126,7 +126,7 @@ class BottomPanel extends Component {
             <button
               {...styles.later}
               {...styles.plainButton}
-              onClick={trackEventOnClick(['PayNote', 'close panel', 'later'], this.close)}
+              onClick={trackEventOnClick(['PayNote', 'later panel', variation], this.close)}
             >
               {t('article/payNote/bottomPanel/actions/later')}
             </button>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -22,9 +22,9 @@ import { ListWithQuery } from '../Testimonial/List'
 
 import { buttonStyles } from './styles'
 
-const GET_MEMBERSTATS = gql`
-query members {
-  memberStats {
+const query = gql`
+query marketingMembershipStats {
+  membershipStats {
     count
   }
 }
@@ -165,7 +165,7 @@ const styles = {
   })
 }
 
-const MarketingPage = ({ me, t, crowdfundingName, loading, data: { memberStats }, ...props }) => {
+const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipStats }, ...props }) => {
   return (
     <Fragment>
       <Container>
@@ -200,11 +200,11 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { memberStats }
             </button>
           </Link>
         </div>
-        {!loading && memberStats && <div {...styles.communityWidget}>
+        {!loading && membershipStats && <div {...styles.communityWidget}>
           <Interaction.H2 {...styles.communityHeadline}>
             {t(
               'marketing/community/title',
-              { count: countFormat(memberStats.count) }
+              { count: countFormat(membershipStats.count) }
             )}
           </Interaction.H2>
           <ListWithQuery singleRow first={6} onSelect={(id) => {
@@ -227,5 +227,5 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { memberStats }
 
 export default compose(
   withT,
-  graphql(GET_MEMBERSTATS)
+  graphql(query)
 )(MarketingPage)

--- a/components/Search/index.js
+++ b/components/Search/index.js
@@ -3,6 +3,7 @@ import { css } from 'glamor'
 import debounce from 'lodash.debounce'
 
 import { Router } from '../../lib/routes'
+import track from '../../lib/piwik'
 
 import { DEFAULT_FILTERS } from './constants'
 import {
@@ -87,7 +88,7 @@ class Search extends Component {
         allowFocus: !this.state.isMobile
       })
       this.updateUrl(undefined, serializeSort(sort))
-      window._paq.push(['trackSiteSearch',
+      track(['trackSiteSearch',
         this.state.searchQuery,
         false,
         this.state.totalCount
@@ -180,7 +181,7 @@ class Search extends Component {
       })
       this.updateUrl(serializedFilters, this.state.serializedSort)
       if (!selected) {
-        window._paq.push(['trackSiteSearch',
+        track(['trackSiteSearch',
           this.state.searchQuery,
           decodeURIComponent(serializedFilters),
           count

--- a/components/constants.js
+++ b/components/constants.js
@@ -18,9 +18,9 @@ export const CONTENT_PADDING = 60
 
 export const ZINDEX_LOADINGBAR = 30
 export const ZINDEX_POPOVER = 25
-export const ZINDEX_BOTTOM_PANEL = 24
 export const ZINDEX_HEADER = 20
 export const ZINDEX_NAVBAR = 19
+export const ZINDEX_BOTTOM_PANEL = 16
 export const ZINDEX_CONTENT = 15
 export const ZINDEX_FOOTER = 11
 export const ZINDEX_SIDEBAR = 10

--- a/components/constants.js
+++ b/components/constants.js
@@ -18,6 +18,7 @@ export const CONTENT_PADDING = 60
 
 export const ZINDEX_LOADINGBAR = 30
 export const ZINDEX_POPOVER = 25
+export const ZINDEX_BOTTOM_PANEL = 24
 export const ZINDEX_HEADER = 20
 export const ZINDEX_NAVBAR = 19
 export const ZINDEX_CONTENT = 15

--- a/lib/piwik.js
+++ b/lib/piwik.js
@@ -20,3 +20,22 @@ const track = (...args) => {
 }
 
 export default track
+
+export const trackEventOnClick = ([category, action, name, value], onClick) => e => {
+  track([
+    'trackEvent',
+    category,
+    action,
+    name,
+    value
+  ])
+
+  if (e.currentTarget.nodeName === 'A' &&
+    (e.metaKey || e.ctrlKey || e.shiftKey || (e.nativeEvent && e.nativeEvent.which === 2))) {
+    // ignore click for new tab / new window behavior
+    return
+  }
+
+  e.preventDefault()
+  onClick(e)
+}

--- a/lib/polyfill.js
+++ b/lib/polyfill.js
@@ -7,3 +7,18 @@ import 'core-js/fn/string/starts-with'
 import 'core-js/es6/set'
 import 'core-js/es6/map'
 import 'core-js/es6/weak-map'
+
+// Workaround https://stackoverflow.com/questions/52390368
+// Based on github.com/fanmingfei/array-reverse-ios12 by 明非
+function buggyReverse () {
+  const a = [1, 2]
+  return String(a) === String(a.reverse())
+}
+if (buggyReverse()) {
+  const originalReverse = Array.prototype.reverse
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.reverse = function reverse () {
+    if (Array.isArray(this)) this.length = this.length
+    return originalReverse.call(this)
+  }
+}

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-20T09:27:00.463Z",
+  "updated": "2018-09-20T10:05:56.112Z",
   "title": "live",
   "data": [
     {
@@ -2619,11 +2619,11 @@
       "value": "Ich bin an Bord."
     },
     {
-      "key": "article/bottomPanel/close",
+      "key": "article/payNote/bottomPanel/close",
       "value": "Schliessen"
     },
     {
-      "key": "article/bottomPanel/actions/later",
+      "key": "article/payNote/bottomPanel/actions/later",
       "value": "Später"
     },
     {

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-13T14:43:14.121Z",
+  "updated": "2018-09-15T12:53:26.807Z",
   "title": "live",
   "data": [
     {
@@ -876,7 +876,7 @@
     },
     {
       "key": "Account/Access/Grants/link/pledges",
-      "value": "Klicken Sie hier um Ihre eigenes Abonnement zu kaufen"
+      "value": "Klicken Sie hier, um Ihr eigenes Abonnement zu kaufen"
     },
     {
       "key": "Account/Access/Campaigns/title",
@@ -2420,7 +2420,7 @@
     },
     {
       "key": "article/payNote/series/before",
-      "value": "Dieser Artikel ist Teil einer Serie. Werden Sie Verleger, um alle Episoden zu lesen."
+      "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
       "key": "article/payNote/series/before/ios",
@@ -2428,15 +2428,15 @@
     },
     {
       "key": "article/payNote/series/before/buy/button",
-      "value": "Jetzt Verleger werden"
+      "value": "Ja, ich will!"
     },
     {
       "key": "article/payNote/series/after/title",
-      "value": "Hat Ihnen dieser Artikel gefallen?"
+      "value": "Wollen Sie mehr lesen?"
     },
     {
       "key": "article/payNote/series/after",
-      "value": "Dieser Artikel ist Teil einer Serie. Werden Sie Verleger, um alle Episoden zu lesen."
+      "value": "Dieser Beitrag ist Teil einer Serie. Wollen Sie die ganze Geschichte? Dann kommen Sie an Bord! Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität."
     },
     {
       "key": "article/payNote/series/after/ios",
@@ -2444,131 +2444,131 @@
     },
     {
       "key": "article/payNote/series/after/buy/button",
-      "value": "Jetzt Verleger werden"
+      "value": "An Bord kommen!"
     },
     {
       "key": "article/payNote/0/before",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+      "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser Online-Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
       "key": "article/payNote/0/before/buy/button",
-      "value": "Kommen Sie an Bord!"
+      "value": "Ja, ich will!"
     },
     {
       "key": "article/payNote/0/after/title",
-      "value": "Schön, Sie hier unten wieder zu sehen! "
+      "value": "Wenn Sie schon hier sind …"
     },
     {
       "key": "article/payNote/0/after",
-      "value": "Es wäre uns eine Freude, wenn Sie bei der Republik Verlegerin oder Verleger würden. Wir versprechen Ihnen dafür Journalismus ohne Kompromisse: ohne Schnörkel, ohne Werbung, ohne Ausreden bei Fehlern."
+      "value": "… treffen Sie eine Entscheidung: Wollen Sie, dass die noch junge Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind niemandem verpflichtet ausser unseren Leserinnen, unserem Gewissen und dem Kampf gegen die Langeweile. Weder Oligarchen noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Doch das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
     },
     {
       "key": "article/payNote/0/after/buy/button",
-      "value": "Jetzt Verleger werden"
+      "value": "Ich bin dabei."
     },
     {
       "key": "article/payNote/1/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik. Wir liefern Journalismus – mit Sorgfalt, mit Tiefe, mit Witz, aber ohne Werbung. Unser Ziel ist, Ihnen das Wesentliche zu liefern. Also nicht das Wetter, sondern das Klima. Denn wir wollen Ihre Zeit nicht mit Unfug verschwenden. Wollen Sie täglich das Beste, was wir zustande bringen?"
     },
     {
       "key": "article/payNote/1/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Republik abonnieren!"
     },
     {
       "key": "article/payNote/1/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Wenn Sie gerade da sind …"
     },
     {
       "key": "article/payNote/1/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "… hat Ihnen dieser Beitrag gefallen? Wir sind die Republik. Ein unabhängiges Online-Magazin, das vergangenen Januar gestartet ist. Unser Job ist, Ihnen jeden Tag Artikel zu liefern, die in die Tiefe gehen. Die besten Analysen, Reportagen, Interviews, Kulturrezensionen, Bundeshausnachrichten, die wir hinkriegen. Wollen Sie ab heute jeden Tag das Klügste lesen, was uns einfällt?"
     },
     {
       "key": "article/payNote/1/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Republik abonnieren!"
     },
     {
       "key": "article/payNote/2/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "{count} Verlegerinnen können sich vielleicht irren. Aber alle haben den Mut gehabt, die Republik zu unterstützen. Unser kühnes Ziel: eine gewichtige Stimme in der Schweizer Medienlandschaft zu sein. Das können wir nicht allein, sondern nur gemeinsam. Mit Ihnen?"
     },
     {
       "key": "article/payNote/2/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Verleger werden!"
     },
     {
       "key": "article/payNote/2/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Wenn Sie schon da sind …"
     },
     {
       "key": "article/payNote/2/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "… wir sind die Republik, ein junges Medienunternehmen mit {count} Verlegerinnen und Journalisten. Unser Ziel: eine gewichtige Stimme in der Schweizer Medienlandschaft zu sein. Und eine vernünftige in der politischen Debatte. Unser digitales Magazin berichtet über Politik, Wirtschaft, Gesellschaft und Kultur. Dafür brauchen wir Sie. Wollen Sie Verlegerin oder Verleger der Republik werden?"
     },
     {
       "key": "article/payNote/2/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Unbedingt!"
     },
     {
       "key": "article/payNote/3/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik. Ein digitales Magazin für Politik, Gesellschaft, Wirtschaft, Kultur, das im Januar 2018 gestartet ist. Es ist ein Projekt gegen die Wahrscheinlichkeit: Wir wollen im winzigen Schweizer Markt ausschliesslich von unseren Leserinnen finanziert sein. Wollen Sie Teil dieses Abenteuers sein?"
     },
     {
       "key": "article/payNote/3/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Natürlich!"
     },
     {
       "key": "article/payNote/3/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Wenn Sie gerade da sind …"
     },
     {
       "key": "article/payNote/3/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "… wollen Sie heute ein Risiko eingehen? Und zusammen mit uns Ihre Zeit, Ihr Vertrauen und Ihr Geld in unabhängigen Journalismus investieren? Entweder mit Vorsicht via ein monatlich kündbares Abonnement? Oder tollkühn via eines über ein Jahr?"
     },
     {
       "key": "article/payNote/3/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Ja, ich wage es!"
     },
     {
       "key": "article/payNote/4/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin ist unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
       "key": "article/payNote/4/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Republik unterstützen!"
     },
     {
       "key": "article/payNote/4/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Da Sie schon hier sind – eine Warnung!"
     },
     {
       "key": "article/payNote/4/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "Wir von der Republik wollen Sie als Abonnentin gewinnen. Deshalb sagen wir Ihnen nur ungern, dass Lesen nicht ohne Risiko ist. Schopenhauer warnte, dass gleichsam mit fremdem Kopf denkt, wer liest. Und dadurch allmählich die Fähigkeit verliert, selber zu denken. Sein Schluss: «Solches aber ist der Fall sehr vieler Gelehrter: Sie haben sich dumm gelesen.» Deshalb versprechen wir Ihnen, falls Sie uns abonnieren, Ihnen so wenig wie möglich zu liefern: nur das Wesentliche. Und nur im Notfall mehr als drei Texte pro Tag. "
     },
     {
       "key": "article/payNote/4/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Okay, weniger ist mehr!"
     },
     {
       "key": "article/payNote/5/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik und haben das ehrgeizige Ziel, für Sie so etwas wie die Steuererklärung zu werden. Denn unabhängiger Journalismus ist wie die Steuern – ein notwendiges Ärgernis. Wie der US-Republikaner Oliver Wendell Holmes (1841–1935) sagte: «Ich zahle gerne Steuern. Damit kaufe ich mir Zivilisation.»"
     },
     {
       "key": "article/payNote/5/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Zivilisation kaufen!"
     },
     {
       "key": "article/payNote/5/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Wenn Sie schon hier sind …"
     },
     {
       "key": "article/payNote/5/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "Wir sind die Republik – ein digitales Magazin ohne Werbung und ohne Kompromisse im Journalismus. Und hätten Sie gerne an Bord. Mit dem ehrgeizigen Ziel, für Sie so etwas wie Ihre Steuererklärung zu werden. Denn unabhängiger Journalismus ist wie die Steuern – ein notwendiges Ärgernis. Ganz so, wie es der US-Republikaner Oliver Wendell Holmes (1841-1935) sagte: «Ich zahle gerne Steuern. Damit kaufe ich mir Zivilisation.»"
     },
     {
       "key": "article/payNote/5/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Ich kaufe Zivilisation."
     },
     {
       "key": "article/payNote/6/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin ist unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
       "key": "article/payNote/6/before/buy/button",
@@ -2576,55 +2576,55 @@
     },
     {
       "key": "article/payNote/6/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Ihr Urteil?"
     },
     {
       "key": "article/payNote/6/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "Ihr Urteil lautet natürlich: Sie sind zur Freiheit verurteilt – lebenslänglich. Und zwar von Jean-Paul Sartre, der Konsumgüterindustrie, der liberalen Revolution von 1848, dem Feminismus, dem Historienfilm «Braveheart», Pippi Langstrumpf, der Verfassung, dem Zufall. Und von uns. Es wäre schön, wenn Sie sich die Freiheit nehmen würden, bei unserem Magazin an Bord zu kommen."
     },
     {
       "key": "article/payNote/6/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Freiheit nehmen!"
     },
     {
       "key": "article/payNote/7/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Sie glauben, dass Meinungsvielfalt darin besteht, dass es linke und rechte Medien gibt? Die dann im Schützengraben aufeinander schiessen? Wir glauben das nicht. Die Aufgabe des Journalismus ist, eine gemeinsame Grundlage zu schaffen, auf der man um seine Interessen kämpft. Dafür arbeitet die Republik."
     },
     {
       "key": "article/payNote/7/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Republik abonnieren!"
     },
     {
       "key": "article/payNote/7/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "War dieser Artikel genug Mainstream?"
     },
     {
       "key": "article/payNote/7/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "Sie glauben, dass Meinungsvielfalt darin besteht, dass es linke und rechte Medien gibt? Die dann im Schützengraben aufeinander schiessen? Wir glauben das nicht. Denn in einem gespaltenen Mediensystem debattieren die Leute nicht über zwei Blickwinkel auf die Wirklichkeit. Sondern sie debattieren in zwei Wirklichkeiten. Die Aufgabe des Journalismus ist, eine gemeinsame Grundlage zu schaffen, auf der man dann um seine Interessen kämpft. Eine Gesellschaft ist nur so gut wie ihre Debatten. Dafür arbeiten wir in der Republik."
     },
     {
       "key": "article/payNote/7/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Ich bin dabei!"
     },
     {
       "key": "article/payNote/8/before",
-      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+      "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser Online-Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
       "key": "article/payNote/8/before/buy/button",
-      "value": "Ja, ich will!"
+      "value": "Republik unterstützen!"
     },
     {
       "key": "article/payNote/8/after/title",
-      "value": "Wenn Sie schon hier sind ..."
+      "value": "Sie haben in diesem Artikel viele Worte gelesen …"
     },
     {
       "key": "article/payNote/8/after",
-      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+      "value": "… aber die wichtigsten drei fehlten. Seit je beruht jede funktionierende Gemeinschaft auf diesen drei Worten. Liebende sagen sie zueinander. Gute Politiker sagen sie ihren Wählern, gute Priester ihrer Gemeinde, gute Eltern ihrem Kind. Sie lauten: Fürchte dich nicht! – Wir von der Republik glauben, dass auch im Journalismus gilt, was Franklin D. Roosevelt einst zur Politik sagte: «Wir haben nichts zu fürchten als die Furcht selbst.»"
     },
     {
       "key": "article/payNote/8/after/buy/button",
-      "value": "Jetzt Republik unterstützen"
+      "value": "Ich bin an Bord."
     },
     {
       "key": "article/bottomPanel/close",
@@ -3184,7 +3184,7 @@
     },
     {
       "key": "tokenAuthorization/fields/explanation",
-      "value": "Im Ihr Konto zu aktivieren, benötigen wir noch folgende Informationen:"
+      "value": "Um Ihr Konto zu aktivieren, benötigen wir noch folgende Informationen:"
     },
     {
       "key": "tokenAuthorization/fields/label/firstName",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-19T16:23:43.623Z",
+  "updated": "2018-09-20T09:27:00.463Z",
   "title": "live",
   "data": [
     {
@@ -2439,183 +2439,183 @@
       "value": "An Bord kommen!"
     },
     {
-      "key": "article/payNote/0/before",
+      "key": "article/payNote/180920-v1/before",
       "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser Online-Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
-      "key": "article/payNote/0/before/buy/button",
+      "key": "article/payNote/180920-v1/before/buy/button",
       "value": "Ja, ich will!"
     },
     {
-      "key": "article/payNote/0/after/title",
+      "key": "article/payNote/180920-v1/after/title",
       "value": "Wenn Sie schon hier sind …"
     },
     {
-      "key": "article/payNote/0/after",
+      "key": "article/payNote/180920-v1/after",
       "value": "… treffen Sie eine Entscheidung: Wollen Sie, dass die noch junge Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind niemandem verpflichtet ausser unseren Leserinnen, unserem Gewissen und dem Kampf gegen die Langeweile. Weder Oligarchen noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Doch das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
     },
     {
-      "key": "article/payNote/0/after/buy/button",
+      "key": "article/payNote/180920-v1/after/buy/button",
       "value": "Ich bin dabei."
     },
     {
-      "key": "article/payNote/1/before",
+      "key": "article/payNote/180920-v2/before",
       "value": "Wir sind die Republik. Wir liefern Journalismus – mit Sorgfalt, mit Tiefe, mit Witz, aber ohne Werbung. Unser Ziel ist, Ihnen das Wesentliche zu liefern. Also nicht das Wetter, sondern das Klima. Denn wir wollen Ihre Zeit nicht mit Unfug verschwenden. Wollen Sie täglich das Beste, was wir zustande bringen?"
     },
     {
-      "key": "article/payNote/1/before/buy/button",
+      "key": "article/payNote/180920-v2/before/buy/button",
       "value": "Republik abonnieren!"
     },
     {
-      "key": "article/payNote/1/after/title",
+      "key": "article/payNote/180920-v2/after/title",
       "value": "Wenn Sie gerade da sind …"
     },
     {
-      "key": "article/payNote/1/after",
+      "key": "article/payNote/180920-v2/after",
       "value": "… hat Ihnen dieser Beitrag gefallen? Wir sind die Republik. Ein unabhängiges Online-Magazin, das vergangenen Januar gestartet ist. Unser Job ist, Ihnen jeden Tag Artikel zu liefern, die in die Tiefe gehen. Die besten Analysen, Reportagen, Interviews, Kulturrezensionen, Bundeshausnachrichten, die wir hinkriegen. Wollen Sie ab heute jeden Tag das Klügste lesen, was uns einfällt?"
     },
     {
-      "key": "article/payNote/1/after/buy/button",
+      "key": "article/payNote/180920-v2/after/buy/button",
       "value": "Republik abonnieren!"
     },
     {
-      "key": "article/payNote/2/before",
+      "key": "article/payNote/180920-v3/before",
       "value": "{count} Verlegerinnen können sich vielleicht irren. Aber alle haben den Mut gehabt, die Republik zu unterstützen. Unser kühnes Ziel: eine gewichtige Stimme in der Schweizer Medienlandschaft zu sein. Das können wir nicht allein, sondern nur gemeinsam. Mit Ihnen?"
     },
     {
-      "key": "article/payNote/2/before/buy/button",
+      "key": "article/payNote/180920-v3/before/buy/button",
       "value": "Verleger werden!"
     },
     {
-      "key": "article/payNote/2/after/title",
+      "key": "article/payNote/180920-v3/after/title",
       "value": "Wenn Sie schon da sind …"
     },
     {
-      "key": "article/payNote/2/after",
+      "key": "article/payNote/180920-v3/after",
       "value": "… wir sind die Republik, ein junges Medienunternehmen mit {count} Verlegerinnen und Journalisten. Unser Ziel: eine gewichtige Stimme in der Schweizer Medienlandschaft zu sein. Und eine vernünftige in der politischen Debatte. Unser digitales Magazin berichtet über Politik, Wirtschaft, Gesellschaft und Kultur. Dafür brauchen wir Sie. Wollen Sie Verlegerin oder Verleger der Republik werden?"
     },
     {
-      "key": "article/payNote/2/after/buy/button",
+      "key": "article/payNote/180920-v3/after/buy/button",
       "value": "Unbedingt!"
     },
     {
-      "key": "article/payNote/3/before",
+      "key": "article/payNote/180920-v4/before",
       "value": "Wir sind die Republik. Ein digitales Magazin für Politik, Gesellschaft, Wirtschaft, Kultur, das im Januar 2018 gestartet ist. Es ist ein Projekt gegen die Wahrscheinlichkeit: Wir wollen im winzigen Schweizer Markt ausschliesslich von unseren Leserinnen finanziert sein. Wollen Sie Teil dieses Abenteuers sein?"
     },
     {
-      "key": "article/payNote/3/before/buy/button",
+      "key": "article/payNote/180920-v4/before/buy/button",
       "value": "Natürlich!"
     },
     {
-      "key": "article/payNote/3/after/title",
+      "key": "article/payNote/180920-v4/after/title",
       "value": "Wenn Sie gerade da sind …"
     },
     {
-      "key": "article/payNote/3/after",
+      "key": "article/payNote/180920-v4/after",
       "value": "… wollen Sie heute ein Risiko eingehen? Und zusammen mit uns Ihre Zeit, Ihr Vertrauen und Ihr Geld in unabhängigen Journalismus investieren? Entweder mit Vorsicht via ein monatlich kündbares Abonnement? Oder tollkühn via eines über ein Jahr?"
     },
     {
-      "key": "article/payNote/3/after/buy/button",
+      "key": "article/payNote/180920-v4/after/buy/button",
       "value": "Ja, ich wage es!"
     },
     {
-      "key": "article/payNote/4/before",
+      "key": "article/payNote/180920-v5/before",
       "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin ist unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
-      "key": "article/payNote/4/before/buy/button",
+      "key": "article/payNote/180920-v5/before/buy/button",
       "value": "Republik unterstützen!"
     },
     {
-      "key": "article/payNote/4/after/title",
+      "key": "article/payNote/180920-v5/after/title",
       "value": "Da Sie schon hier sind – eine Warnung!"
     },
     {
-      "key": "article/payNote/4/after",
+      "key": "article/payNote/180920-v5/after",
       "value": "Wir von der Republik wollen Sie als Abonnentin gewinnen. Deshalb sagen wir Ihnen nur ungern, dass Lesen nicht ohne Risiko ist. Schopenhauer warnte, dass gleichsam mit fremdem Kopf denkt, wer liest. Und dadurch allmählich die Fähigkeit verliert, selber zu denken. Sein Schluss: «Solches aber ist der Fall sehr vieler Gelehrter: Sie haben sich dumm gelesen.» Deshalb versprechen wir Ihnen, falls Sie uns abonnieren, Ihnen so wenig wie möglich zu liefern: nur das Wesentliche. Und nur im Notfall mehr als drei Texte pro Tag. "
     },
     {
-      "key": "article/payNote/4/after/buy/button",
+      "key": "article/payNote/180920-v5/after/buy/button",
       "value": "Okay, weniger ist mehr!"
     },
     {
-      "key": "article/payNote/5/before",
+      "key": "article/payNote/180920-v6/before",
       "value": "Wir sind die Republik und haben das ehrgeizige Ziel, für Sie so etwas wie die Steuererklärung zu werden. Denn unabhängiger Journalismus ist wie die Steuern – ein notwendiges Ärgernis. Wie der US-Republikaner Oliver Wendell Holmes (1841–1935) sagte: «Ich zahle gerne Steuern. Damit kaufe ich mir Zivilisation.»"
     },
     {
-      "key": "article/payNote/5/before/buy/button",
+      "key": "article/payNote/180920-v6/before/buy/button",
       "value": "Zivilisation kaufen!"
     },
     {
-      "key": "article/payNote/5/after/title",
+      "key": "article/payNote/180920-v6/after/title",
       "value": "Wenn Sie schon hier sind …"
     },
     {
-      "key": "article/payNote/5/after",
+      "key": "article/payNote/180920-v6/after",
       "value": "Wir sind die Republik – ein digitales Magazin ohne Werbung und ohne Kompromisse im Journalismus. Und hätten Sie gerne an Bord. Mit dem ehrgeizigen Ziel, für Sie so etwas wie Ihre Steuererklärung zu werden. Denn unabhängiger Journalismus ist wie die Steuern – ein notwendiges Ärgernis. Ganz so, wie es der US-Republikaner Oliver Wendell Holmes (1841-1935) sagte: «Ich zahle gerne Steuern. Damit kaufe ich mir Zivilisation.»"
     },
     {
-      "key": "article/payNote/5/after/buy/button",
+      "key": "article/payNote/180920-v6/after/buy/button",
       "value": "Ich kaufe Zivilisation."
     },
     {
-      "key": "article/payNote/6/before",
+      "key": "article/payNote/180920-v7/before",
       "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin ist unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
-      "key": "article/payNote/6/before/buy/button",
+      "key": "article/payNote/180920-v7/before/buy/button",
       "value": "Ja, ich will!"
     },
     {
-      "key": "article/payNote/6/after/title",
+      "key": "article/payNote/180920-v7/after/title",
       "value": "Ihr Urteil?"
     },
     {
-      "key": "article/payNote/6/after",
+      "key": "article/payNote/180920-v7/after",
       "value": "Ihr Urteil lautet natürlich: Sie sind zur Freiheit verurteilt – lebenslänglich. Und zwar von Jean-Paul Sartre, der Konsumgüterindustrie, der liberalen Revolution von 1848, dem Feminismus, dem Historienfilm «Braveheart», Pippi Langstrumpf, der Verfassung, dem Zufall. Und von uns. Es wäre schön, wenn Sie sich die Freiheit nehmen würden, bei unserem Magazin an Bord zu kommen."
     },
     {
-      "key": "article/payNote/6/after/buy/button",
+      "key": "article/payNote/180920-v7/after/buy/button",
       "value": "Freiheit nehmen!"
     },
     {
-      "key": "article/payNote/7/before",
+      "key": "article/payNote/180920-v8/before",
       "value": "Sie glauben, dass Meinungsvielfalt darin besteht, dass es linke und rechte Medien gibt? Die dann im Schützengraben aufeinander schiessen? Wir glauben das nicht. Die Aufgabe des Journalismus ist, eine gemeinsame Grundlage zu schaffen, auf der man um seine Interessen kämpft. Dafür arbeitet die Republik."
     },
     {
-      "key": "article/payNote/7/before/buy/button",
+      "key": "article/payNote/180920-v8/before/buy/button",
       "value": "Republik abonnieren!"
     },
     {
-      "key": "article/payNote/7/after/title",
+      "key": "article/payNote/180920-v8/after/title",
       "value": "War dieser Artikel genug Mainstream?"
     },
     {
-      "key": "article/payNote/7/after",
+      "key": "article/payNote/180920-v8/after",
       "value": "Sie glauben, dass Meinungsvielfalt darin besteht, dass es linke und rechte Medien gibt? Die dann im Schützengraben aufeinander schiessen? Wir glauben das nicht. Denn in einem gespaltenen Mediensystem debattieren die Leute nicht über zwei Blickwinkel auf die Wirklichkeit. Sondern sie debattieren in zwei Wirklichkeiten. Die Aufgabe des Journalismus ist, eine gemeinsame Grundlage zu schaffen, auf der man dann um seine Interessen kämpft. Eine Gesellschaft ist nur so gut wie ihre Debatten. Dafür arbeiten wir in der Republik."
     },
     {
-      "key": "article/payNote/7/after/buy/button",
+      "key": "article/payNote/180920-v8/after/buy/button",
       "value": "Ich bin dabei!"
     },
     {
-      "key": "article/payNote/8/before",
+      "key": "article/payNote/180920-v9/before",
       "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser Online-Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
-      "key": "article/payNote/8/before/buy/button",
+      "key": "article/payNote/180920-v9/before/buy/button",
       "value": "Republik unterstützen!"
     },
     {
-      "key": "article/payNote/8/after/title",
+      "key": "article/payNote/180920-v9/after/title",
       "value": "Sie haben in diesem Artikel viele Worte gelesen …"
     },
     {
-      "key": "article/payNote/8/after",
+      "key": "article/payNote/180920-v9/after",
       "value": "… aber die wichtigsten drei fehlten. Seit je beruht jede funktionierende Gemeinschaft auf diesen drei Worten. Liebende sagen sie zueinander. Gute Politiker sagen sie ihren Wählern, gute Priester ihrer Gemeinde, gute Eltern ihrem Kind. Sie lauten: Fürchte dich nicht! – Wir von der Republik glauben, dass auch im Journalismus gilt, was Franklin D. Roosevelt einst zur Politik sagte: «Wir haben nichts zu fürchten als die Furcht selbst.»"
     },
     {
-      "key": "article/payNote/8/after/buy/button",
+      "key": "article/payNote/180920-v9/after/buy/button",
       "value": "Ich bin an Bord."
     },
     {

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-15T12:53:26.807Z",
+  "updated": "2018-09-19T16:23:43.623Z",
   "title": "live",
   "data": [
     {
@@ -1096,7 +1096,7 @@
     },
     {
       "key": "profile/disclosures/label",
-      "value": "Interessenbindungen"
+      "value": "Interessenbindungen (optional)"
     },
     {
       "key": "profile/disclosures/tooLong",
@@ -2423,10 +2423,6 @@
       "value": "Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität. Wollen Sie unabhängigen Journalismus unterstützen, freuen wir uns, Sie an Bord zu sehen."
     },
     {
-      "key": "article/payNote/series/before/ios",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
-    },
-    {
       "key": "article/payNote/series/before/buy/button",
       "value": "Ja, ich will!"
     },
@@ -2437,10 +2433,6 @@
     {
       "key": "article/payNote/series/after",
       "value": "Dieser Beitrag ist Teil einer Serie. Wollen Sie die ganze Geschichte? Dann kommen Sie an Bord! Wir sind die Republik – ein neues Modell im Schweizer Journalismus. Unser digitales Magazin arbeitet unabhängig: keine Werbung, keine Klick-Wirtschaft, keine Kompromisse in der Qualität."
-    },
-    {
-      "key": "article/payNote/series/after/ios",
-      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
     },
     {
       "key": "article/payNote/series/after/buy/button",
@@ -2629,6 +2621,10 @@
     {
       "key": "article/bottomPanel/close",
       "value": "Schliessen"
+    },
+    {
+      "key": "article/bottomPanel/actions/later",
+      "value": "Später"
     },
     {
       "key": "article/share/title",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-13T07:49:58.629Z",
+  "updated": "2018-09-13T14:43:14.121Z",
   "title": "live",
   "data": [
     {
@@ -1093,6 +1093,14 @@
     {
       "key": "profile/biography/label",
       "value": "Steckbrief"
+    },
+    {
+      "key": "profile/disclosures/label",
+      "value": "Interessenbindungen"
+    },
+    {
+      "key": "profile/disclosures/tooLong",
+      "value": "Interessenbindungen, maximal 140 Zeichen"
     },
     {
       "key": "profile/statement/label",
@@ -2443,10 +2451,6 @@
       "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
     },
     {
-      "key": "article/payNote/0/before/ios",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
-    },
-    {
       "key": "article/payNote/0/before/buy/button",
       "value": "Kommen Sie an Bord!"
     },
@@ -2459,20 +2463,12 @@
       "value": "Es wäre uns eine Freude, wenn Sie bei der Republik Verlegerin oder Verleger würden. Wir versprechen Ihnen dafür Journalismus ohne Kompromisse: ohne Schnörkel, ohne Werbung, ohne Ausreden bei Fehlern."
     },
     {
-      "key": "article/payNote/0/after/ios",
-      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
-    },
-    {
       "key": "article/payNote/0/after/buy/button",
       "value": "Jetzt Verleger werden"
     },
     {
       "key": "article/payNote/1/before",
       "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
-    },
-    {
-      "key": "article/payNote/1/before/ios",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
     },
     {
       "key": "article/payNote/1/before/buy/button",
@@ -2487,20 +2483,12 @@
       "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
     },
     {
-      "key": "article/payNote/1/after/ios",
-      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
-    },
-    {
       "key": "article/payNote/1/after/buy/button",
       "value": "Jetzt Republik unterstützen"
     },
     {
       "key": "article/payNote/2/before",
       "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
-    },
-    {
-      "key": "article/payNote/2/before/ios",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
     },
     {
       "key": "article/payNote/2/before/buy/button",
@@ -2515,20 +2503,12 @@
       "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
     },
     {
-      "key": "article/payNote/2/after/ios",
-      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
-    },
-    {
       "key": "article/payNote/2/after/buy/button",
       "value": "Jetzt Republik unterstützen"
     },
     {
       "key": "article/payNote/3/before",
       "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
-    },
-    {
-      "key": "article/payNote/3/before/ios",
-      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
     },
     {
       "key": "article/payNote/3/before/buy/button",
@@ -2543,11 +2523,107 @@
       "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
     },
     {
-      "key": "article/payNote/3/after/ios",
-      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+      "key": "article/payNote/3/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
     },
     {
-      "key": "article/payNote/3/after/buy/button",
+      "key": "article/payNote/4/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/4/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/4/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/4/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/4/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/5/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/5/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/5/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/5/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/5/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/6/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/6/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/6/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/6/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/6/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/7/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/7/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/7/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/7/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/7/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/8/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/8/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/8/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/8/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/8/after/buy/button",
       "value": "Jetzt Republik unterstützen"
     },
     {

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-10T19:11:36.686Z",
+  "updated": "2018-09-13T07:49:58.629Z",
   "title": "live",
   "data": [
     {
@@ -2401,6 +2401,158 @@
     {
       "key": "article/payNote/after/series",
       "value": "Dieser Artikel ist Teil einer Serie. Werden Sie Verleger, um alle Episoden zu lesen."
+    },
+    {
+      "key": "article/payNote/secondaryAction/text",
+      "value": "Noch nicht überzeugt? {link}"
+    },
+    {
+      "key": "article/payNote/secondaryAction/linkText",
+      "value": "Jetzt probelesen"
+    },
+    {
+      "key": "article/payNote/series/before",
+      "value": "Dieser Artikel ist Teil einer Serie. Werden Sie Verleger, um alle Episoden zu lesen."
+    },
+    {
+      "key": "article/payNote/series/before/ios",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/series/before/buy/button",
+      "value": "Jetzt Verleger werden"
+    },
+    {
+      "key": "article/payNote/series/after/title",
+      "value": "Hat Ihnen dieser Artikel gefallen?"
+    },
+    {
+      "key": "article/payNote/series/after",
+      "value": "Dieser Artikel ist Teil einer Serie. Werden Sie Verleger, um alle Episoden zu lesen."
+    },
+    {
+      "key": "article/payNote/series/after/ios",
+      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+    },
+    {
+      "key": "article/payNote/series/after/buy/button",
+      "value": "Jetzt Verleger werden"
+    },
+    {
+      "key": "article/payNote/0/before",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/0/before/ios",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/0/before/buy/button",
+      "value": "Kommen Sie an Bord!"
+    },
+    {
+      "key": "article/payNote/0/after/title",
+      "value": "Schön, Sie hier unten wieder zu sehen! "
+    },
+    {
+      "key": "article/payNote/0/after",
+      "value": "Es wäre uns eine Freude, wenn Sie bei der Republik Verlegerin oder Verleger würden. Wir versprechen Ihnen dafür Journalismus ohne Kompromisse: ohne Schnörkel, ohne Werbung, ohne Ausreden bei Fehlern."
+    },
+    {
+      "key": "article/payNote/0/after/ios",
+      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+    },
+    {
+      "key": "article/payNote/0/after/buy/button",
+      "value": "Jetzt Verleger werden"
+    },
+    {
+      "key": "article/payNote/1/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/1/before/ios",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/1/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/1/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/1/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/1/after/ios",
+      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+    },
+    {
+      "key": "article/payNote/1/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/2/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/2/before/ios",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/2/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/2/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/2/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/2/after/ios",
+      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+    },
+    {
+      "key": "article/payNote/2/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/payNote/3/before",
+      "value": "Wir sind die Republik. Ein Online-Magazin, das vergangenen Januar gestartet ist. Wir sind crowdfunded und getrieben von unserem Willen, eine gewichtige unabhängige Stimme in der Schweizer Medienlandschaft zu sein. Wollen Sie mit einer Mitgliedschaft unabhängigen Journalismus unterstützen?"
+    },
+    {
+      "key": "article/payNote/3/before/ios",
+      "value": "Danke für Ihre Neugier! Dieser Artikel wurde grosszügigerweise für Sie von einer unserer {count} Verlegerinnen und Verleger freigeschaltet."
+    },
+    {
+      "key": "article/payNote/3/before/buy/button",
+      "value": "Ja, ich will!"
+    },
+    {
+      "key": "article/payNote/3/after/title",
+      "value": "Wenn Sie schon hier sind ..."
+    },
+    {
+      "key": "article/payNote/3/after",
+      "value": "... Hand aufs Herz: wollen Sie, dass die Republik weiterhin unabhängigen Journalismus betreiben kann? Wir sind unabhängig und niemandem verpflichtet, ausser unseren Leserinnen und unserem Anspruch als Journalisten. Weder Oligarchen, noch Werbetreibende haben einen Einfluss auf unsere Berichterstattung. Das funktioniert nur, wenn viele uns dabei unterstützen. {count} tun dies bereits."
+    },
+    {
+      "key": "article/payNote/3/after/ios",
+      "value": "Schön, Sie hier unten wieder zu sehen! Wir hoffen, es hat Ihnen gefallen."
+    },
+    {
+      "key": "article/payNote/3/after/buy/button",
+      "value": "Jetzt Republik unterstützen"
+    },
+    {
+      "key": "article/bottomPanel/close",
+      "value": "Schliessen"
     },
     {
       "key": "article/share/title",

--- a/pages/article.js
+++ b/pages/article.js
@@ -1,5 +1,4 @@
-import { compose } from 'react-apollo'
 import withData from '../lib/apollo/withData'
 import Page from '../components/Article/Page'
 
-export default compose(withData)(Page)
+export default withData(Page)

--- a/pages/front.js
+++ b/pages/front.js
@@ -33,8 +33,7 @@ class FrontPage extends Component {
     if (isPathKnown(url) && !isMember && !inNativeIOSApp) {
       if (serverContext) {
         const indexPath = routes
-          .filter(r => r.name === 'index')
-          .shift()
+          .find(r => r.name === 'index')
           .toPath()
 
         serverContext.res.redirect(302, indexPath)


### PR DESCRIPTION
Following the Guardian approach:
- `<PayNote.Before>` becomes a closable BottomPanel
- `<PayNote.After>` stays at the end of the article with optimized layout and CTA

#### Behavior:
- We randomly select from 4 sets of paynote messages (still WIP), plus a dedicated set for series articles.
- The bottom panel is expanded by default and can disappear in two ways:
  1. user clicks close button
  2. user scrolls to bottom of the page (so the end of article paynote becomes visible in the case the user reads down without closing the bottom panel)
- `<PayNote.Before>` only has one (subscribe) call-to-action
- `<PayNote.After>` always has a (subscribe) call-to-action, and a secondary (preview) call-to-action for users that are signed in but have no membership. We decided against a secondary button here since we didn't want to give the preview CTA as much visual weight (especially on mobile).

#### Other notable changes:
- At the end of the article, we decided to hide the action bar for paynote users, for  two reasons: 
  1. the paynote CTA is more important than the action bar in this case
  2. it removes a lot of whitespace and allows us to bring the `<PayNote.After>` much closer to the end of the article

#### `<PayNote.Before>` with dummy text
![screen shot 2018-09-13 at 10 18 59](https://user-images.githubusercontent.com/23520051/45476230-b8bc3e80-b73e-11e8-8a64-5aa87be45520.png)
<img width="444" alt="screen shot 2018-09-13 at 14 03 13" src="https://user-images.githubusercontent.com/23520051/45487163-d8af2a80-b75d-11e8-9b88-90b882bab50f.png">


#### `<PayNote.After>` with dummy text
<img width="887" alt="screen shot 2018-09-12 at 17 29 11" src="https://user-images.githubusercontent.com/23520051/45475999-27e56300-b73e-11e8-8238-b25f7d5c1ff5.png">
<img width="876" alt="screen shot 2018-09-12 at 17 29 37" src="https://user-images.githubusercontent.com/23520051/45476000-27e56300-b73e-11e8-9bc0-88150b2830dd.png">
<img width="413" alt="screen shot 2018-09-12 at 17 29 50" src="https://user-images.githubusercontent.com/23520051/45476001-27e56300-b73e-11e8-8768-6d853901a1aa.png">




