### PR TITLE
fix(Discussion): wrap focusSelector() in a timeout to allow comments to be collapsed first

### DIFF
--- a/components/Discussion/Comments.js
+++ b/components/Discussion/Comments.js
@@ -192,7 +192,9 @@ class Comments extends PureComponent {
         focusError: undefined
       }, () => {
         if (focusInfo) {
-          focusSelector(`[data-comment-id='${focusInfo.id}']`)
+          setTimeout(() => {
+            focusSelector(`[data-comment-id='${focusInfo.id}']`)
+          }, 50)
         }
       })
     }
@@ -218,7 +220,9 @@ class Comments extends PureComponent {
             focusLoading: false,
             focusError: undefined
           }, () => {
-            focusSelector(`[data-comment-id='${focusInfo.id}']`)
+            setTimeout(() => {
+              focusSelector(`[data-comment-id='${focusInfo.id}']`)
+            }, 50)
           })
         })
         .catch(() => {


### PR DESCRIPTION
Fixes #243. See https://github.com/orbiting/republik-frontend/issues/243#issuecomment-492530991 for a description what's happening.