### PR TITLE
Fix year divisor in lib/timeago, lib/timeahead

### DIFF
--- a/lib/timeago.js
+++ b/lib/timeago.js
@@ -5,13 +5,13 @@ const specs = [
   { n: 7, key: 'timeago/days' },
   { n: 365 / 7 / 12, key: 'timeago/weeks' },
   { n: 12, key: 'timeago/months', fn: 'round' },
-  { n: 10, key: 'timeago/years' }
+  { n: 1, key: 'timeago/years' }
 ]
 
 // diff is in seconds, positive.
 export default (t, diff) => {
   let i = 0
-  for (; diff >= specs[i].n && i < specs.length; i++) {
+  for (; i < specs.length && diff >= specs[i].n; i++) {
     diff /= specs[i].n
   }
 

--- a/lib/timeago.test.js
+++ b/lib/timeago.test.js
@@ -4,10 +4,10 @@ import { t } from './withT'
 
 [
   [
-    'now',
-    new Date(2018, 0, 11),
-    new Date(2018, 0, 11),
-    'gerade eben'
+    'now', // test name
+    new Date(2018, 0, 11), // "now"
+    new Date(2018, 0, 11), // date to compare now with
+    'gerade eben' // expected return string
   ],
   [
     'minutes',
@@ -40,10 +40,28 @@ import { t } from './withT'
     'vor 2 Monaten'
   ],
   [
-    'the case that lead to the bug discovery',
+    '7 months ago',
     new Date(2018, 0, 12),
     new Date(2017, 4, 31),
     'vor 7 Monaten'
+  ],
+  [
+    'a year ago',
+    new Date(2018, 0, 11),
+    new Date(2017, 0, 1),
+    'vor einem Jahr'
+  ],
+  [
+    '3 years ago',
+    new Date(2018, 0, 11),
+    new Date(2015, 0, 11),
+    'vor 3 Jahren'
+  ],
+  [
+    '11 years ago',
+    new Date(2018, 0, 11),
+    new Date(2007, 0, 11),
+    'vor 11 Jahren'
   ]
 ].map(([title, now, date, expected]) => {
   test(`timeago.${title}`, assert => {

--- a/lib/timeahead.js
+++ b/lib/timeahead.js
@@ -5,14 +5,14 @@ const specs = [
   { n: 7, key: 'timeAhead/days' },
   { n: 365 / 7 / 12, key: 'timeAhead/weeks' },
   { n: 12, key: 'timeAhead/months', fn: 'round' },
-  { n: 10, key: 'timeAhead/years' }
+  { n: 1, key: 'timeAhead/years' }
 ]
 
 // diff is in seconds.
 export default (t, diff) => {
   diff = Math.abs(diff)
   let i = 0
-  for (; diff >= specs[i].n && i < specs.length; i++) {
+  for (; i < specs.length && diff >= specs[i].n; i++) {
     diff /= specs[i].n
   }
 

--- a/lib/timeahead.test.js
+++ b/lib/timeahead.test.js
@@ -4,10 +4,10 @@ import { t } from './withT'
 
 [
   [
-    'now',
-    new Date(2018, 0, 11),
-    new Date(2018, 0, 11),
-    'in weniger als einer Minute'
+    'now', // test name
+    new Date(2018, 0, 11), // "now"
+    new Date(2018, 0, 11), // date to compare now with
+    'in weniger als einer Minute' // expected return string
   ],
   [
     'second ahead',
@@ -68,6 +68,12 @@ import { t } from './withT'
     new Date(2017, 4, 31),
     new Date(2018, 5, 1),
     'in einem Jahr'
+  ],
+  [
+    '11 years ahead',
+    new Date(2017, 4, 31),
+    new Date(2028, 5, 1),
+    'in 11 Jahren'
   ]
 ].map(([title, now, date, expected]) => {
   test(`timeahead.${title}`, assert => {


### PR DESCRIPTION
This Pull Request fixes two bugs:
- A loop divides initially seconds into next unit. Divisor for year unit was set to be 10, but should be 1.
- Loop ends without checking for a divisor when there there are no more units to divide value with

Changes applied to lib/timeago.js and lib/timeahead.js.

Adopted tests.