### PR TITLE
fix(RelatedEpisodes): reverse order on mobile, so next episode comes first

### DIFF
--- a/components/Article/RelatedEpisodes.js
+++ b/components/Article/RelatedEpisodes.js
@@ -63,7 +63,7 @@ const RelatedEpisodes = ({ t, episodes, path }) => {
   return !!(previousEpisode || nextEpisode) && (
     <Center>
       <Breakout size='breakout'>
-        <TeaserFrontTileRow columns={2}>
+        <TeaserFrontTileRow columns={2} mobileReverse>
           {previousEpisode && (
             <Tile
               t={t}

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,9 +885,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.6.1.tgz",
-      "integrity": "sha512-GNeW3r8i9vHm9LHm2d7oky8/4kr4eNjLvKtxG/prFfBxT+yqJRQeXbAEkPCaOxjySbWg6cxsUjOnJV+7o4MMbg==",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.6.3.tgz",
+      "integrity": "sha512-n/0cQSX/elRE0o7JmraKSX/cQcbFEprzVZH7TngCIC9PuXD3eF3Qeg2GaXQRJy6bWe0AT7H4k7P1Fh/dEBLZ3A==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^6.6.1",
+    "@project-r/styleguide": "^6.6.3",
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",


### PR DESCRIPTION
Depends on https://github.com/orbiting/styleguide/pull/188

#### Before
<img width="375" alt="screen shot 2018-11-07 at 15 24 47" src="https://user-images.githubusercontent.com/23520051/48137047-76782f00-e2a1-11e8-8bef-39bd2a781908.png">

#### After
<img width="377" alt="screen shot 2018-11-07 at 15 25 04" src="https://user-images.githubusercontent.com/23520051/48137048-76782f00-e2a1-11e8-827f-72cd05d15aa7.png">
