### PR TITLE
Communicate Deactivation and Improve Membership Explanations

### DIFF
--- a/components/Account/Memberships/Cancel.js
+++ b/components/Account/Memberships/Cancel.js
@@ -109,8 +109,8 @@ class CancelMembership extends Component {
                 {!!latestPeriod && <P>
                   {membership.active && !membership.overdue && t.first(
                     [
-                      `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}`,
-                      `memberships/latestPeriod/renew/${membership.renew}`
+                      `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}/autoPay/${membership.autoPay}`,
+                      `memberships/latestPeriod/renew/${membership.renew}/autoPay/${membership.autoPay}`
                     ],
                     { formattedEndDate },
                     ''

--- a/components/Account/Memberships/List.js
+++ b/components/Account/Memberships/List.js
@@ -12,7 +12,9 @@ import query from '../belongingsQuery'
 
 import Manage from './Manage'
 
-const { H2 } = Interaction
+import Box from '../../Frame/Box'
+
+const { H2, P } = Interaction
 
 class MembershipsList extends Component {
   render () {
@@ -23,6 +25,7 @@ class MembershipsList extends Component {
       prolongIds,
       waitingMemberships
     } = this.props
+
     return (
       <Loader loading={loading} error={error} render={() => {
         if (!memberships.length) {
@@ -34,6 +37,13 @@ class MembershipsList extends Component {
             <H2>{t.pluralize('memberships/title', {
               count: memberships.length
             })}</H2>
+            {!memberships.find(membership => membership.active) &&
+              <Box style={{ padding: '15px 20px', margin: '1em 0em' }}>
+                <P>
+                  {t('memberships/noActive')}
+                </P>
+              </Box>
+            }
             {memberships.map(membership => (
               <Manage key={membership.id}
                 membership={membership}

--- a/components/Account/Memberships/Manage.js
+++ b/components/Account/Memberships/Manage.js
@@ -57,17 +57,7 @@ class Actions extends Component {
         {!prolong && membership.active && membership.renew && waitingMemberships && <P>
           {t('memberships/manage/prolong/awaiting')}
         </P>}
-        {membership.active && membership.renew && <P>
-          <Link route='cancel' params={{ membershipId: membership.id }} passHref>
-            <A>
-              {t.first([
-                `memberships/${membership.type.name}/manage/cancel/link`,
-                'memberships/manage/cancel/link'
-              ])}
-            </A>
-          </Link>
-        </P>}
-        {!membership.renew && !!membership.periods.length && membership.type.name === 'MONTHLY_ABO' && <P>
+        {!membership.renew && !!membership.periods.length && !prolong && <P>
           <A href='#reactivate' onClick={(e) => {
             e.preventDefault()
             this.setState({
@@ -109,6 +99,16 @@ class Actions extends Component {
             </TokenPackageLink>
           </P>
         }
+        {membership.active && membership.renew && <P>
+          <Link route='cancel' params={{ membershipId: membership.id }} passHref>
+            <A>
+              {t.first([
+                `memberships/${membership.type.name}/manage/cancel/link`,
+                'memberships/manage/cancel/link'
+              ])}
+            </A>
+          </Link>
+        </P>}
         {!!remoteError &&
           <P style={{ color: colors.error, marginTop: 10 }}>{remoteError}</P>}
       </Fragment>
@@ -154,8 +154,16 @@ const ManageActions = compose(
 
 const Manage = ({ t, membership, highlighted, prolong, waitingMemberships, title, compact, actions }) => {
   const createdAt = new Date(membership.createdAt)
-  const latestPeriod = membership.periods[0]
-  const formattedEndDate = latestPeriod && dayFormat(new Date(latestPeriod.endDate))
+  const latestPeriod = membership.periods
+    .reduce((acc, period) => {
+      return acc && new Date(period.endDate) < new Date(acc.endDate)
+        ? acc
+        : period
+    })
+
+  const latestPeriodEndDate = latestPeriod && new Date(latestPeriod.endDate)
+  const formattedEndDate = latestPeriod && dayFormat(latestPeriodEndDate)
+  const overdue = latestPeriod && latestPeriodEndDate < new Date()
 
   return (
     <AccountItem
@@ -168,20 +176,40 @@ const Manage = ({ t, membership, highlighted, prolong, waitingMemberships, title
           { sequenceNumber: membership.sequenceNumber }
         )
       }>
-      {!!latestPeriod && <P>
-        {membership.active && !membership.overdue && t.first(
-          [
-            `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}`,
-            `memberships/latestPeriod/renew/${membership.renew}`
-          ],
-          { formattedEndDate },
-          ''
-        )}
-        {membership.overdue && t(
-          'memberships/latestPeriod/overdue',
-          { formattedEndDate }
-        )}
-      </P>}
+      {membership.active && !!latestPeriod && !overdue &&
+        <P>
+          {membership.active && !membership.overdue && t.first(
+            [
+              `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}`,
+              `memberships/latestPeriod/renew/${membership.renew}`
+            ],
+            { formattedEndDate },
+            ''
+          )}
+        </P>
+      }
+      {membership.active && !!latestPeriod && overdue &&
+        <P>
+          {t.first(
+            [
+              `memberships/${membership.type.name}/latestPeriod/overdue`,
+              'memberships/latestPeriod/overdue'
+            ],
+            { formattedEndDate }
+          )}
+        </P>
+      }
+      {!membership.active && !membership.renew && !!latestPeriod && overdue &&
+        <P>
+          {t.first(
+            [
+              `memberships/${membership.type.name}/ended`,
+              'memberships/latestPeriod/ended'
+            ],
+            { formattedEndDate }
+          )}
+        </P>
+      }
       {actions && <ManageActions membership={membership} prolong={prolong} waitingMemberships={waitingMemberships} />}
     </AccountItem>
   )

--- a/components/Account/Memberships/Manage.js
+++ b/components/Account/Memberships/Manage.js
@@ -180,8 +180,8 @@ const Manage = ({ t, membership, highlighted, prolong, waitingMemberships, title
         <P>
           {membership.active && !membership.overdue && t.first(
             [
-              `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}`,
-              `memberships/latestPeriod/renew/${membership.renew}`
+              `memberships/${membership.type.name}/latestPeriod/renew/${membership.renew}/autoPay/${membership.autoPay}`,
+              `memberships/latestPeriod/renew/${membership.renew}/autoPay/${membership.autoPay}`
             ],
             { formattedEndDate },
             ''

--- a/components/Account/Memberships/Manage.js
+++ b/components/Account/Memberships/Manage.js
@@ -67,7 +67,7 @@ class Actions extends Component {
             </A>
           </Link>
         </P>}
-        {!membership.renew && !!membership.periods.length && <P>
+        {!membership.renew && !!membership.periods.length && membership.type.name === 'MONTHLY_ABO' && <P>
           <A href='#reactivate' onClick={(e) => {
             e.preventDefault()
             this.setState({

--- a/components/Account/belongingsQuery.js
+++ b/components/Account/belongingsQuery.js
@@ -23,6 +23,7 @@ query myBelongings {
       renew
       active
       overdue
+      autoPay
       user {
         id
       }

--- a/components/Bookmarks/Page.js
+++ b/components/Bookmarks/Page.js
@@ -6,7 +6,7 @@ import { enforceMembership } from '../Auth/withMembership'
 import { enforceAuthorization } from '../Auth/withAuthorization'
 import gql from 'graphql-tag'
 import DocumentListContainer, { documentFragment } from '../Feed/DocumentListContainer'
-import withT, { t } from '../../lib/withT'
+import withT from '../../lib/withT'
 
 import {
   mediaQueries,
@@ -71,12 +71,6 @@ const mergeConnection = (data, connection) => ({
   }
 })
 
-const feedLink = <Link route='feed' key='link'>
-  <a {...linkRule}>
-    {t('pages/feed/title')}
-  </a>
-</Link>
-
 const bookmarkIcon = <IconDefault size={22} key='icon' />
 
 class Page extends Component {
@@ -98,7 +92,11 @@ class Page extends Component {
             placeholder={
               <Interaction.P style={{ marginBottom: 60 }}>
                 {t.elements('pages/bookmarks/placeholder', {
-                  feedLink,
+                  feedLink: <Link route='feed' key='link'>
+                    <a {...linkRule}>
+                      {t('pages/bookmarks/placeholder/feedText')}
+                    </a>
+                  </Link>,
                   bookmarkIcon
                 })}
               </Interaction.P>

--- a/components/CrowdfundingStatus/index.js
+++ b/components/CrowdfundingStatus/index.js
@@ -170,6 +170,8 @@ class Status extends Component {
       )
     }
 
+    const isRunning = minutes >= 0
+
     return (
       <Fragment>
         {[
@@ -204,8 +206,8 @@ class Status extends Component {
           </Fragment>
         ))}
         <P>
-          <span {...styles.smallNumber}>
-            {minutes >= 0 ? (
+          <span {...styles.smallNumber} style={isRunning ? undefined : { lineHeight: 1.3 }}>
+            {isRunning ? (
               [
                 days > 0 && t.pluralize(
                   'crowdfunding/status/time/days',
@@ -232,14 +234,14 @@ class Status extends Component {
                   }
                 )
               ].filter(Boolean).join(' ')
-            ) : (
-              t.first([
-                `crowdfunding/status/time/ended/${crowdfundingName}`,
-                'crowdfunding/status/time/ended'
-              ])
-            )}
+            ) : t.first([
+              `crowdfunding/status/time/ended/${crowdfundingName}`,
+              'crowdfunding/status/time/ended'
+            ])}
           </span>
-          <Label>{t('crowdfunding/status/time/label')}</Label>
+          {isRunning
+            ? <Label>{t('crowdfunding/status/time/label')}</Label>
+            : <br />}
         </P>
       </Fragment>
     )

--- a/components/Frame/ProlongBox.js
+++ b/components/Frame/ProlongBox.js
@@ -61,7 +61,7 @@ const ProlongBox = ({
     const colorStyle = { color: dark ? '#fff' : undefined }
 
     const explanation = t.elements(`${baseKey}/explanation`, {
-      cancelLink: <Link key='cancelLink' route='cancel'>
+      cancelLink: <Link key='cancelLink' route='cancel' passHref>
         <Editorial.A style={colorStyle}>
           {t(`${baseKey}/explanation/cancelText`)}
         </Editorial.A>

--- a/components/Frame/ProlongBox.js
+++ b/components/Frame/ProlongBox.js
@@ -1,20 +1,24 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { withRouter } from 'next/router'
 import { compose } from 'react-apollo'
 import { timeDay } from 'd3-time'
 
-import { Editorial, colors, mediaQueries } from '@project-r/styleguide'
+import { Editorial, Interaction, colors, mediaQueries, Button, Center } from '@project-r/styleguide'
 
 import { css } from 'glamor'
 
 import TokenPackageLink from '../Link/TokenPackage'
 import withInNativeApp from '../../lib/withInNativeApp'
+import { Link } from '../../lib/routes'
+import { timeFormat } from '../../lib/utils/format'
 
 import { negativeColors } from './constants'
 
 const styles = {
   box: css({
-    padding: 15,
+    padding: 15
+  }),
+  singleLine: css({
     textAlign: 'center',
     fontSize: 13,
     [mediaQueries.mUp]: {
@@ -25,13 +29,20 @@ const styles = {
     backgroundColor: colors.primaryBg
   }),
   boxDark: css({
-    backgroundColor: negativeColors.primaryBg
+    backgroundColor: negativeColors.primaryBg,
+    color: '#fff'
   })
 }
 
+const SingleLine = ({ children }) => <div {...styles.singleLine}>
+  {children}
+</div>
+
+const dayFormat = timeFormat('%d. %B %Y')
+
 const ProlongBox = ({
   t, prolongBeforeDate, router,
-  inNativeApp, inNativeIOSApp, dark
+  inNativeApp, inNativeIOSApp, dark: inDarkFrame
 }) => {
   if (router.pathname === '/pledge' || router.pathname === '/cancel' || router.pathname === '/meta') {
     return null
@@ -39,14 +50,46 @@ const ProlongBox = ({
   const date = new Date(prolongBeforeDate)
   const numberOfDays = timeDay.count(new Date(), date)
   if (numberOfDays <= 30) {
+    const key = numberOfDays <= 2
+      ? numberOfDays < 0
+        ? 'overdue'
+        : 'due'
+      : 'before'
+    const baseKey = `prolongNecessary/${key}`
+
+    const dark = inDarkFrame || key !== 'before'
+    const colorStyle = { color: dark ? '#fff' : undefined }
+
+    const explanation = t.elements(`${baseKey}/explanation`, {
+      cancelLink: <Link key='cancelLink' route='cancel'>
+        <Editorial.A style={colorStyle}>
+          {t(`${baseKey}/explanation/cancelText`)}
+        </Editorial.A>
+      </Link>,
+      graceEndDate: dayFormat(timeDay.offset(date, 14))
+    }, '')
+    const hasExplanation = !!explanation.length
+    const Title = hasExplanation ? Interaction.H2 : Fragment
+    const Wrapper = hasExplanation ? Center : SingleLine
+
+    const buttonText = t(`${baseKey}/button`, undefined, '')
+
     return <div {...styles.box} {...styles[dark ? 'boxDark' : 'boxLight']}>
-      {t.elements('prolongNecessary/jan15', {
-        link: <TokenPackageLink key='link' params={{ package: 'PROLONG' }} passHref>
-          <Editorial.A style={{ color: dark ? '#fff' : undefined }}>
-            {t('prolongNecessary/jan15/linkText')}
-          </Editorial.A>
-        </TokenPackageLink>
-      })}
+      <Wrapper>
+        <Title style={colorStyle}>
+          {t.elements(baseKey, {
+            link: <TokenPackageLink key='link' params={{ package: 'PROLONG' }} passHref>
+              <Editorial.A style={colorStyle}>
+                {t(`${baseKey}/linkText`)}
+              </Editorial.A>
+            </TokenPackageLink>
+          })}
+        </Title>
+        {buttonText && <TokenPackageLink key='link' params={{ package: 'PROLONG' }}>
+          <Button style={{ marginTop: 10 }} primary>{buttonText}</Button>
+        </TokenPackageLink>}
+        {hasExplanation && <Interaction.P style={{ ...colorStyle, marginTop: 10 }}>{explanation}</Interaction.P>}
+      </Wrapper>
     </div>
   }
   return null

--- a/components/Pledge/Form.js
+++ b/components/Pledge/Form.js
@@ -566,6 +566,7 @@ query pledgeForm($crowdfundingName: String!, $accessToken: ID) {
           renew
           active
           overdue
+          autoPay
           type {
             name
           }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-14T09:44:08.071Z",
+  "updated": "2019-01-14T12:54:59.323Z",
   "title": "live",
   "data": [
     {
@@ -45,10 +45,6 @@
     {
       "key": "nav/share",
       "value": "Republik teilen"
-    },
-    {
-      "key": "nav/bookmarks",
-      "value": "Lesezeichen"
     },
     {
       "key": "navbar/front",
@@ -105,14 +101,6 @@
     {
       "key": "pages/feed/title",
       "value": "Feed"
-    },
-    {
-      "key": "pages/bookmarks/title",
-      "value": "Lesezeichen"
-    },
-    {
-      "key": "pages/bookmarks/placeholder",
-      "value": "Sie haben keine Lesezeichen gesetzt. Stöbern Sie im {feedLink} und klicken Sie bei einem Artikel auf {bookmarkIcon} – dann erscheint er hier auf Ihrer persönlichen Liste. "
     },
     {
       "key": "pages/search/title",
@@ -2615,14 +2603,6 @@
       "value": "+41797874765"
     },
     {
-      "key": "bookmark/title/bookmarked",
-      "value": "Lesezeichen entfernen"
-    },
-    {
-      "key": "bookmark/title/default",
-      "value": "Lesezeichen hinzufügen"
-    },
-    {
       "key": "feed/loadMore",
       "value": "Das waren die neuesten {count} Beiträge. Weitere {remaining} anschauen?"
     },
@@ -3547,6 +3527,10 @@
       "value": "Zur Debattenseite"
     },
     {
+      "key": "feedback/fetchMore",
+      "value": "Mehr Beiträge"
+    },
+    {
       "key": "tokenAuthorization/error",
       "value": "Ungültiger Link"
     },
@@ -4183,30 +4167,6 @@
       "value": "jetzt verlängern"
     },
     {
-      "key": "prolongNecessary/due",
-      "value": "Ihr Mitgliedschaftsbeitrag ist fällig: {link}"
-    },
-    {
-      "key": "prolongNecessary/due/linkText",
-      "value": "jetzt bezahlen"
-    },
-    {
-      "key": "prolongNecessary/overdue",
-      "value": "Ihr Mitglied­schafts­beitrag ist überfällig"
-    },
-    {
-      "key": "prolongNecessary/overdue/button",
-      "value": "Jetzt bezahlen"
-    },
-    {
-      "key": "prolongNecessary/overdue/explanation",
-      "value": "Falls Sie bis am {graceEndDate} nicht bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft und {cancelLink}."
-    },
-    {
-      "key": "prolongNecessary/overdue/explanation/cancelText",
-      "value": "teilen Sie uns mit warum"
-    },
-    {
       "key": "pledge/option/PROLONG/ABO/label",
       "value": "Abo und Mitgliedschaft"
     },
@@ -4307,10 +4267,6 @@
       "value": "Das Crowdfunding ist vorbei."
     },
     {
-      "key": "crowdfunding/status/time/ended/PROLONG",
-      "value": "Die Vorverlängerungsphase ist vorbei."
-    },
-    {
       "key": "meta/prolong/title",
       "value": "Mit der Republik ins zweite Jahr"
     },
@@ -4373,6 +4329,58 @@
     {
       "key": "overview/after/pledgeButton",
       "value": "Jetzt Mitglied werden"
+    },
+    {
+      "key": "prolongNecessary/due",
+      "value": "Ihr Mitgliedschaftsbeitrag ist fällig: {link}."
+    },
+    {
+      "key": "prolongNecessary/due/linkText",
+      "value": "Jetzt bezahlen"
+    },
+    {
+      "key": "prolongNecessary/overdue",
+      "value": "Ihr Mitglied­schafts­beitrag ist überfällig."
+    },
+    {
+      "key": "prolongNecessary/overdue/button",
+      "value": "Jetzt bezahlen"
+    },
+    {
+      "key": "prolongNecessary/overdue/explanation",
+      "value": "Falls Sie bis zum {graceEndDate} nicht bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft: {cancelLink}."
+    },
+    {
+      "key": "prolongNecessary/overdue/explanation/cancelText",
+      "value": "Teilen Sie uns mit, warum."
+    },
+    {
+      "key": "crowdfunding/status/time/ended/PROLONG",
+      "value": "Die erste grosse Verlängerungsphase ist vorbei."
+    },
+    {
+      "key": "nav/bookmarks",
+      "value": "Lesezeichen"
+    },
+    {
+      "key": "bookmark/title/bookmarked",
+      "value": "Lesezeichen entfernen"
+    },
+    {
+      "key": "bookmark/title/default",
+      "value": "Lesezeichen hinzufügen"
+    },
+    {
+      "key": "pages/bookmarks/title",
+      "value": "Lesezeichen"
+    },
+    {
+      "key": "pages/bookmarks/placeholder",
+      "value": "Sie haben keine Lesezeichen gesetzt. Stöbern Sie im {feedLink} und klicken Sie bei einem Artikel auf {bookmarkIcon} – dann erscheint er hier auf Ihrer persönlichen Liste. "
+    },
+    {
+      "key": "pages/bookmarks/placeholder/feedText",
+      "value": "Feed"
     }
   ]
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-14T14:36:30.588Z",
+  "updated": "2019-01-14T17:18:04.154Z",
   "title": "live",
   "data": [
     {
@@ -592,7 +592,7 @@
     },
     {
       "key": "account/ios/box",
-      "value": "Besuchen Sie unsere Webseite, um ihre Mitgliedschaft zu verwalten."
+      "value": "Besuchen Sie unsere Webseite, um Ihre Mitgliedschaft zu verwalten."
     },
     {
       "key": "Account/title",
@@ -4356,7 +4356,7 @@
     },
     {
       "key": "crowdfunding/status/time/ended/PROLONG",
-      "value": "Die erste grosse Verlängerungsphase ist vorbei."
+      "value": "Ein detaillierter Überblick folgt Ende Monat."
     },
     {
       "key": "nav/bookmarks",
@@ -4380,7 +4380,7 @@
     },
     {
       "key": "pages/bookmarks/help",
-      "value": "Die Lesezeichen sind sortiert nach dem Zeitpunkt ihres Hinzufügens (neueste zuerst)."
+      "value": "Neu hinzugefügte Artikel erscheinen zuoberst."
     },
     {
       "key": "pages/bookmarks/placeholder/feedText",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-13T23:07:14.942Z",
+  "updated": "2019-01-13T23:19:30.913Z",
   "title": "live",
   "data": [
     {
@@ -4012,7 +4012,7 @@
     },
     {
       "key": "memberships/cancel/accountLink",
-      "value": "Zurück zum Konto"
+      "value": "Zum Konto"
     },
     {
       "key": "memberships/cancel/button",
@@ -4188,7 +4188,7 @@
     },
     {
       "key": "prolongNecessary/overdue/explanation",
-      "value": "Falls Sie nicht bis am {graceEndDate} bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft und {cancelLink}."
+      "value": "Falls Sie bis am {graceEndDate} nicht bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft und {cancelLink}."
     },
     {
       "key": "prolongNecessary/overdue/explanation/cancelText",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-13T13:39:09.965Z",
+  "updated": "2019-01-13T23:07:14.942Z",
   "title": "live",
   "data": [
     {
@@ -4163,12 +4163,36 @@
       "value": "Ist das nicht Ihre E-Mail-Adresse?"
     },
     {
-      "key": "prolongNecessary/jan15",
+      "key": "prolongNecessary/before",
       "value": "Mit der Republik ins zweite Jahr: {link}"
     },
     {
-      "key": "prolongNecessary/jan15/linkText",
+      "key": "prolongNecessary/before/linkText",
       "value": "jetzt verlängern"
+    },
+    {
+      "key": "prolongNecessary/due",
+      "value": "Ihr Mitgliedschaftsbeitrag ist fällig: {link}"
+    },
+    {
+      "key": "prolongNecessary/due/linkText",
+      "value": "jetzt bezahlen"
+    },
+    {
+      "key": "prolongNecessary/overdue",
+      "value": "Ihr Mitglied­schafts­beitrag ist überfällig"
+    },
+    {
+      "key": "prolongNecessary/overdue/button",
+      "value": "Jetzt bezahlen"
+    },
+    {
+      "key": "prolongNecessary/overdue/explanation",
+      "value": "Falls Sie nicht bis am {graceEndDate} bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft und {cancelLink}."
+    },
+    {
+      "key": "prolongNecessary/overdue/explanation/cancelText",
+      "value": "teilen Sie uns mit warum"
     },
     {
       "key": "pledge/option/PROLONG/ABO/label",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-14T12:54:59.323Z",
+  "updated": "2019-01-14T14:36:30.588Z",
   "title": "live",
   "data": [
     {
@@ -4160,7 +4160,7 @@
     },
     {
       "key": "prolongNecessary/before",
-      "value": "Mit der Republik ins zweite Jahr: {link}"
+      "value": "Mit der Republik ins zweite Jahr: {link}."
     },
     {
       "key": "prolongNecessary/before/linkText",
@@ -4340,7 +4340,7 @@
     },
     {
       "key": "prolongNecessary/overdue",
-      "value": "Ihr Mitglied­schafts­beitrag ist überfällig."
+      "value": "Ihr Mitglied­schafts­beitrag ist fällig."
     },
     {
       "key": "prolongNecessary/overdue/button",
@@ -4348,7 +4348,7 @@
     },
     {
       "key": "prolongNecessary/overdue/explanation",
-      "value": "Falls Sie bis zum {graceEndDate} nicht bezahlen, werden wir Ihre Mitgliedschaft deaktivieren. Wollen Sie die Republik nicht mehr unterstützen? Bitte kündigen Sie Ihre Mitgliedschaft: {cancelLink}."
+      "value": "Ihre Mitgliedschaft wird am {graceEndDate} deaktiviert, wenn Sie bis dahin nicht bezahlen. Wollen Sie die Republik nicht mehr lesen? Bitte kündigen Sie Ihre Mitgliedschaft: {cancelLink}."
     },
     {
       "key": "prolongNecessary/overdue/explanation/cancelText",
@@ -4377,6 +4377,10 @@
     {
       "key": "pages/bookmarks/placeholder",
       "value": "Sie haben keine Lesezeichen gesetzt. Stöbern Sie im {feedLink} und klicken Sie bei einem Artikel auf {bookmarkIcon} – dann erscheint er hier auf Ihrer persönlichen Liste. "
+    },
+    {
+      "key": "pages/bookmarks/help",
+      "value": "Die Lesezeichen sind sortiert nach dem Zeitpunkt ihres Hinzufügens (neueste zuerst)."
     },
     {
       "key": "pages/bookmarks/placeholder/feedText",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-13T23:19:30.913Z",
+  "updated": "2019-01-14T09:44:08.071Z",
   "title": "live",
   "data": [
     {
@@ -3199,11 +3199,23 @@
       "value": "Sie haben keine aktiven Mitgliedschaften oder Abonnements"
     },
     {
-      "key": "memberships/latestPeriod/renew/true",
+      "key": "memberships/latestPeriod/renew/true/autoPay/true",
       "value": "Automatische Erneuerung am {formattedEndDate}"
     },
     {
-      "key": "memberships/latestPeriod/renew/false",
+      "key": "memberships/latestPeriod/renew/true/autoPay/false",
+      "value": "Bezahlt bis am {formattedEndDate}"
+    },
+    {
+      "key": "memberships/MONTHLY_ABO/latestPeriod/renew/true/autoPay/false",
+      "value": "Automatische Erneuerung am {formattedEndDate}"
+    },
+    {
+      "key": "memberships/latestPeriod/renew/false/autoPay/true",
+      "value": "Gültig bis am {formattedEndDate}"
+    },
+    {
+      "key": "memberships/latestPeriod/renew/false/autoPay/false",
       "value": "Gültig bis am {formattedEndDate}"
     },
     {
@@ -3888,7 +3900,7 @@
     },
     {
       "key": "option/PROLONG/additionalPeriods/BONUS/explanation",
-      "value": "Damit werden im nächsten Jahr nicht mehr so viele Verlängerungen im Januar fällig. Wir verringern unser Klumpenrisiko."
+      "value": null
     },
     {
       "key": "option/PROLONG/additionalPeriods/give",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-10T15:33:37.289Z",
+  "updated": "2019-01-13T13:39:09.965Z",
   "title": "live",
   "data": [
     {
@@ -3195,20 +3195,24 @@
       "value": "Die Gutscheincodes können dann von der beschenkten Person auf <a href=\"/abholen\">republik.ch/abholen</a> eingelöst werden."
     },
     {
+      "key": "memberships/noActive",
+      "value": "Sie haben keine aktiven Mitgliedschaften oder Abonnements"
+    },
+    {
       "key": "memberships/latestPeriod/renew/true",
-      "value": "Gültig bis {formattedEndDate}"
+      "value": "Automatische Erneuerung am {formattedEndDate}"
     },
     {
       "key": "memberships/latestPeriod/renew/false",
-      "value": "Läuft am {formattedEndDate} aus"
-    },
-    {
-      "key": "memberships/MONTHLY_ABO/latestPeriod/renew/true",
-      "value": "Ihr Abonnement wird am {formattedEndDate} automatisch erneuert."
+      "value": "Gültig bis am {formattedEndDate}"
     },
     {
       "key": "memberships/latestPeriod/overdue",
       "value": "Überfällig seit dem {formattedEndDate}"
+    },
+    {
+      "key": "memberships/latestPeriod/ended",
+      "value": "Endete am {formattedEndDate}"
     },
     {
       "key": "memberships/MONTHLY_ABO/manage/prolong/link",

--- a/pages/meta.js
+++ b/pages/meta.js
@@ -85,8 +85,8 @@ const CrowdfundingRevival = compose(
       </Interaction.P>}
       <List>
         <List.Item>Erneuern weniger als 50 Prozent von Ihnen, müssen wir radikal über die Bücher gehen – beim Produkt, bei der Strategie, beim Organigramm.</List.Item>
-        <List.Item><Highlight>Erneuern etwas mehr als 50 Prozent (<Number value={8000} />)</Highlight>, liegt ein langer, steiniger, aber machbarer Weg vor uns bis zum Punkt von <Number value={28000} /> Verlegerinnen, die wir für eine ausgeglichene Rechnung brauchen.</List.Item>
-        <List.Item><Highlight>Schaffen wir, dass zwei von drei Verlegerinnen (<Number value={10660} />) an Bord bleiben</Highlight>, liegt ebenfalls eine Menge an Risiko und Ärger vor uns. Nur wird sich dieser weit konzentrierter um das zukünftige Produkt als um die zukünftige Bilanz drehen.</List.Item>
+        <List.Item><Highlight>Erneuern etwas mehr als 50 Prozent</Highlight>, liegt ein langer, steiniger, aber machbarer Weg vor uns bis zum Punkt von <Number value={28000} /> Verlegerinnen, die wir für eine ausgeglichene Rechnung brauchen.</List.Item>
+        <List.Item><Highlight>Schaffen wir, dass zwei von drei Verlegerinnen an Bord bleiben</Highlight>, liegt ebenfalls eine Menge an Risiko und Ärger vor uns. Nur wird sich dieser weit konzentrierter um das zukünftige Produkt als um die zukünftige Bilanz drehen.</List.Item>
       </List>
     </Center>
   </Fragment>


### PR DESCRIPTION
This Pull Request will ensure a cancelled membership (`renew: false`) can only be reactivated if no prolong is available. An expired membership requires a prolong to be available.

It attempts to improve "state wording" about a membership:

* "Automatische Erneuerung am {formattedEndDate}" displayed not only for `MONTHLY_ABO`
* "Gültig bis am {formattedEndDate}" on cancelled but not expired memberships
* "Endete am {formattedEndDate}" on (auto-)cancelled and expired memberships

<img width="462" alt="bildschirmfoto 2019-01-13 um 14 52 40" src="https://user-images.githubusercontent.com/331800/51086139-ecd25b00-1742-11e9-8a25-ab08c270c005.png">

<img width="457" alt="bildschirmfoto 2019-01-13 um 14 54 26" src="https://user-images.githubusercontent.com/331800/51086152-299e5200-1743-11e9-88c8-8225c43ec788.png">

It renders a note about no active memberships in a first attempt to improve understanding of "Abonnements" section.

<img width="837" alt="bildschirmfoto 2019-01-13 um 14 49 46" src="https://user-images.githubusercontent.com/331800/51086118-9e24c100-1742-11e9-8fe9-fb224141aa45.png">


## Disrupters

### T-30 (as is)
<img width="576" alt="screenshot 2019-01-14 at 00 08 14" src="https://user-images.githubusercontent.com/410211/51091881-25008a80-1791-11e9-8838-77445ac10c47.png">

### T-2
<img width="576" alt="screenshot 2019-01-14 at 00 07 40" src="https://user-images.githubusercontent.com/410211/51091889-38abf100-1791-11e9-94ef-87f3a3c6ebc6.png">

### T+1
<img width="576" alt="screenshot 2019-01-14 at 00 04 44" src="https://user-images.githubusercontent.com/410211/51091890-45c8e000-1791-11e9-8ac0-6502d4e7f098.png">


 