### PR TITLE
fix(Pledge): Default 0 value to an empty string

### DIFF
--- a/components/Pledge/CustomizePackage.js
+++ b/components/Pledge/CustomizePackage.js
@@ -546,9 +546,11 @@ class CustomizePackage extends Component {
                       const option = field.option
                       const fieldKey = field.key
                       const elementKey = [option.id, fieldKey].join('-')
-                      const value = values[fieldKey] === undefined
-                        ? field.default
-                        : values[fieldKey]
+                      const value = (
+                        values[fieldKey] === undefined
+                          ? field.default
+                          : values[fieldKey]
+                      ) || ''
                       const label = t.first([
                         ...(isAboGive ? [
                           `option/${pkg.name}/${option.reward.name}/label/give`,


### PR DESCRIPTION
This Pull Request aims to prevent display of "0" but rather returns and empty string as value.

**Before**
<img width="682" alt="bildschirmfoto 2018-12-17 um 10 53 49" src="https://user-images.githubusercontent.com/331800/50079553-2f5b5300-01ea-11e9-907c-6dcdda1a76f4.png">

**After**
<img width="680" alt="bildschirmfoto 2018-12-17 um 10 53 59" src="https://user-images.githubusercontent.com/331800/50079613-57e34d00-01ea-11e9-902a-a2aedd6124f1.png">