### PR TITLE
Parse and trime card inputs before submitting in components/Payment/Form

### DIFF
--- a/components/Payment/Form.js
+++ b/components/Payment/Form.js
@@ -195,10 +195,10 @@ class PaymentForm extends Component {
           amount: total,
           usage: 'reusable',
           card: {
-            number: values.cardNumber,
-            cvc: values.cardCVC,
-            exp_month: values.cardMonth,
-            exp_year: values.cardYear
+            number: values.cardNumber.trim(),
+            cvc: values.cardCVC.trim(),
+            exp_month: parseInt(values.cardMonth),
+            exp_year: parseInt(values.cardYear)
           },
           metadata
         }, (status, source) => {

--- a/components/Payment/Form.js
+++ b/components/Payment/Form.js
@@ -195,10 +195,10 @@ class PaymentForm extends Component {
           amount: total,
           usage: 'reusable',
           card: {
-            number: values.cardNumber.trim(),
-            cvc: values.cardCVC.trim(),
-            exp_month: parseInt(values.cardMonth),
-            exp_year: parseInt(values.cardYear)
+            number: values.cardNumber && values.cardNumber.trim(),
+            cvc: values.cardCVC && values.cardCVC.trim(),
+            exp_month: +values.cardMonth,
+            exp_year: +values.cardYear
           },
           metadata
         }, (status, source) => {


### PR DESCRIPTION
Won't alter a users input but parse and trim card inputs before submitting to stripe. 
It trims card number and CVC, and parses month and year as an integer.

[Stripe's validation of expiry date](https://stripe.com/docs/stripe-js/v2#card-validateExpiry) accepts trailing whitespaces but Stripe API afterwards won't. 

Eexpiry month set to `<whitespace>08` is not rejected in Stripe validation library but from Stripe API, result in an API error: "The 'exp_month' parameter should be an integer (instead, is 08)."