### PR TITLE
feat(Feed): add subtle tag for pre-published articles

### DIFF
--- a/components/Feed/DocumentListContainer.js
+++ b/components/Feed/DocumentListContainer.js
@@ -21,6 +21,7 @@ export const documentFragment = `
       title
       description
       publishDate
+      prepublication
       path
       kind
       template

--- a/components/Feed/Feed.js
+++ b/components/Feed/Feed.js
@@ -21,6 +21,7 @@ class Feed extends Component {
   renderFeedItem = doc =>
     <TeaserFeed
       {...doc.meta}
+      t={this.props.t}
       credits={this.props.showHeader ? formatCredits(doc.meta.credits) : doc.meta.credits}
       publishDate={undefined}
       kind={

--- a/components/Feed/StickySection.js
+++ b/components/Feed/StickySection.js
@@ -1,5 +1,9 @@
 import { Component } from 'react'
-import { HEADER_HEIGHT, HEADER_HEIGHT_MOBILE } from '../constants'
+import {
+  HEADER_HEIGHT,
+  HEADER_HEIGHT_MOBILE,
+  ZINDEX_FEED_STICKY_SECTION_LABEL
+} from '../constants'
 import { css } from 'glamor'
 import { mediaQueries, colors } from '@project-r/styleguide'
 import PropTypes from 'prop-types'
@@ -27,7 +31,8 @@ const style = {
   label: css({
     padding: '8px 0',
     borderTop: '1px solid #000',
-    backgroundColor: '#fff'
+    backgroundColor: '#fff',
+    zIndex: ZINDEX_FEED_STICKY_SECTION_LABEL
   }),
   sticky: css({
     top: HEADER_HEIGHT_MOBILE - 1,

--- a/components/constants.js
+++ b/components/constants.js
@@ -24,6 +24,7 @@ export const ZINDEX_BOTTOM_PANEL = 16
 export const ZINDEX_CONTENT = 15
 export const ZINDEX_FOOTER = 11
 export const ZINDEX_SIDEBAR = 10
+export const ZINDEX_FEED_STICKY_SECTION_LABEL = 2
 export const ZINDEX_FRAME_TOGGLE = 1
 
 export const DEFAULT_TOKEN_TYPE = 'EMAIL_TOKEN'

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-02-14T10:10:21.554Z",
+  "updated": "2019-02-14T14:37:45.985Z",
   "title": "live",
   "data": [
     {
@@ -4473,6 +4473,10 @@
     {
       "key": "pages/bookmarks/placeholder/feedText",
       "value": "Feed"
+    },
+    {
+      "key": "styleguide/TeaserFeed/InternalOnlyTag",
+      "value": "INTERN"
     }
   ]
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-02-14T14:37:45.985Z",
+  "updated": "2019-02-14T17:51:42.716Z",
   "title": "live",
   "data": [
     {
@@ -4476,7 +4476,7 @@
     },
     {
       "key": "styleguide/TeaserFeed/InternalOnlyTag",
-      "value": "INTERN"
+      "value": "Nur intern publiziert"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,9 +885,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.23.0.tgz",
-      "integrity": "sha512-9e0Fcqa3e2vb2RPlqfasnAC+ea2gjC+rstJ/4TObdqWr5nkDtRYe4n6cs+ceyZ2VV4SKa4nP/TFZlsMw7CLqBA==",
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.25.1.tgz",
+      "integrity": "sha512-00oDEB993ROwjoudDjxJ+A10TTPRUi1ElVrCjnEAaLuDFE1rjwYbNmsDsCm0xDv8CLZW4kVq0rVTQe2VzHJEbA==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^6.23.0",
+    "@project-r/styleguide": "^6.25.1",
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",


### PR DESCRIPTION
Depends on https://github.com/orbiting/styleguide/pull/216

**Purpose**
Avoid internal confusion when prepublished articles appear in feed, looking as if they were public.

**Solution**
Add a subtle tag on the article teaser, based on the already existing flag in API.

Note that I had to introduce a z-index because making the TeaserFeed container `position: relative` in the styleguide caused the sticky date labels to be stacked under the scrolling teasers.

<img width="964" alt="screenshot 2019-02-14 at 18 52 57" src="https://user-images.githubusercontent.com/23520051/52806626-ca0ccc80-3089-11e9-8bbe-402db4d8b0a3.png">

<img width="382" alt="screenshot 2019-02-14 at 18 52 19" src="https://user-images.githubusercontent.com/23520051/52806655-d8f37f00-3089-11e9-84fc-776dd9bc14ab.png">

