### PR TITLE
feat(Feed, Article): enable (auto-)discussion icon everywhere

### DIFF
--- a/components/ActionBar/Article.js
+++ b/components/ActionBar/Article.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import ActionBar from './'
 import DiscussionIconLink from '../Discussion/IconLink'
+import { getDiscussionIconLinkProps } from './utils'
 
 import {
   colors
@@ -22,7 +23,14 @@ class ArticleActionBar extends Component {
   }
   render () {
     const { alive } = this.state
-    const { title, discussionId, discussionPage, discussionPath, documentId, dossierUrl, estimatedReadingMinutes, onAudioClick, onGalleryClick, onPdfClick, pdfUrl, showBookmark, t, url, userBookmark, inNativeApp } = this.props
+    const { title, template, path, linkedDiscussion, ownDiscussion, documentId, dossierUrl, estimatedReadingMinutes, onAudioClick, onGalleryClick, onPdfClick, pdfUrl, showBookmark, t, url, userBookmark, inNativeApp } = this.props
+    const {
+      discussionId,
+      discussionPath,
+      discussionQuery,
+      discussionCount,
+      isDiscussionPage
+    } = getDiscussionIconLinkProps(linkedDiscussion, ownDiscussion, template, path)
 
     return (
       <Fragment>
@@ -48,8 +56,10 @@ class ArticleActionBar extends Component {
         {discussionId && alive &&
           <DiscussionIconLink
             discussionId={discussionId}
-            discussionPage={discussionPage}
+            discussionPage={isDiscussionPage}
             path={discussionPath}
+            query={discussionQuery}
+            count={discussionCount}
             style={{ marginLeft: 7 }} />
         }
       </Fragment>

--- a/components/ActionBar/Feed.js
+++ b/components/ActionBar/Feed.js
@@ -5,10 +5,10 @@ import { compose } from 'react-apollo'
 
 import Bookmark from './Bookmark'
 import { DiscussionIconLinkWithoutEnhancer } from '../Discussion/IconLink'
+import { getDiscussionIconLinkProps } from './utils'
 import IconLink from '../IconLink'
 import PathLink from '../Link/Path'
 import ReadingTime from './ReadingTime'
-import { routes } from '../../lib/routes'
 import withT from '../../lib/withT'
 
 import { colors } from '@project-r/styleguide'
@@ -87,24 +87,12 @@ const ActionBar = ({
     }
   ]
 
-  const isLinkedDiscussion = linkedDiscussion && !linkedDiscussion.closed && template === 'article'
-  const isOwnDiscussion = !isLinkedDiscussion && ownDiscussion && !ownDiscussion.closed
-  const isArticleAutoDiscussion = isOwnDiscussion && template === 'article'
-  const isDiscussion = isOwnDiscussion && template === 'discussion'
-  const totalCount =
-    (isLinkedDiscussion && linkedDiscussion.comments && linkedDiscussion.comments.totalCount) ||
-    (isOwnDiscussion && ownDiscussion.comments && ownDiscussion.comments.totalCount) || undefined
-
-  const discussionId =
-    (isLinkedDiscussion && linkedDiscussion.id) ||
-    (isOwnDiscussion && ownDiscussion.id) ||
-    undefined
-  const discussionPath =
-    (isLinkedDiscussion && linkedDiscussion.path) ||
-    (isArticleAutoDiscussion && routes.find(r => r.name === 'discussion').toPath()) ||
-    (isDiscussion && path) ||
-    undefined
-  const query = isArticleAutoDiscussion ? { t: 'article', id: ownDiscussion.id } : undefined
+  const {
+    discussionId,
+    discussionPath,
+    discussionQuery,
+    discussionCount
+  } = getDiscussionIconLinkProps(linkedDiscussion, ownDiscussion, template, path)
 
   return (
     <Fragment>
@@ -130,12 +118,12 @@ const ActionBar = ({
         {estimatedReadingMinutes > 1 && (
           <ReadingTime minutes={estimatedReadingMinutes} small style={{ marginBottom: '-1px' }} />
         )}
-        {(isLinkedDiscussion || isOwnDiscussion) && (
+        {discussionId && (
           <DiscussionIconLinkWithoutEnhancer
             discussionId={discussionId}
             path={discussionPath}
-            query={query}
-            count={totalCount}
+            query={discussionQuery}
+            count={discussionCount}
             small
           />
         )}

--- a/components/ActionBar/utils.js
+++ b/components/ActionBar/utils.js
@@ -1,0 +1,30 @@
+import { routes } from '../../lib/routes'
+
+export const getDiscussionIconLinkProps = (linkedDiscussion, ownDiscussion, template, path) => {
+  const isLinkedDiscussion = linkedDiscussion && !linkedDiscussion.closed && template === 'article'
+  const isOwnDiscussion = !isLinkedDiscussion && ownDiscussion && !ownDiscussion.closed
+  const isArticleAutoDiscussion = isOwnDiscussion && template === 'article'
+  const isDiscussionPage = isOwnDiscussion && template === 'discussion'
+  const discussionCount =
+    (isLinkedDiscussion && linkedDiscussion.comments && linkedDiscussion.comments.totalCount) ||
+    (isOwnDiscussion && ownDiscussion.comments && ownDiscussion.comments.totalCount) || undefined
+
+  const discussionId =
+    (isLinkedDiscussion && linkedDiscussion.id) ||
+    (isOwnDiscussion && ownDiscussion.id) ||
+    undefined
+  const discussionPath =
+    (isLinkedDiscussion && linkedDiscussion.path) ||
+    (isArticleAutoDiscussion && routes.find(r => r.name === 'discussion').toPath()) ||
+    (isDiscussionPage && path) ||
+    undefined
+  const discussionQuery = isArticleAutoDiscussion ? { t: 'article', id: ownDiscussion.id } : undefined
+
+  return {
+    discussionId,
+    discussionPath,
+    discussionQuery,
+    discussionCount,
+    isDiscussionPage
+  }
+}

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -96,11 +96,17 @@ const getDocument = gql`
         ownDiscussion {
           id
           closed
+          comments {
+            totalCount
+          }
         }
         linkedDiscussion {
           id
           path
           closed
+          comments {
+            totalCount
+          }
         }
         color
         format {
@@ -289,12 +295,6 @@ class ArticlePage extends Component {
       ...runMetaFromQuery(article.content.meta.fromQuery, router.query)
     }
 
-    const linkedDiscussion = meta &&
-      meta.linkedDiscussion &&
-      !meta.linkedDiscussion.closed &&
-      meta.linkedDiscussion
-    const linkedDiscussionId = linkedDiscussion && linkedDiscussion.id
-
     const hasPdf = meta && meta.template === 'article'
 
     const actionBar = meta && (
@@ -302,9 +302,10 @@ class ArticlePage extends Component {
         t={t}
         url={meta.url}
         title={meta.title}
-        discussionPage={meta && meta.template === 'discussion'}
-        discussionId={linkedDiscussionId}
-        discussionPath={linkedDiscussion && linkedDiscussion.path}
+        template={meta.template}
+        path={meta.path}
+        linkedDiscussion={meta.linkedDiscussion}
+        ownDiscussion={meta.ownDiscussion}
         dossierUrl={meta.dossier && meta.dossier.meta.path}
         onAudioClick={meta.audioSource && this.toggleAudio}
         onGalleryClick={meta.indicateGallery && this.showGallery}

--- a/components/Feed/DocumentListContainer.js
+++ b/components/Feed/DocumentListContainer.js
@@ -40,6 +40,21 @@ export const documentFragment = `
           kind
         }
       }
+      ownDiscussion {
+        id
+        closed
+        comments {
+          totalCount
+        }
+      }
+      linkedDiscussion {
+        id
+        path
+        closed
+        comments {
+          totalCount
+        }
+      }
     }
   }
   ${bookmarkOnDocumentFragment}


### PR DESCRIPTION
Depends on https://github.com/orbiting/backends/pull/202

Enables:
- Both ownDiscussion and linkedDiscussion icons in Feed
- ownDiscussion icon in article

_Note that articles with ownDiscussion will now have both the icon and the end-of-article box._

## ownDiscussion icon in feed
<img width="543" alt="screenshot 2019-01-31 at 20 10 15" src="https://user-images.githubusercontent.com/23520051/52078839-8350aa00-2594-11e9-930f-e0943ae03402.png">

## ownDiscussion icon in article
<img width="622" alt="screenshot 2019-01-31 at 20 10 39" src="https://user-images.githubusercontent.com/23520051/52078840-8350aa00-2594-11e9-9b02-0d42a8d9981c.png">
