### PR TITLE
Fix translations

### DIFF
--- a/lib/translations.json
+++ b/lib/translations.json
@@ -4531,6 +4531,10 @@
       "value": "Das sind wir"
     },
     {
+      "key": "pages/about/description",
+      "value": "Die Republik ist ein digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen und Lesern."
+    },
+    {
       "key": "pages/about/lead",
       "value": "Die Republik ist ein digitales Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen und Lesern. Gemeinsam sind wir eine Rebellion gegen die Medienkonzerne, für die Medienvielfalt. Unabhängig, werbefrei – und mit nur einem Ziel: begeisternden Journalismus zu liefern."
     },

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-04-24T10:00:17.810Z",
+  "updated": "2019-05-15T13:42:53.050Z",
   "title": "live",
   "data": [
     {
@@ -3020,7 +3020,7 @@
     },
     {
       "key": "article/autodiscussionteaser/text",
-      "value": "Was gefällt Ihnen an diesem Artikel? Was gibt es zu ergänzen? Was ist kritikwürdig? Ihre Mitverlegerinnen und die Redaktion freuen sich auf Ihr Wissen und Ihre Perspektive. {link}."
+      "value": "Was gefällt Ihnen an diesem Beitrag? Was gibt es zu ergänzen? Was ist kritikwürdig? Ihre Mitverlegerinnen und die Redaktion freuen sich auf Ihr Wissen und Ihre Perspektive. {link}."
     },
     {
       "key": "article/autodiscussionteaser/linktext",


### PR DESCRIPTION
- autodiscussion teaser: Artikel -> Beitrag
- add missing translation pages/about/description (used for meta.description)