### PR TITLE
Progress: misc launch-blocking fixes

### DIFF
--- a/components/ActionBar/UserProgress.js
+++ b/components/ActionBar/UserProgress.js
@@ -30,8 +30,10 @@ const styles = {
 }
 
 const UserProgress = ({ t, userProgress }) => {
-  const { percentage } = userProgress
-  const percent = Math.round(percentage * 100)
+  const { percentage, max } = userProgress
+  const percent = !percentage && max && max.percentage === 1
+    ? 100
+    : Math.round(percentage * 100)
   if (!percent) {
     return null
   }

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -345,7 +345,6 @@ class ArticlePage extends Component {
           <AudioPlayer
             mediaId={audioSource.mediaId}
             src={audioSource}
-            userProgress={audioSource.userProgress}
             closeHandler={this.toggleAudio}
             autoPlay
             download

--- a/components/Article/Progress/BackToTopButton.js
+++ b/components/Article/Progress/BackToTopButton.js
@@ -1,15 +1,35 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
+import datetime from './datetime'
 import withT from '../../../lib/withT'
 import UpIcon from 'react-icons/lib/md/arrow-upward'
 import { negativeColors } from '../../Frame/constants'
+
+import {
+  colors,
+  mediaQueries
+} from '@project-r/styleguide'
 
 const ANIMATE_OUT_DURATION_SECS = 0.3
 const RADIUS = 16
 
 const styles = {
   container: css({
+    background: '#fff',
+    borderTop: `1px solid ${colors.divider}`,
+    color: colors.text,
+    position: 'fixed',
+    bottom: 0,
+    transition: `opacity ${ANIMATE_OUT_DURATION_SECS}s ease-in-out`,
+    textAlign: 'center',
+    padding: `${RADIUS + 5}px 15px 30px 15px`,
+    width: '100%',
+    [mediaQueries.mUp]: {
+      paddingBottom: '50px'
+    }
+  }),
+  button: css({
     backgroundColor: negativeColors.primaryBg,
     boxShadow: '0 0 0px 2px rgba(255, 255, 255, .25)',
     cursor: 'pointer',
@@ -17,15 +37,31 @@ const styles = {
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    position: 'fixed',
-    bottom: 70,
+    position: 'absolute',
+    top: -RADIUS,
     left: `calc(50% - ${RADIUS}px)`,
     width: `${RADIUS * 2}px`,
     height: `${RADIUS * 2}px`,
     borderRadius: `${RADIUS}px`,
     border: 'none',
-    outline: 'none',
-    transition: `opacity ${ANIMATE_OUT_DURATION_SECS}s ease-in-out`
+    outline: 'none'
+  }),
+  label: css({
+    cursor: 'pointer',
+    marginBottom: 5,
+    fontSize: 16,
+    [mediaQueries.mUp]: {
+      fontSize: 19,
+      marginBottom: 10
+    }
+  }),
+  note: css({
+    color: colors.lightText,
+    cursor: 'pointer',
+    fontSize: 16,
+    [mediaQueries.mUp]: {
+      fontSize: 19
+    }
   })
 }
 
@@ -36,14 +72,18 @@ class BackToTopButton extends React.Component {
     this.state = {
       closed: false
     }
+
+    this.close = () => {
+      setTimeout(() => {
+        this.setState({ closed: true })
+      }, ANIMATE_OUT_DURATION_SECS * 1000)
+    }
   }
 
   componentDidUpdate () {
     const { animateOut } = this.props
     if (!this.state.closed && animateOut) {
-      setTimeout(() => {
-        this.setState({ closed: true })
-      }, ANIMATE_OUT_DURATION_SECS * 1000)
+      this.close()
     }
   }
 
@@ -52,18 +92,31 @@ class BackToTopButton extends React.Component {
     if (closed) {
       return null
     }
-    const { t, onClick, animateOut, style } = this.props
-    const opacity = animateOut ? 0 : 1
+    const { t, onClick, animateOut, style, updatedAt } = this.props
+    const opacity = animateOut || this.state.animateOut ? 0 : 1
+    const date = updatedAt && Date.parse(updatedAt)
 
     return (
-      <button
-        {...styles.container}
-        style={{ ...style, opacity }}
-        onClick={onClick}
-        title={t('article/progress/backtotopbutton/title')}
-      >
-        <UpIcon size={RADIUS * 1.5} fill={negativeColors.text} />
-      </button>
+      <div {...styles.container} style={{ ...style, opacity }}>
+        <button
+          {...styles.button}
+          onClick={onClick}
+          title={t('article/progress/backtotopbutton/title')}
+        >
+          <UpIcon size={RADIUS * 1.5} fill={negativeColors.text} />
+        </button>
+        <div {...styles.label} onClick={onClick}>
+          {t('article/progress/backtotopbutton/title')}
+        </div>
+        {date && (
+          <div {...styles.note} onClick={() => {
+            this.setState({ animateOut: true })
+            this.close()
+          }}>
+            {datetime(t, date)}
+          </div>
+        )}
+      </div>
     )
   }
 }
@@ -72,7 +125,8 @@ BackToTopButton.propTypes = {
   t: PropTypes.func,
   onClick: PropTypes.func,
   animateOut: PropTypes.bool,
-  style: PropTypes.object
+  style: PropTypes.object,
+  updatedAt: PropTypes.string
 }
 
 export default withT(BackToTopButton)

--- a/components/Article/Progress/api.js
+++ b/components/Article/Progress/api.js
@@ -1,4 +1,4 @@
-import { graphql, compose } from 'react-apollo'
+import { graphql, compose, withApollo } from 'react-apollo'
 import gql from 'graphql-tag'
 
 export const userProgressFragment = `
@@ -103,20 +103,25 @@ const upsertMediaProgressMutation = gql`
   }
 `
 
-export const userProgressOnAudioSourceFragment = `
-  fragment UserProgressOnAudioSource on AudioSource {
-    mediaId
-    durationMs
-    userProgress {
+export const mediaProgressQuery = gql`
+  query mediaProgress($mediaId: ID!) {
+    mediaProgress(mediaId: $mediaId) {
       id
+      mediaId
       secs
-      createdAt
-      updatedAt
     }
   }
 `
 
+export const userProgressOnAudioSourceFragment = `
+  fragment UserProgressOnAudioSource on AudioSource {
+    mediaId
+    durationMs
+  }
+`
+
 export const withProgressApi = compose(
+  withApollo,
   graphql(consentQuery, {
     props: ({ data, errors }) => ({
       data,

--- a/components/Article/Progress/api.js
+++ b/components/Article/Progress/api.js
@@ -9,6 +9,10 @@ export const userProgressFragment = `
       nodeId
       createdAt
       updatedAt
+      max {
+        id
+        percentage
+      }
     }
   }
 `

--- a/components/Article/Progress/datetime.js
+++ b/components/Article/Progress/datetime.js
@@ -1,0 +1,30 @@
+import { timeFormat, swissTime } from '../../../lib/utils/format'
+
+const MS_PER_DAY = 60 * 60 * 24 * 1000
+
+const getLastMidnight = () => {
+  const today = new Date()
+  today.setHours(0)
+  today.setMinutes(0)
+  today.setSeconds(0)
+  return today
+}
+
+export default (t, date, lastMidnight = getLastMidnight()) => {
+  const diff = date - lastMidnight
+
+  const formatDate = swissTime.format('%d.%m.%Y')
+  const formatTime = timeFormat('%H:%M')
+
+  const displayDay = diff > 0
+    ? t('article/progress/time/today')
+    : diff > -MS_PER_DAY
+      ? t('article/progress/time/yesterday')
+      : t('article/progress/time/other', { date: formatDate(date) })
+  const displayTime = formatTime(date)
+
+  return t('article/progress/time', {
+    day: displayDay,
+    time: displayTime
+  })
+}

--- a/components/Article/Progress/datetime.test.js
+++ b/components/Article/Progress/datetime.test.js
@@ -1,0 +1,38 @@
+import test from 'tape'
+import datetime from './datetime'
+import { t } from '../../../lib/withT'
+
+[
+  [
+    'today',
+    new Date(2019, 1, 15, 7, 14, 0),
+    new Date(2019, 1, 15, 0, 0, 0),
+    'Ihre Leseposition von heute um 07:14 Uhr.'
+  ],
+  [
+    'yesterday',
+    new Date(2019, 1, 14, 7, 14, 0),
+    new Date(2019, 1, 15, 0, 0, 0),
+    'Ihre Leseposition von gestern um 07:14 Uhr.'
+  ],
+  [
+    'two days ago',
+    new Date(2019, 1, 13, 7, 14, 0),
+    new Date(2019, 1, 15, 0, 0, 0),
+    'Ihre Leseposition vom 13.02.2019 um 07:14 Uhr.'
+  ],
+  [
+    'one year ago',
+    new Date(2018, 1, 15, 7, 14, 0),
+    new Date(2019, 1, 15, 0, 0, 0),
+    'Ihre Leseposition vom 15.02.2018 um 07:14 Uhr.'
+  ]
+].map(([title, date, lastMidnight, expected]) => {
+  test(`datetime.${title}`, assert => {
+    assert.equal(
+      datetime(t, date, lastMidnight),
+      expected
+    )
+    assert.end()
+  })
+})

--- a/components/Article/Progress/datetime.test.js
+++ b/components/Article/Progress/datetime.test.js
@@ -19,13 +19,13 @@ import { t } from '../../../lib/withT'
     'two days ago',
     new Date(2019, 1, 13, 7, 14, 0),
     new Date(2019, 1, 15, 0, 0, 0),
-    'Ihre Leseposition vom 13.02.2019 um 07:14 Uhr.'
+    'Ihre Leseposition am 13.02.2019 um 07:14 Uhr.'
   ],
   [
     'one year ago',
     new Date(2018, 1, 15, 7, 14, 0),
     new Date(2019, 1, 15, 0, 0, 0),
-    'Ihre Leseposition vom 15.02.2018 um 07:14 Uhr.'
+    'Ihre Leseposition am 15.02.2018 um 07:14 Uhr.'
   ]
 ].map(([title, date, lastMidnight, expected]) => {
   test(`datetime.${title}`, assert => {

--- a/components/Article/Progress/datetime.test.js
+++ b/components/Article/Progress/datetime.test.js
@@ -7,13 +7,13 @@ import { t } from '../../../lib/withT'
     'today',
     new Date(2019, 1, 15, 7, 14, 0),
     new Date(2019, 1, 15, 0, 0, 0),
-    'Ihre Leseposition von heute um 07:14 Uhr.'
+    'Ihre Leseposition heute um 07:14 Uhr.'
   ],
   [
     'yesterday',
     new Date(2019, 1, 14, 7, 14, 0),
     new Date(2019, 1, 15, 0, 0, 0),
-    'Ihre Leseposition von gestern um 07:14 Uhr.'
+    'Ihre Leseposition gestern um 07:14 Uhr.'
   ],
   [
     'two days ago',

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -244,12 +244,14 @@ class Progress extends Component {
           // We only persist progress for a downward scroll, but we still measure
           // an upward scroll to keep track of the current reading position.
           const progress = this.measureProgress(downwards)
+          const storedUserProgress = this.props.article && this.props.article.userProgress
           if (
             downwards &&
             progress &&
             progress.nodeId &&
             progress.percentage > 0 &&
-            progress.elementIndex > 1 // ignore first two elements.
+            progress.elementIndex > 1 && // ignore first two elements.
+            (!storedUserProgress || storedUserProgress.nodeId !== progress.nodeId)
           ) {
             this.props.upsertDocumentProgress(documentId, progress.percentage, progress.nodeId)
           }
@@ -381,6 +383,7 @@ class Progress extends Component {
     const { initialized, width, percentage, pageYOffset, showBackToTopButton, BackToTopButtonAnimateOut } = this.state
     const {
       children,
+      article,
       myProgressConsent,
       revokeConsent,
       submitConsent,
@@ -390,6 +393,7 @@ class Progress extends Component {
 
     const showConsentPrompt = myProgressConsent && myProgressConsent.hasConsentedTo === null
     const consentRejected = myProgressConsent && myProgressConsent.hasConsentedTo === false
+    const updatedAt = article && article.userProgress && article.userProgress.updatedAt
 
     const progressPrompt = showConsentPrompt && isArticle
       ? (
@@ -413,7 +417,7 @@ class Progress extends Component {
         {progressPrompt}
         {children}
         {showBackToTopButton && (
-          <BackToTopButton onClick={this.scrollToTop} animateOut={BackToTopButtonAnimateOut} />
+          <BackToTopButton onClick={this.scrollToTop} animateOut={BackToTopButtonAnimateOut} updatedAt={updatedAt} />
         )}
         {debug && (
           <div style={{ position: 'fixed', bottom: 0, color: '#fff', left: 0, right: 0, background: 'rgba(0, 0, 0, .7)', padding: '3px 10px' }}>

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -326,7 +326,7 @@ class Progress extends Component {
         variables: { mediaId },
         fetchPolicy: 'network-only'
       }).then(({ data }) => {
-        return Promise.resolve(data.mediaProgress && data.mediaProgress.secs)
+        return data.mediaProgress && data.mediaProgress.secs
       })
     }
 

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -321,18 +321,12 @@ class Progress extends Component {
     }, 5000, { 'trailing': false })
 
     this.getMediaProgress = (mediaId) => {
-      return new Promise((resolve, reject) => {
-        this.props.client.query({
-          query: mediaProgressQuery,
-          variables: { mediaId },
-          fetchPolicy: 'network-only'
-        }).then(({ data, errors }) => {
-          if (data.mediaProgress || data.mediaProgress === null) {
-            resolve(data.mediaProgress && data.mediaProgress.secs)
-          }
-        }).catch(() => {
-          resolve()
-        })
+      return this.props.client.query({
+        query: mediaProgressQuery,
+        variables: { mediaId },
+        fetchPolicy: 'network-only'
+      }).then(({ data }) => {
+        return Promise.resolve(data.mediaProgress && data.mediaProgress.secs)
       })
     }
 

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -332,8 +332,7 @@ class Progress extends Component {
           }
         }).catch(() => {
           resolve()
-        }
-        )
+        })
       })
     }
 

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -83,7 +83,12 @@ class Progress extends Component {
     }
 
     this.poll = (userProgress) => {
-      if (!userProgress || !this.props.isArticle || (!userProgress.nodeId && !userProgress.percentage)) {
+      if (
+        !userProgress ||
+        !this.props.isArticle ||
+        (!userProgress.nodeId && !userProgress.percentage) ||
+        userProgress.percentage === 1
+      ) {
         this.setState({ initialized: true })
         return
       }

--- a/components/Feed/fragments.js
+++ b/components/Feed/fragments.js
@@ -1,9 +1,11 @@
 import { onDocumentFragment as bookmarkOnDocumentFragment } from '../Bookmarks/fragments'
+import { userProgressFragment } from '../Article/Progress/api'
 
 export const documentFragment = `
   fragment DocumentListDocument on Document {
     id
     ...BookmarkOnDocument
+    ...UserProgressOnDocument
     meta {
       credits
       title
@@ -35,4 +37,5 @@ export const documentFragment = `
     }
   }
   ${bookmarkOnDocumentFragment}
+  ${userProgressFragment}
 `

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-02-19T09:23:31.549Z",
+  "updated": "2019-02-25T16:17:53.822Z",
   "title": "live",
   "data": [
     {
@@ -3048,7 +3048,23 @@
     },
     {
       "key": "article/progress/backtotopbutton/title",
-      "value": "Nach oben"
+      "value": "Zum Anfang"
+    },
+    {
+      "key": "article/progress/time",
+      "value": "Ihre Leseposition {day} um {time} Uhr."
+    },
+    {
+      "key": "article/progress/time/today",
+      "value": "von heute"
+    },
+    {
+      "key": "article/progress/time/yesterday",
+      "value": "von gestern"
+    },
+    {
+      "key": "article/progress/time/other",
+      "value": "vom {date}"
     },
     {
       "key": "merci/postpay/lead",
@@ -4477,6 +4493,66 @@
     {
       "key": "styleguide/TeaserFeed/InternalOnlyTag",
       "value": "Intern publiziert"
+    },
+    {
+      "key": "pages/about/title",
+      "value": "Das sind wir"
+    },
+    {
+      "key": "pages/about/lead",
+      "value": "Die Republik ist ein digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen und Lesern. Gemeinsam sind wir eine Rebellion gegen die Medienkonzerne, für die Medienvielfalt. Unabhängig, werbefrei – und mit nur einem Ziel: begeisternden Journalismus zu liefern."
+    },
+    {
+      "key": "pages/about/audience/title",
+      "value": "Über {count} Leserinnen pro Monat"
+    },
+    {
+      "key": "pages/about/audience/text",
+      "value": "Klein genug, um zu überleben. Gross genug, um Wirkung zu haben. Das war 2018 der Plan beim Start der Republik. Heute machen wir tatsächlich immer wieder einen Unterschied. {emphasis1} Für unsere wachsende Leserschaft. Und die Öffentlichkeit. Manchmal gelingt es. Manchmal scheitern wir. Immer arbeiten wir hart daran. Versprochen!"
+    },
+    {
+      "key": "pages/about/audience/text/emphasis1",
+      "value": "Die Mächtigen beobachten, kritisieren, die Gesellschaft bewegen, Fragen klären, Debatten anstossen: Das ist unser Service."
+    },
+    {
+      "key": "pages/about/publishers/title",
+      "value": "{count} Verleger"
+    },
+    {
+      "key": "pages/about/publishers/text",
+      "value": "Ein neues Geschäftsmodell für unabhängigen Journalismus schaffen wir nur gemeinsam – oder gar nicht. Deshalb gehört die Republik nicht nur uns Macherinnen, sondern auch ihren Lesern. {emphasis1} Ohne ihre aktuell {count} Verlegerinnen wäre die Republik – nichts! Täglich kommen neue Unterstützer an Bord. Bald auch Sie?"
+    },
+    {
+      "key": "pages/about/publishers/text/emphasis1",
+      "value": "Journalismus braucht ein aufmerksames, neugieriges und furchtloses Publikum, das bereit ist, in unabhängigen Journalismus zu investieren."
+    },
+    {
+      "key": "pages/about/output/title",
+      "value": "{count}  Produktionen"
+    },
+    {
+      "key": "pages/about/output/text",
+      "value": "Die Republik erscheint von Montag bis Samstag – {emphasis1} Und liefert Ihnen {emphasis2} zu den wichtigsten Fragen der Gegenwart. Weniger, dafür besser: Das ist unser Anspruch. Und Sie besuchen uns, wann Sie wollen: täglich, wöchentlich, monatlich. Brisante Recherchen, erhellende Analysen und Debatten, unterhaltsame Essays. In Texten, Bildern, Podcasts, Videos, Grafiken – und live an Veranstaltungen."
+    },
+    {
+      "key": "pages/about/output/text/emphasis1",
+      "value": "auf der Website, als Newsletter, in der App."
+    },
+    {
+      "key": "pages/about/output/text/emphasis2",
+      "value": "täglich ein bis drei Beiträge"
+    },
+    {
+      "key": "pages/about/employees/title",
+      "value": "{count} Macherinnen"
+    },
+    {
+      "key": "pages/about/employees/text",
+      "value": "Unsere Crew ist Ihr persönliches Expeditionsteam in die Wirklichkeit. Wir arbeiten uns durch den Staub der Welt, trennen Wichtiges von Unwichtigem – und liefern Ihnen in der verworrenen Gegenwart die bestmögliche Übersicht. Doch die Republik ist mehr als Ihre Redaktion. Vom Community-Team über die Marketing-Expertinnen bis zum Erste-Hilfe-Team."
+    },
+    {
+      "key": "pages/about/mediaResponses/title",
+      "value": "Das sagen andere über uns"
     }
   ]
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-02-25T16:17:53.822Z",
+  "updated": "2019-02-26T09:18:34.521Z",
   "title": "live",
   "data": [
     {
@@ -3064,7 +3064,7 @@
     },
     {
       "key": "article/progress/time/other",
-      "value": "vom {date}"
+      "value": "am {date}"
     },
     {
       "key": "merci/postpay/lead",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-02-26T09:18:34.521Z",
+  "updated": "2019-02-26T09:26:20.154Z",
   "title": "live",
   "data": [
     {
@@ -3056,11 +3056,11 @@
     },
     {
       "key": "article/progress/time/today",
-      "value": "von heute"
+      "value": "heute"
     },
     {
       "key": "article/progress/time/yesterday",
-      "value": "von gestern"
+      "value": "gestern"
     },
     {
       "key": "article/progress/time/other",

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,8 +885,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "https://s3.eu-central-1.amazonaws.com/republik-assets-dev/npm/project-r-styleguide-position.tgz",
-      "integrity": "sha512-FUZWIao2HAZeaBPJBzn7MFFJf2pi+QlgEk+XQzLfta9sof0LQaU5cyp81Fhb/jC4dLtQzvuwL/lvAb1ROsWvhw==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.25.2.tgz",
+      "integrity": "sha512-kKsNfIqtjAAeahZvraeN6hEw7FTjolotmHA4Jk6qt0yX+U9NrL9mof5ktHPl8oq+IzPojJsSx0OEmgOUuu6GWw==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,9 +885,8 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-6.25.1.tgz",
-      "integrity": "sha512-00oDEB993ROwjoudDjxJ+A10TTPRUi1ElVrCjnEAaLuDFE1rjwYbNmsDsCm0xDv8CLZW4kVq0rVTQe2VzHJEbA==",
+      "version": "https://s3.eu-central-1.amazonaws.com/republik-assets-dev/npm/project-r-styleguide-position.tgz",
+      "integrity": "sha512-FUZWIao2HAZeaBPJBzn7MFFJf2pi+QlgEk+XQzLfta9sof0LQaU5cyp81Fhb/jC4dLtQzvuwL/lvAb1ROsWvhw==",
       "requires": {
         "react-icons": "^2.2.7",
         "react-swipeable": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "^6.25.1",
+    "@project-r/styleguide": "https://s3.eu-central-1.amazonaws.com/republik-assets-dev/npm/project-r-styleguide-position.tgz",
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tape": "^4.9.1"
   },
   "dependencies": {
-    "@project-r/styleguide": "https://s3.eu-central-1.amazonaws.com/republik-assets-dev/npm/project-r-styleguide-position.tgz",
+    "@project-r/styleguide": "^6.25.2",
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "apollo-cache-inmemory": "^1.2.10",
     "apollo-client": "^2.4.2",


### PR DESCRIPTION
Misc fixes:
- don't restore document position at 100%
- display max percentage in teasers if it's 100%
- enable progress circle on article teasers also on Bookmarks page
- add more user guidance and visibility to back-to-top button
- load mediaProgress independent of document (so that audio progress refreshes cross-device on close and re-open)

Depends on https://github.com/orbiting/styleguide/pull/219