### PR TITLE
Shorter disclosure label and explanation below input field

### DIFF
--- a/components/Vote/ElectionCandidacy.js
+++ b/components/Vote/ElectionCandidacy.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import ErrorMessage from '../ErrorMessage'
 import voteT from './voteT'
 
-import { A, colors, InlineSpinner, Interaction, mediaQueries, NarrowContainer } from '@project-r/styleguide'
+import { A, Label, colors, InlineSpinner, Interaction, mediaQueries, NarrowContainer } from '@project-r/styleguide'
 import Frame from '../Frame'
 import withT from '../../lib/withT'
 import Button from '@project-r/styleguide/lib/components/Button'
@@ -110,7 +110,7 @@ const fields = (t, vt) => ([
   },
   {
     label: t('profile/disclosures/label'),
-    explanation: t('profile/disclosures/explanation'),
+    explanation: <Label>{t('profile/disclosures/explanation')}</Label>,
     name: 'disclosures',
     autoSize: true
   }

--- a/components/Vote/ElectionCandidacy.js
+++ b/components/Vote/ElectionCandidacy.js
@@ -110,6 +110,7 @@ const fields = (t, vt) => ([
   },
   {
     label: t('profile/disclosures/label'),
+    explanation: t('profile/disclosures/explanation'),
     name: 'disclosures',
     autoSize: true
   }
@@ -351,7 +352,7 @@ class ElectionCandidacy extends React.Component {
                         </div>
                       </div>
                     }
-                    <div>
+                    <div {...styles.section}>
                       <Small indent={false} dangerousHTML={vt('info/candidacy/finePrint')} />
                     </div>
                     <div {...styles.vSpace}>
@@ -441,7 +442,7 @@ const updateCandidacy = gql`mutation updateCandidacy($slug:String!, $birthday: D
       isListed
       description
     }
-    publicUrl    
+    publicUrl
   }
   submitCandidacy(slug: $slug) {
     id

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-09-20T10:05:56.112Z",
+  "updated": "2018-09-29T06:32:36.071Z",
   "title": "live",
   "data": [
     {
@@ -1096,11 +1096,15 @@
     },
     {
       "key": "profile/disclosures/label",
-      "value": "Interessenbindungen (optional)"
+      "value": "Interessenbindungen"
     },
     {
       "key": "profile/disclosures/tooLong",
       "value": "Interessenbindungen, maximal 140 Zeichen"
+    },
+    {
+      "key": "profile/disclosures/explanation",
+      "value": "Keine Interessenbindungen? Lassen Sie das Feld leer."
     },
     {
       "key": "profile/statement/label",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@project-r/styleguide": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.94.0.tgz",
-      "integrity": "sha512-cFIkGYcmW1VJcY6gIGg2GjRLBh5wORUQ4HsTdLuzMsj3ojuxjZAvs8NV5Wo9lCxjplJZxCe9CcOHsxjs0072ZA==",
+      "version": "5.95.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-5.95.0.tgz",
+      "integrity": "sha512-rSWWCfsYjowLnA5tfaY4HcvKuU1VlSwGGjrlQT9QGHsJamMg2Mz9dtfW2Uhzn+Bp1pGZ8k/eA+GQwq9NyWbsvQ==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "webpack-bundle-analyzer": "^2.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^5.94.0",
+    "@project-r/styleguide": "^5.95.0",
     "apollo-cache-inmemory": "^1.1.4",
     "apollo-client": "^2.0.4",
     "apollo-fetch": "^0.7.0",


### PR DESCRIPTION
On small screen devices, disclosure input label did not fit onto a single. This Pull Request splits label into a label and an explanation below input field.

**Before**
<img width="318" alt="vote iphone 5 label empty" src="https://user-images.githubusercontent.com/331800/46242036-90317700-c3c3-11e8-80dc-1f3c87fef178.png">

**Afterwards**
<img width="316" alt="vote iphone 5 new empty" src="https://user-images.githubusercontent.com/331800/46242038-945d9480-c3c3-11e8-9e9d-d3c090790409.png">
