### PR TITLE
Show voucher code and link to claim page

### DIFF
--- a/components/Account/Access/Campaigns/Campaign.js
+++ b/components/Account/Access/Campaigns/Campaign.js
@@ -1,19 +1,33 @@
-import { Interaction } from '@project-r/styleguide'
+import { A, Interaction } from '@project-r/styleguide'
+import { compose } from 'react-apollo'
+
+import withT from '../../../../lib/withT'
+import { Link } from '../../../../lib/routes'
 
 import Form from './Form'
 import Grants from './Grants'
 
 const { H2, P } = Interaction
 
-const Campaign = ({ campaign, grantAccess, revokeAccess }) => {
+const Campaign = ({ campaign, grantAccess, revokeAccess, t }) => {
   return (
     <div style={{ marginBottom: 40 }}>
       <H2>{campaign.title}</H2>
       <P>{campaign.description}</P>
+      <P>{t.elements(
+        'Account/Access/Campaigns/Campaign/claimNotice', {
+          linkClaim: <Link
+            route='claim'
+            params={{ context: 'access' }}
+            passHref>
+            <A>{t('Account/Access/Campaigns/Campaign/claimNotice/linkClaim')}</A>
+          </Link>
+        })}
+      </P>
       <Grants campaign={campaign} revokeAccess={revokeAccess} />
       <Form campaign={campaign} grantAccess={grantAccess} />
     </div>
   )
 }
 
-export default Campaign
+export default compose(withT)(Campaign)

--- a/components/Account/Access/Campaigns/Form.js
+++ b/components/Account/Access/Campaigns/Form.js
@@ -9,8 +9,9 @@ import {
 import ErrorMessage from '../../../ErrorMessage'
 import FieldSet from '../../../FieldSet'
 import withT from '../../../../lib/withT'
+import { Link } from '../../../../lib/routes'
 
-const { H3 } = Interaction
+const { H3, P } = Interaction
 
 class Form extends Component {
   constructor (props) {
@@ -143,6 +144,16 @@ class Form extends Component {
                   { count: campaign.slots.used }
                 )}
               </H3>
+              <P>
+                {t.elements('Account/Access/Campaigns/Form/explanation', {
+                  linkClaim: <Link
+                    route='claim'
+                    params={{ context: 'access' }}
+                    passHref>
+                    <A>{t('Account/Access/Campaigns/Form/explanation/linkClaim')}</A>
+                  </Link>
+                })}
+              </P>
               <FieldSet
                 values={values}
                 errors={errors}

--- a/components/Account/Access/Campaigns/Grant.js
+++ b/components/Account/Access/Campaigns/Grant.js
@@ -17,6 +17,9 @@ const Grants = ({ grant, revokeAccess, t }) => {
     recipient: <Emphasis key={`grant-recipient-${grant.id}`}>
       {grant.email}
     </Emphasis>,
+    voucherCode: <Emphasis key={`grant-voucher-${grant.id}`}>
+      {grant.voucherCode}
+    </Emphasis>,
     beginBefore: <Emphasis key={`grant-before-${grant.id}`}>
       {dayFormat(new Date(grant.beginBefore))}
     </Emphasis>,
@@ -36,7 +39,7 @@ const Grants = ({ grant, revokeAccess, t }) => {
       <br />
       {!grant.beginAt &&
         <Fragment>
-          {t('Account/Access/Campaigns/Grants/unclaimed')}
+          { t.elements('Account/Access/Campaigns/Grants/unclaimed', elements)}
           <br />
           { t.elements('Account/Access/Campaigns/Grants/beginBefore', elements)}
           <br />

--- a/components/Account/belongingsQuery.js
+++ b/components/Account/belongingsQuery.js
@@ -63,6 +63,7 @@ query myBelongings {
       grants {
         id
         email
+        voucherCode
         beginBefore
         beginAt
         endAt

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2018-12-21T09:44:24.156Z",
+  "updated": "2018-12-23T16:37:31.511Z",
   "title": "live",
   "data": [
     {
@@ -1015,12 +1015,28 @@
       "value": "Zugriff teilen"
     },
     {
+      "key": "Account/Access/Campaigns/Campaign/claimNotice",
+      "value": "(Gutscheincodes können auf {linkClaim} eingelöst werden.)"
+    },
+    {
+      "key": "Account/Access/Campaigns/Campaign/claimNotice/linkClaim",
+      "value": "republik.ch/abholen"
+    },
+    {
       "key": "Account/Access/Campaigns/Form/title/0",
       "value": "Zugriff teilen"
     },
     {
       "key": "Account/Access/Campaigns/Form/title/other",
       "value": "Einen weiteren Zugriff teilen"
+    },
+    {
+      "key": "Account/Access/Campaigns/Form/explanation",
+      "value": "Beschenkte erhalten eine Einladungs-E-Mail mit einem Gutscheincode und {linkClaim}, auf dem der Gutscheincode eingelöst werden kann."
+    },
+    {
+      "key": "Account/Access/Campaigns/Form/explanation/linkClaim",
+      "value": "Link zur /abholen-Seite"
     },
     {
       "key": "Account/Access/Campaigns/Form/reset",
@@ -1088,7 +1104,7 @@
     },
     {
       "key": "Account/Access/Campaigns/Grants/unclaimed",
-      "value": "noch nicht eingelöst"
+      "value": "noch nicht eingelöst, Gutscheincode: {voucherCode}"
     },
     {
       "key": "Account/Access/Campaigns/Grants/beginAt",


### PR DESCRIPTION
This Pull Request displays a voucher code next to unclaimed grants.

<img width="374" alt="bildschirmfoto 2018-12-23 um 17 39 02" src="https://user-images.githubusercontent.com/331800/50385701-d4d66100-06d9-11e9-80aa-727726abf33e.png">

It also delivers some explanation on how to claim a grant to a granter:

<img width="318" alt="bildschirmfoto 2018-12-23 um 17 38 41" src="https://user-images.githubusercontent.com/331800/50385705-e6b80400-06d9-11e9-95cf-8d57275b400f.png">

<img width="374" alt="bildschirmfoto 2018-12-23 um 17 39 12" src="https://user-images.githubusercontent.com/331800/50385706-eb7cb800-06d9-11e9-9d7d-7ecafe8c949b.png">
