### PR TITLE
Improve Series Episode Navigation

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -608,7 +608,10 @@ class ArticlePage extends Component {
                   </Center>}
                 </Fragment>
               )}
-              {isMember && episodes && <RelatedEpisodes episodes={episodes} path={meta.path} />}
+              {isMember && episodes && <RelatedEpisodes
+                title={series.title}
+                episodes={episodes}
+                path={meta.path} />}
               {isFormat && <Feed formatId={article.id} />}
               {(isMember || isFormat) && (
                 <Fragment>

--- a/components/Article/Progress/index.js
+++ b/components/Article/Progress/index.js
@@ -120,7 +120,7 @@ class Progress extends Component {
         return Math.abs(progressElements[index].getBoundingClientRect().top - headerHeight)
       }
 
-      let closestIndex = this.lastClosestIndex || 0
+      let closestIndex = (progressElements[this.lastClosestIndex] && this.lastClosestIndex) || 0
       let closestDistance = getDistanceForIndex(closestIndex)
 
       const length = progressElements.length

--- a/components/Article/RelatedEpisodes.js
+++ b/components/Article/RelatedEpisodes.js
@@ -1,8 +1,13 @@
 import React from 'react'
-import { Link } from '../../lib/routes'
+import { css } from 'glamor'
+
 import withT from '../../lib/withT'
 import { romanize } from '../../lib/utils/romanize'
 import { timeFormat } from '../../lib/utils/format'
+import HrefLink from '../Link/Href'
+
+import ArrowLeftIcon from 'react-icons/lib/md/keyboard-arrow-left'
+import ArrowRightIcon from 'react-icons/lib/md/keyboard-arrow-right'
 
 import {
   colors,
@@ -12,72 +17,102 @@ import {
   TeaserFrontTile,
   TeaserFrontTileHeadline,
   TeaserFrontTileRow,
-  TeaserFrontCredit
+  TeaserFrontCredit,
+  Interaction
 } from '@project-r/styleguide'
 
 const dayFormat = timeFormat('%d. %B %Y')
 
-const DefaultLink = ({ children }) => children
+const styles = {
+  prev: css({
+    marginTop: -3,
+    marginRight: 5,
+    marginLeft: 'calc(-1em - 5px)'
+  }),
+  next: css({
+    marginTop: -3,
+    marginLeft: 5,
+    marginRight: 'calc(-1em - 5px)'
+  }),
+  link: css({
+    color: 'inherit',
+    textDecoration: 'none'
+  })
+}
 
-const Tile = ({ t, episode, index, LinkComponent = DefaultLink }) => {
+const Tile = ({ t, episode, index, prev, next }) => {
   const date = episode && episode.publishDate
   const label = episode && episode.label
   const meta = episode && episode.document && episode.document.meta
-  const route = meta && meta.path
+  const path = meta && meta.path
   const image = (episode && episode.image) || (meta && meta.image)
-  const align = image ? { align: 'top' } : {}
 
-  if (route) {
-    LinkComponent = ({ children }) => <Link route={route}>{children}</Link>
-  }
+  const Link = path
+    ? HrefLink
+    : ({ children }) => children
+  const headline = <TeaserFrontTileHeadline.Editorial>
+    {episode.title}
+  </TeaserFrontTileHeadline.Editorial>
+
   return (
-    <LinkComponent>
+    <Link href={path}>
       <TeaserFrontTile
-        color={route ? colors.text : colors.lightText}
+        color={path
+          ? colors.text
+          : colors.lightText}
         image={image}
-        {...align}
+        align={image ? 'top' : undefined}
       >
         <Editorial.Format>
+          {prev && <ArrowLeftIcon {...styles.prev} />}
           {label || t('article/series/episode', { count: romanize(index + 1) })}
+          {next && <ArrowRightIcon {...styles.next} />}
         </Editorial.Format>
-        <TeaserFrontTileHeadline.Editorial>
-          {episode.title}
-        </TeaserFrontTileHeadline.Editorial>
+        {path
+          ? <Link href={path} passHref>
+            <a {...styles.link}>
+              {headline}
+            </a>
+          </Link>
+          : headline
+        }
         {!!date && (
-          <TeaserFrontCredit>{dayFormat(Date.parse(date))}</TeaserFrontCredit>
+          <TeaserFrontCredit>{dayFormat(new Date(date))}</TeaserFrontCredit>
         )}
       </TeaserFrontTile>
-    </LinkComponent>
+    </Link>
   )
 }
 
-const RelatedEpisodes = ({ t, episodes, path }) => {
-  let nextEpisode, previousEpisode
+const RelatedEpisodes = ({ t, episodes, path, title }) => {
+  const currentEpisodeIndex = episodes.findIndex(
+    episode => episode.document && episode.document.meta.path === path
+  )
+  const previousEpisode = episodes[currentEpisodeIndex - 1]
+  const nextEpisode = episodes[currentEpisodeIndex + 1]
+  if (!previousEpisode && !nextEpisode) {
+    return null
+  }
 
-  const currentEpisodeIndex = episodes
-    .map(episode => episode.document && episode.document.meta.path)
-    .indexOf(path)
-  previousEpisode = currentEpisodeIndex > 0 && episodes[currentEpisodeIndex - 1]
-  nextEpisode = episodes[currentEpisodeIndex + 1]
-
-  return !!(previousEpisode || nextEpisode) && (
+  return (
     <Center>
       <Breakout size='breakout'>
+        <Interaction.H3 style={{ textAlign: 'center', marginTop: 50 }}>
+          {title}
+        </Interaction.H3>
         <TeaserFrontTileRow columns={2} mobileReverse>
-          {previousEpisode && (
-            <Tile
-              t={t}
-              episode={previousEpisode}
-              index={currentEpisodeIndex - 1}
-            />
-          )}
-          {nextEpisode && (
-            <Tile
-              t={t}
-              episode={nextEpisode}
-              index={currentEpisodeIndex + 1}
-            />
-          )}
+          {previousEpisode && <Tile
+            t={t}
+            episode={previousEpisode}
+            prev
+            index={episodes.indexOf(previousEpisode)}
+          />}
+          {nextEpisode && <Tile
+            t={t}
+            episode={nextEpisode}
+            next
+            index={episodes.indexOf(nextEpisode)}
+          />}
         </TeaserFrontTileRow>
       </Breakout>
     </Center>

--- a/components/Article/SeriesNavPanel.js
+++ b/components/Article/SeriesNavPanel.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { withRouter } from 'next/router'
 
 import { css } from 'glamor'
-import { Link, Router } from '../../lib/routes'
+import { Link } from '../../lib/routes'
 import { timeFormat } from '../../lib/utils/format'
 import { romanize } from '../../lib/utils/romanize'
 import withT from '../../lib/withT'
@@ -43,13 +43,9 @@ const styles = {
     },
     cursor: 'pointer'
   }),
-  linkSelected: css({
+  current: css({
     backgroundColor: '#fff',
-    textDecoration: 'none',
     color: colors.text
-  }),
-  selected: css({
-    backgroundColor: '#fff'
   }),
   unpublished: css({
     color: negativeColors.lightText
@@ -100,19 +96,12 @@ const EpisodeLink = withRouter(({ episode, translation, params = {}, router, ind
   }
   if (router.asPath && router.asPath === route) {
     return (
-      <a
+      <div
         {...styles.base}
-        {...styles.linkSelected}
-        style={{ cursor: 'pointer' }}
-        onClick={e => {
-          e.preventDefault()
-          Router.replaceRoute(route, params).then(() => {
-            window.scroll(0, 0)
-          })
-        }}
+        {...styles.current}
       >
         <LinkContent episode={episode} index={index} t={t} />
-      </a>
+      </div>
     )
   }
   return (


### PR DESCRIPTION
Changes
- show series title
- arrow for next / prev
- make current episode not clickable
- fix reading pos measure bug when not re-mounting article page on series navigation

Before
<img width="654" alt="Screenshot 2019-04-29 at 00 57 24" src="https://user-images.githubusercontent.com/410211/56871125-c5fe1300-6a19-11e9-8839-c6153bffa767.png">
<img width="678" alt="Screenshot 2019-04-29 at 00 55 35" src="https://user-images.githubusercontent.com/410211/56871117-9cdd8280-6a19-11e9-9f64-d02f909e568c.png">
<img width="662" alt="Screenshot 2019-04-29 at 00 56 56" src="https://user-images.githubusercontent.com/410211/56871122-b54d9d00-6a19-11e9-8541-9a2c926e7f83.png">

After
<img width="652" alt="Screenshot 2019-04-29 at 00 58 01" src="https://user-images.githubusercontent.com/410211/56871135-dca46a00-6a19-11e9-9419-538a160117b6.png">
<img width="654" alt="Screenshot 2019-04-29 at 00 55 49" src="https://user-images.githubusercontent.com/410211/56871137-e201b480-6a19-11e9-9552-fe89c0ee8a28.png">
<img width="650" alt="Screenshot 2019-04-29 at 00 58 43" src="https://user-images.githubusercontent.com/410211/56871145-f47bee00-6a19-11e9-856c-7a2f4d4e6f83.png">