### PR TITLE
fix(Statements): allow up- and downvote from the beginning

### DIFF
--- a/components/Discussion/Statements.js
+++ b/components/Discussion/Statements.js
@@ -201,8 +201,6 @@ class Statements extends Component {
                           downVotes,
                           content
                         } = node
-                        const canUpvote = !userVote || userVote === 'DOWN'
-
                         return (
                           <div {...styles.wrapper} key={`comment-${id}`}>
                             <div {...styles.questionRank}>{index + 1}.</div>
@@ -217,7 +215,11 @@ class Statements extends Component {
                                   {(mutateComment) => (
                                     <div {...styles.vote}>
                                       <IconButton
-                                        onClick={canUpvote ? this.submitHandler(mutateComment, { commentId: id }) : null}
+                                        onClick={
+                                          (!userVote || userVote === 'DOWN')
+                                            ? this.submitHandler(mutateComment, { commentId: id })
+                                            : null
+                                        }
                                         title={t('styleguide/CommentActions/upvote')}>
                                         <MdKeyboardArrowUp />
                                       </IconButton>
@@ -236,7 +238,11 @@ class Statements extends Component {
                                       <Label
                                         title={t.pluralize('styleguide/CommentActions/downvote/count', { count: downVotes })}>{downVotes}</Label>
                                       <IconButton
-                                        onClick={!canUpvote ? this.submitHandler(mutateComment, { commentId: id }) : null}
+                                        onClick={
+                                          (!userVote || userVote === 'UP')
+                                            ? this.submitHandler(mutateComment, { commentId: id })
+                                            : null
+                                        }
                                         title={t('styleguide/CommentActions/downvote')}>
                                         <MdKeyboardArrowDown />
                                       </IconButton>


### PR DESCRIPTION
instead of only allowing to upvote initially, allow up- and down-voting

this:
![screenshot from 2019-02-15 11-52-51](https://user-images.githubusercontent.com/3500621/52852250-58c82a80-3118-11e9-8d79-2e898156fc0d.png)

becomes this:
![screenshot from 2019-02-15 11-53-13](https://user-images.githubusercontent.com/3500621/52852248-58c82a80-3118-11e9-9274-50c2cabe8d8d.png)

