### PR TITLE
show discussion icon if closed but has comments

### DIFF
--- a/components/ActionBar/utils.js
+++ b/components/ActionBar/utils.js
@@ -1,8 +1,14 @@
 import { routes } from '../../lib/routes'
 
 export const getDiscussionIconLinkProps = (linkedDiscussion, ownDiscussion, template, path) => {
-  const isLinkedDiscussion = linkedDiscussion && !linkedDiscussion.closed && template === 'article'
-  const isOwnDiscussion = !isLinkedDiscussion && ownDiscussion && !ownDiscussion.closed
+  const isLinkedDiscussion =
+    linkedDiscussion &&
+    template === 'article' &&
+    (!linkedDiscussion.closed || (linkedDiscussion.comments && linkedDiscussion.comments.totalCount > 0))
+  const isOwnDiscussion =
+    !isLinkedDiscussion &&
+    ownDiscussion &&
+    (!ownDiscussion.closed || (ownDiscussion.comments && ownDiscussion.comments.totalCount > 0))
   const isArticleAutoDiscussion = isOwnDiscussion && template === 'article'
   const isDiscussionPage = isOwnDiscussion && template === 'discussion'
   const discussionCount =

--- a/components/Feedback/ArticleSearch.js
+++ b/components/Feedback/ArticleSearch.js
@@ -119,11 +119,12 @@ class ArticleSearch extends Component {
               meta &&
               meta.linkedDiscussion &&
               !meta.linkedDiscussion.closed &&
+              (!meta.linkedDiscussion.closed || (meta.linkedDiscussion.comments && meta.linkedDiscussion.comments.totalCount > 0)) &&
               meta.linkedDiscussion
           const discussionId =
               meta &&
               ((meta.ownDiscussion &&
-                !meta.ownDiscussion.closed &&
+                (!meta.ownDiscussion.closed || (meta.ownDiscussion.comments && meta.ownDiscussion.comments.totalCount > 0)) &&
                 meta.ownDiscussion.id) ||
                 (linkedDiscussion && linkedDiscussion.id))
 

--- a/components/Feedback/LatestComments.js
+++ b/components/Feedback/LatestComments.js
@@ -36,7 +36,7 @@ export const CommentLink = ({
   if (discussion) {
     if (discussion.document) {
       const meta = discussion.document.meta || {}
-      const ownDiscussion = meta.ownDiscussion && !meta.ownDiscussion.closed
+      const ownDiscussion = meta.ownDiscussion && (!meta.ownDiscussion.closed || (meta.ownDiscussion.comments && meta.ownDiscussion.comment.totalCount > 0))
       const template = meta.template
       tab = ownDiscussion && template === 'article' && 'article'
     } else {


### PR DESCRIPTION
this PR changes the Article page, so that the discussion icon is show even if the discussion is closed, but has comments.