### PR TITLE
Shorter disclosure label and notice below input field

### DIFF
--- a/components/FieldSet.js
+++ b/components/FieldSet.js
@@ -1,11 +1,11 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import {css} from 'glamor'
 
 import AutosizeInput from 'react-textarea-autosize'
 import MaskedInput from 'react-maskedinput'
 
 import {
-  FieldSet
+  FieldSet, Label
 } from '@project-r/styleguide'
 
 export const styles = {
@@ -48,6 +48,14 @@ const FieldSetWithMaskAndAutoSize = props => (
             {...styles.mask}
             placeholderChar={field.maskChar || ' '}
             mask={field.mask} />
+        )
+      }
+      if (field.notice) {
+        fieldProps.renderInput = (inputProps, b, c) => (
+          <Fragment>
+            <input {...inputProps} />
+            <Label>{field.notice}</Label>
+          </Fragment>
         )
       }
       return fieldProps

--- a/components/Vote/ElectionCandidacy.js
+++ b/components/Vote/ElectionCandidacy.js
@@ -110,6 +110,7 @@ const fields = (t, vt) => ([
   },
   {
     label: t('profile/disclosures/label'),
+    notice: t('profile/disclosures/notice'),
     name: 'disclosures',
     autoSize: true
   }
@@ -441,7 +442,7 @@ const updateCandidacy = gql`mutation updateCandidacy($slug:String!, $birthday: D
       isListed
       description
     }
-    publicUrl    
+    publicUrl
   }
   submitCandidacy(slug: $slug) {
     id

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-20T10:05:56.112Z",
+  "updated": "2018-09-28T12:52:40.901Z",
   "title": "live",
   "data": [
     {
@@ -1096,11 +1096,15 @@
     },
     {
       "key": "profile/disclosures/label",
-      "value": "Interessenbindungen (optional)"
+      "value": "Interessenbindungen"
     },
     {
       "key": "profile/disclosures/tooLong",
       "value": "Interessenbindungen, maximal 140 Zeichen"
+    },
+    {
+      "key": "profile/disclosures/notice",
+      "value": "(optional)"
     },
     {
       "key": "profile/statement/label",


### PR DESCRIPTION
This Pull Request extends `FieldSet` to render a notice prop as `Label`.

It updates translations.

**Before**

<img width="476" alt="mobile iphone 5 broken" src="https://user-images.githubusercontent.com/331800/46212852-4d29c200-c337-11e8-8a0c-1d51d7ab6620.png">

**After**

<img width="478" alt="mobile iphone 5 empty" src="https://user-images.githubusercontent.com/331800/46213058-df31ca80-c337-11e8-9279-d02425670727.png">
<img width="478" alt="mobile iphone 5 filled" src="https://user-images.githubusercontent.com/331800/46213064-e22cbb00-c337-11e8-848f-0ac78e973dfb.png">

<img width="668" alt="desktop empty" src="https://user-images.githubusercontent.com/331800/46213104-02f51080-c338-11e8-8465-ae5a6ac92be3.png">
<img width="661" alt="desktop filled" src="https://user-images.githubusercontent.com/331800/46213113-07212e00-c338-11e8-9170-6f483b6efdb6.png">
