### PR TITLE
fix(ListWithQuery): add minColumns prop

### DIFF
--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -207,7 +207,7 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipSta
               { count: countFormat(membershipStats.count) }
             )}
           </Interaction.H2>
-          <ListWithQuery singleRow first={6} onSelect={(id) => {
+          <ListWithQuery singleRow minColumns={3} first={6} onSelect={(id) => {
             Router.push(`/community?id=${id}`).then(() => {
               window.scrollTo(0, 0)
               return false


### PR DESCRIPTION
- Keep the reasonable default SIZES e.g. for Impressum or Community
- Allow to override the minimum number of columns in special contexts (e.g. we never want less than 3 columns on the marketing page)
- Instead of merging styles at render time, use precomputed styles when possible (unless minColumns is defined)

## Current situation (2 columns on iPhone5)
<img width="381" alt="screen shot 2018-10-10 at 16 42 48" src="https://user-images.githubusercontent.com/23520051/46744524-9b31b480-ccab-11e8-9e3d-0d79a8a7fe5c.png">

## After the fix (3 columns on iPhone5)
<img width="378" alt="screen shot 2018-10-10 at 16 37 58" src="https://user-images.githubusercontent.com/23520051/46744575-b3093880-ccab-11e8-9041-511ff037be9c.png">




