### PR TITLE
Don't render empty recipient field in Access Grants

### DIFF
--- a/components/Account/Access/Campaigns/Campaign.js
+++ b/components/Account/Access/Campaigns/Campaign.js
@@ -17,6 +17,7 @@ const Campaign = ({ campaign, grantAccess, revokeAccess, t }) => {
       <P>{t.elements(
         'Account/Access/Campaigns/Campaign/claimNotice', {
           linkClaim: <Link
+            key={`campaign-claim-notice-${campaign.id}`}
             route='claim'
             params={{ context: 'access' }}
             passHref>

--- a/components/Account/Access/Campaigns/Form.js
+++ b/components/Account/Access/Campaigns/Form.js
@@ -147,6 +147,7 @@ class Form extends Component {
               <P>
                 {t.elements('Account/Access/Campaigns/Form/explanation', {
                   linkClaim: <Link
+                    key={`campaign-form-explanation-${campaign.id}`}
                     route='claim'
                     params={{ context: 'access' }}
                     passHref>

--- a/components/Account/Access/Campaigns/Grant.js
+++ b/components/Account/Access/Campaigns/Grant.js
@@ -14,9 +14,10 @@ const dayFormat = timeFormat('%e. %B %Y')
 
 const Grants = ({ grant, revokeAccess, t }) => {
   const elements = {
-    recipient: <Emphasis key={`grant-recipient-${grant.id}`}>
-      {grant.email}
-    </Emphasis>,
+    recipient: grant.email &&
+      <Emphasis key={`grant-recipient-${grant.id}`}>
+        {grant.email}
+      </Emphasis>,
     voucherCode: <Emphasis key={`grant-voucher-${grant.id}`}>
       {grant.voucherCode}
     </Emphasis>,
@@ -35,9 +36,13 @@ const Grants = ({ grant, revokeAccess, t }) => {
 
   return (
     <Item key={`grant-item-${grant.id}`}>
-      { t.elements('Account/Access/Campaigns/Grants/recipient', elements)}
-      <br />
-      {!grant.beginAt &&
+      {elements.recipient &&
+        <Fragment>
+          { t.elements('Account/Access/Campaigns/Grants/recipient', elements)}
+          <br />
+        </Fragment>
+      }
+      {!elements.beginAt &&
         <Fragment>
           { t.elements('Account/Access/Campaigns/Grants/unclaimed', elements)}
           <br />
@@ -46,7 +51,7 @@ const Grants = ({ grant, revokeAccess, t }) => {
           <Revoke grant={grant} revokeAccess={revokeAccess} />
         </Fragment>
       }
-      {grant.beginAt &&
+      {elements.beginAt &&
         <Fragment>
           { t.elements('Account/Access/Campaigns/Grants/beginAt', elements)}
           <br />


### PR DESCRIPTION
Access Grants sometimes won't have a recipient's email address e.g. auto-generated voucher codes. Changes reflect that.

<img width="687" alt="Bildschirmfoto 2019-04-02 um 15 23 29" src="https://user-images.githubusercontent.com/331800/55406018-8ef02b00-555b-11e9-9152-4239a0a6e9cf.png">

<img width="664" alt="Bildschirmfoto 2019-04-02 um 15 23 18" src="https://user-images.githubusercontent.com/331800/55406012-8d266780-555b-11e9-95c0-8818d6aac9a4.png">

It also sets missing key props on `LinkRoute` components.