### PR TITLE
strip hash from document path when sending to API

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -13,6 +13,7 @@ import PdfOverlay, { getPdfUrl, countImages } from './PdfOverlay'
 import Extract from './Extract'
 import withT from '../../lib/withT'
 import withInNativeApp, { postMessage } from '../../lib/withInNativeApp'
+import { cleanAsPath } from '../../lib/routes'
 
 import Discussion from '../Discussion/Discussion'
 import DiscussionIconLink from '../Discussion/IconLink'
@@ -497,7 +498,7 @@ const ComposedPage = compose(
   graphql(getDocument, {
     options: ({ router: { asPath } }) => ({
       variables: {
-        path: asPath.split('?')[0]
+        path: cleanAsPath(asPath)
       }
     })
   })

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -18,6 +18,7 @@ import SSRCachingBoundary from '../SSRCachingBoundary'
 import { renderMdast } from 'mdast-react-render'
 
 import { PUBLIC_BASE_URL } from '../../lib/constants'
+import { cleanAsPath } from '../../lib/routes'
 
 const schema = createFrontSchema({
   Link
@@ -114,7 +115,7 @@ export default compose(
   graphql(getDocument, {
     options: props => ({
       variables: {
-        path: props.path || props.router.asPath.split('?')[0],
+        path: props.path || cleanAsPath(props.router.asPath),
         first: 15
       }
     }),

--- a/components/StatusError/index.js
+++ b/components/StatusError/index.js
@@ -5,7 +5,7 @@ import { withRouter } from 'next/router'
 
 import withT from '../../lib/withT'
 import withInNativeApp from '../../lib/withInNativeApp'
-import { Router } from '../../lib/routes'
+import { Router, cleanAsPath } from '../../lib/routes'
 import { PUBLIC_BASE_URL } from '../../lib/constants'
 
 import Loader from '../Loader'
@@ -54,7 +54,7 @@ export default compose(
     skip: props => props.statusCode !== 404 || !props.router.asPath,
     options: ({ router: { asPath } }) => ({
       variables: {
-        path: asPath.split('?')[0]
+        path: cleanAsPath(asPath)
       }
     }),
     props: ({ data, ownProps: { serverContext, statusCode, router, inNativeApp, me } }) => {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,6 +12,8 @@ routes.matchPath = path => {
   return null
 }
 
+routes.cleanAsPath = asPath => asPath.split('?')[0].split('#')[0]
+
 routes
   .add('index', '/')
   .add('preview', '/probelesen')

--- a/pages/front.js
+++ b/pages/front.js
@@ -4,7 +4,7 @@ import { withRouter } from 'next/router'
 
 import { Loader } from '@project-r/styleguide'
 
-import { Router, routes } from '../lib/routes'
+import { Router, routes, cleanAsPath } from '../lib/routes'
 import Frame from '../components/Frame'
 import Front from '../components/Front'
 import StatusError from '../components/StatusError'
@@ -15,7 +15,7 @@ import withInNativeApp from '../lib/withInNativeApp'
 const KNOWN_PATHS = ['/feuilleton']
 
 const isPathKnown = (router) => {
-  return KNOWN_PATHS.indexOf(router.asPath.split('?')[0]) !== -1
+  return KNOWN_PATHS.indexOf(cleanAsPath(router.asPath)) !== -1
 }
 
 class FrontPage extends Component {


### PR DESCRIPTION
Anchor hashes currently do not work on articles and front because they lead to a 404 when client-side rendering: https://www.republik.ch/2018/10/18/cum-ex-files-lesehilfe#cumcum

- initially loads fine SSR, because hases are not sent to the server
- and then re-requests with the hash client side and results in a 404

Hashes should not be sent to the server, adding a simple `split('#')[0]` will make the behaviour and requested path consistent between server and client. Also did it for fronts and redirects.