### PR TITLE
notificationOptions: honour app

### DIFF
--- a/components/Discussion/NotificationOptions.js
+++ b/components/Discussion/NotificationOptions.js
@@ -221,7 +221,8 @@ class NotificationOptions extends PureComponent {
           const emailEnabled = discussionNotificationChannels.indexOf('EMAIL') > -1
           const browserEnabled = discussionNotificationChannels.indexOf('WEB') > -1 &&
             webNotificationsPermission === 'granted'
-          const notificationsChannelEnabled = emailEnabled || browserEnabled
+          const appEnabled = discussionNotificationChannels.indexOf('APP') > -1
+          const notificationsChannelEnabled = emailEnabled || browserEnabled || appEnabled
           const types = selectedValue !== 'NONE' && (
             (emailEnabled && browserEnabled && t(`components/Discussion/NotificationChannel/EMAIL_WEB/label`)) ||
             (emailEnabled && t(`components/Discussion/NotificationChannel/EMAIL/label`)) ||

--- a/components/Discussion/NotificationOptions.js
+++ b/components/Discussion/NotificationOptions.js
@@ -223,15 +223,17 @@ class NotificationOptions extends PureComponent {
             webNotificationsPermission === 'granted'
           const appEnabled = discussionNotificationChannels.indexOf('APP') > -1
           const notificationsChannelEnabled = emailEnabled || browserEnabled || appEnabled
-          const types = selectedValue !== 'NONE' && (
-            (emailEnabled && browserEnabled && appEnabled && t(`components/Discussion/NotificationChannel/EMAIL_WEB_APP/label`)) ||
-            (emailEnabled && browserEnabled && t(`components/Discussion/NotificationChannel/EMAIL_WEB/label`)) ||
-            (emailEnabled && appEnabled && t(`components/Discussion/NotificationChannel/EMAIL_APP/label`)) ||
-            (browserEnabled && appEnabled && t(`components/Discussion/NotificationChannel/WEB_APP/label`)) ||
-            (emailEnabled && t(`components/Discussion/NotificationChannel/EMAIL/label`)) ||
-            (appEnabled && t(`components/Discussion/NotificationChannel/APP/label`)) ||
-            (browserEnabled && t(`components/Discussion/NotificationChannel/WEB/label`))
+
+          const translationKey = selectedValue !== 'NONE' && (
+            (emailEnabled && browserEnabled && appEnabled && 'EMAIL_WEB_APP') ||
+            (emailEnabled && browserEnabled && 'EMAIL_WEB') ||
+            (emailEnabled && appEnabled && 'EMAIL_APP') ||
+            (browserEnabled && appEnabled && 'WEB_APP') ||
+            (emailEnabled && 'EMAIL') ||
+            (appEnabled && 'APP') ||
+            (browserEnabled && 'WEB')
           )
+          const types = translationKey && t(`components/Discussion/NotificationChannel/${translationKey}/label`)
 
           const color = selectedValue === 'NONE' ? colors.disabled : colors.primary
 

--- a/components/Discussion/NotificationOptions.js
+++ b/components/Discussion/NotificationOptions.js
@@ -224,8 +224,12 @@ class NotificationOptions extends PureComponent {
           const appEnabled = discussionNotificationChannels.indexOf('APP') > -1
           const notificationsChannelEnabled = emailEnabled || browserEnabled || appEnabled
           const types = selectedValue !== 'NONE' && (
+            (emailEnabled && browserEnabled && appEnabled && t(`components/Discussion/NotificationChannel/EMAIL_WEB_APP/label`)) ||
             (emailEnabled && browserEnabled && t(`components/Discussion/NotificationChannel/EMAIL_WEB/label`)) ||
+            (emailEnabled && appEnabled && t(`components/Discussion/NotificationChannel/EMAIL_APP/label`)) ||
+            (browserEnabled && appEnabled && t(`components/Discussion/NotificationChannel/WEB_APP/label`)) ||
             (emailEnabled && t(`components/Discussion/NotificationChannel/EMAIL/label`)) ||
+            (appEnabled && t(`components/Discussion/NotificationChannel/APP/label`)) ||
             (browserEnabled && t(`components/Discussion/NotificationChannel/WEB/label`))
           )
 

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-29T18:10:43.033Z",
+  "updated": "2019-01-31T14:58:26.301Z",
   "title": "live",
   "data": [
     {
@@ -1592,7 +1592,7 @@
     },
     {
       "key": "components/Discussion/Notification/noChannels",
-      "value": "E-Mail- oder Browser-Benachrichtigungen aktivieren"
+      "value": "E-Mail-, Browser- oder App-Benachrichtigungen aktivieren"
     },
     {
       "key": "components/Discussion/Notification/MY_CHILDREN/label",
@@ -1615,8 +1615,24 @@
       "value": "Browser-Benachrichtigungen"
     },
     {
+      "key": "components/Discussion/NotificationChannel/APP/label",
+      "value": "App-Benachrichtigungen"
+    },
+    {
       "key": "components/Discussion/NotificationChannel/EMAIL_WEB/label",
       "value": "E-Mail- und Browser-Benachrichtigungen"
+    },
+    {
+      "key": "components/Discussion/NotificationChannel/EMAIL_APP/label",
+      "value": "E-Mail- und App-Benachrichtigungen"
+    },
+    {
+      "key": "components/Discussion/NotificationChannel/WEB_APP/label",
+      "value": "Browser- und App-Benachrichtigungen"
+    },
+    {
+      "key": "components/Discussion/NotificationChannel/EMAIL_WEB_APP/label",
+      "value": "E-Mail-, Browser- und App-Benachrichtigungen"
     },
     {
       "key": "components/Discussion/info/MY_CHILDREN",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-01-31T14:58:26.301Z",
+  "updated": "2019-01-31T15:47:15.154Z",
   "title": "live",
   "data": [
     {
@@ -1592,7 +1592,7 @@
     },
     {
       "key": "components/Discussion/Notification/noChannels",
-      "value": "E-Mail-, Browser- oder App-Benachrichtigungen aktivieren"
+      "value": "Benachrichtigungen aktivieren"
     },
     {
       "key": "components/Discussion/Notification/MY_CHILDREN/label",


### PR DESCRIPTION
This PR fixes
1. the NotificationOption not honouring enabled app notifications. This resulted in the chooser not allowing to choose an option if only app notifications are enabled in a user's account
2. the NotificationOption not indicating enabled app notifications in the info label.

Before:
![screenshot from 2019-01-31 13-51-26](https://user-images.githubusercontent.com/3500621/52055604-1fac8980-2560-11e9-9f29-2e60f29ea20f.png)

![19d5f367-4647-4e1f-ac44-e12587c58b35](https://user-images.githubusercontent.com/3500621/52063123-41167100-2572-11e9-9f63-b2acdff069bb.jpeg)
After:
![screenshot from 2019-01-31 13-54-53](https://user-images.githubusercontent.com/3500621/52055611-263b0100-2560-11e9-94ca-9854711b3649.png)

![screenshot from 2019-01-31 16-09-42](https://user-images.githubusercontent.com/3500621/52063314-ad917000-2572-11e9-8c8e-608ab067640b.png)
![screenshot from 2019-01-31 16-09-18](https://user-images.githubusercontent.com/3500621/52063315-ad917000-2572-11e9-8858-bffc3b12b950.png)
![screenshot from 2019-01-31 16-08-34](https://user-images.githubusercontent.com/3500621/52063318-ae2a0680-2572-11e9-9ca4-964e51c51c03.png)
