### PR TITLE
Marketing

### DIFF
--- a/components/About/Page.js
+++ b/components/About/Page.js
@@ -43,7 +43,7 @@ query AboutPage {
     title
     url
   }
-  documents(feed: true, first: 1, template: "article") {
+  documents(feed: true, first: 0, template: "article") {
     totalCount
   }
 }

--- a/components/ErrorMessage.js
+++ b/components/ErrorMessage.js
@@ -7,8 +7,8 @@ import {
 
 const { P } = Interaction
 
-export default ({ error }) => (
-  <P style={{ color: colors.error, margin: '20px 0' }}>
+export default ({ error, style }) => (
+  <P style={{ color: colors.error, margin: '20px 0', ...style }}>
     {errorToString(error)}
   </P>
 )

--- a/components/Feed/index.js
+++ b/components/Feed/index.js
@@ -30,7 +30,7 @@ const styles = {
 
 const documentsQuery = gql`
   query getDocuments($cursor: String) {
-    documents(feed: true, first: 50, after: $cursor) {
+    documents(feed: true, first: 30, after: $cursor) {
       ...DocumentListConnection
     }
   }

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -24,6 +24,7 @@ import { PUBLIC_BASE_URL } from '../../lib/constants'
 import { cleanAsPath } from '../../lib/routes'
 
 import { useInfiniteScroll } from '../../lib/hooks/useInfiniteScroll'
+import { intersperse } from '../../lib/utils/helpers'
 
 const schema = createFrontSchema({
   Link
@@ -143,21 +144,28 @@ const Front = ({
           {hasMore && <div {...styles.more}>
             {loadingMoreError && <ErrorMessage error={loadingMoreError} />}
             {loadingMore && <InlineSpinner />}
-            {!infiniteScroll && hasMore &&
-            <Editorial.A href='#' style={{ color: negativeColors.text }} onClick={event => {
-              event && event.preventDefault()
-              setInfiniteScroll(true)
-            }}>
-              {
-                t('front/loadMore',
-                  {
-                    count: front.children.nodes.length,
-                    remaining: front.children.totalCount - front.children.nodes.length
-                  }
-                )
-              }
-            </Editorial.A>
-            }
+            {!infiniteScroll && hasMore && <Fragment>
+              <Editorial.A href='#' style={{ color: negativeColors.text }} onClick={event => {
+                event && event.preventDefault()
+                setInfiniteScroll(true)
+              }}>
+                {
+                  t('front/loadMore',
+                    {
+                      count: front.children.nodes.length,
+                      remaining: front.children.totalCount - front.children.nodes.length
+                    }
+                  )
+                }
+              </Editorial.A>
+              {front.meta.path === '/' && <div style={{ marginTop: 10 }}>{t.elements('front/chronology', {
+                years: intersperse([2019, 2018].map(year =>
+                  <Link key={year} route='overview' params={{ year }} passHref>
+                    <Editorial.A style={{ color: negativeColors.text }}>{year}</Editorial.A>
+                  </Link>
+                ), () => ', ')
+              })}</div>}
+            </Fragment>}
           </div>}
         </div>
       }} />

--- a/components/Front/index.js
+++ b/components/Front/index.js
@@ -12,7 +12,7 @@ import createFrontSchema from '@project-r/styleguide/lib/templates/Front'
 import withT from '../../lib/withT'
 import Loader from '../Loader'
 import Frame from '../Frame'
-import Link from '../Link/Href'
+import HrefLink from '../Link/Href'
 import SSRCachingBoundary from '../SSRCachingBoundary'
 import ErrorMessage from '../ErrorMessage'
 
@@ -21,13 +21,13 @@ import { negativeColors } from '../Frame/Footer'
 import { renderMdast } from 'mdast-react-render'
 
 import { PUBLIC_BASE_URL } from '../../lib/constants'
-import { cleanAsPath } from '../../lib/routes'
+import { Link, cleanAsPath } from '../../lib/routes'
 
 import { useInfiniteScroll } from '../../lib/hooks/useInfiniteScroll'
 import { intersperse } from '../../lib/utils/helpers'
 
 const schema = createFrontSchema({
-  Link
+  Link: HrefLink
 })
 
 const getDocument = gql`

--- a/components/Loader.js
+++ b/components/Loader.js
@@ -6,7 +6,7 @@ const PageLoader = props => (
   <Loader
     ErrorContainer={NarrowContainer}
     {...props}
-    style={{ minHeight: `calc(100vh - ${HEADER_HEIGHT}px)` }}
+    style={{ minHeight: `calc(100vh - ${HEADER_HEIGHT}px)`, ...props.style }}
   />
 )
 

--- a/components/Marketing/Feuilleton.js
+++ b/components/Marketing/Feuilleton.js
@@ -7,7 +7,6 @@ import {
   Container,
   Editorial,
   Interaction,
-  Label,
   P,
   PullQuote,
   PullQuoteText,
@@ -143,15 +142,6 @@ const FeuilletonMarketingPage = ({
                 {t('marketing/join/button/label')}
               </button>
             </Link>
-            <Label {...sharedStyles.signInLabel}>{
-              t.elements(
-                'marketing/signin',
-                { link: <Link key='link' route={'signin'}>
-                  <a>{t('marketing/signin/link') }</a>
-                </Link>
-                }
-              )
-            }</Label>
           </div>
           <Link route='preview'>
             <button {...buttonStyles.standard}>
@@ -159,6 +149,15 @@ const FeuilletonMarketingPage = ({
             </button>
           </Link>
         </div>
+        <div {...sharedStyles.signIn}>{
+          t.elements(
+            'marketing/signin',
+            { link: <Link key='link' route={'signin'}>
+              <a>{t('marketing/signin/link') }</a>
+            </Link>
+            }
+          )
+        }</div>
       </Container>
       <Center>
         <Subheader>{t('marketing/feuilleton/what/title')}</Subheader>
@@ -260,8 +259,8 @@ const FeuilletonMarketingPage = ({
           <ListWithQuery singleRow minColumns={3} first={6} onSelect={(id) => {
             Router.push(`/community?id=${id}`).then(() => {
               window.scrollTo(0, 0)
-              return false
             })
+            return false
           }} />
           <Interaction.P {...sharedStyles.communityLink}>
             <Link route='community'>

--- a/components/Marketing/Feuilleton.js
+++ b/components/Marketing/Feuilleton.js
@@ -26,7 +26,7 @@ import { RawList as FaqList } from '../Faq/List'
 
 import {
   List as TestimonialList,
-  fragments as testimonialFragments
+  testimonialFields
 } from '../Testimonial/List'
 
 import { buttonStyles, sharedStyles } from './styles'
@@ -56,7 +56,7 @@ query feuilletonMarketingPage {
   statements(first: 6) {
     totalCount
     nodes {
-      ...TestimonialOnUser
+      ${testimonialFields}
     }
     pageInfo {
       hasNextPage
@@ -64,7 +64,6 @@ query feuilletonMarketingPage {
     }
   }
 }
-${testimonialFragments.TestimonialOnUser}
 `
 
 const styles = {

--- a/components/Marketing/Feuilleton.js
+++ b/components/Marketing/Feuilleton.js
@@ -266,7 +266,7 @@ const FeuilletonMarketingPage = ({
               {
                 count: membershipStats
                   ? countFormat(membershipStats.count)
-                  : `~${countFormat(22500)}`
+                  : t('marketing/community/defaultCount')
               }
             )}
           </Interaction.H2>

--- a/components/Marketing/Feuilleton.js
+++ b/components/Marketing/Feuilleton.js
@@ -24,7 +24,10 @@ import { Link, Router } from '../../lib/routes'
 import Employee from '../Imprint/Employee'
 import { RawList as FaqList } from '../Faq/List'
 
-import { ListWithQuery } from '../Testimonial/List'
+import {
+  List as TestimonialList,
+  fragments as testimonialFragments
+} from '../Testimonial/List'
 
 import { buttonStyles, sharedStyles } from './styles'
 
@@ -50,7 +53,18 @@ query feuilletonMarketingPage {
     question
     answer
   }
+  statements(first: 6) {
+    totalCount
+    nodes {
+      ...TestimonialOnUser
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
 }
+${testimonialFragments.TestimonialOnUser}
 `
 
 const styles = {
@@ -256,12 +270,19 @@ const FeuilletonMarketingPage = ({
               }
             )}
           </Interaction.H2>
-          <ListWithQuery singleRow minColumns={3} first={6} onSelect={(id) => {
-            Router.push(`/community?id=${id}`).then(() => {
-              window.scrollTo(0, 0)
-            })
-            return false
-          }} />
+          <TestimonialList
+            singleRow
+            minColumns={3}
+            first={6}
+            statements={data.statements ? data.statements.nodes : []}
+            loading={data.loading}
+            t={t}
+            onSelect={(id) => {
+              Router.push(`/community?id=${id}`).then(() => {
+                window.scrollTo(0, 0)
+              })
+              return false
+            }} />
           <Interaction.P {...sharedStyles.communityLink}>
             <Link route='community'>
               <a>{t('marketing/community/link')}</a>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -237,6 +237,21 @@ class MarketingPage extends Component {
             </Link>
           </Interaction.P>
           <div {...sharedStyles.spacer} />
+          <div {...sharedStyles.actions} style={{ marginTop: 0 }}>
+            <div>
+              <Link route='pledge'>
+                <button {...buttonStyles.primary}>
+                  {t('marketing/join/button/label')}
+                </button>
+              </Link>
+            </div>
+            <Link route='preview'>
+              <button {...buttonStyles.standard}>
+                {t('marketing/preview/button/label')}
+              </button>
+            </Link>
+          </div>
+          <div {...sharedStyles.spacer} />
         </Container>}
       </Fragment>
     )

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -87,70 +87,92 @@ const styles = {
 const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipStats, front, articles, statements }, ...props }) => {
   return (
     <Fragment>
-      <Container>
-        <h1 {...sharedStyles.headline}>
-          <RawHtml
-            dangerouslySetInnerHTML={{
-              __html: t('marketing/title')
-            }}
-          />
-        </h1>
-        <p {...sharedStyles.lead}>{t('marketing/lead')}</p>
-        <div {...sharedStyles.actions}>
-          <div>
-            <Link route='pledge'>
-              <button {...buttonStyles.primary}>
-                {t('marketing/join/button/label')}
+      <div style={{ overflow: 'hidden' }}>
+        <Container>
+          <h1 {...sharedStyles.headline}>
+            <RawHtml
+              dangerouslySetInnerHTML={{
+                __html: t('marketing/title')
+              }}
+            />
+          </h1>
+          <p {...sharedStyles.lead}>{t('marketing/lead')}</p>
+          <div {...sharedStyles.actions}>
+            <div>
+              <Link route='pledge'>
+                <button {...buttonStyles.primary}>
+                  {t('marketing/join/button/label')}
+                </button>
+              </Link>
+            </div>
+            <Link route='preview'>
+              <button {...buttonStyles.standard}>
+                {t('marketing/preview/button/label')}
               </button>
             </Link>
           </div>
-          <Link route='preview'>
-            <button {...buttonStyles.standard}>
-              {t('marketing/preview/button/label')}
-            </button>
-          </Link>
-        </div>
-        <div {...sharedStyles.signIn}>{
-          t.elements(
-            'marketing/signin',
-            { link: <Link key='link' route={'signin'}>
-              <a>{t('marketing/signin/link') }</a>
-            </Link>
-            }
-          )
-        }</div>
-      </Container>
-      {!loading && front && <div style={{
-        backgroundColor: negativeColors.containerBg,
-        color: negativeColors.text,
-        padding: 30
-      }}>
-        <Container style={{
-          maxWidth: 1200, padding: 0
-        }}>
-          <Interaction.H2 style={{
-            color: negativeColors.text,
-            marginTop: 0,
-            marginBottom: 10,
-            textAlign: 'center'
-          }}>
-            {articles.totalCount} Produktionen
-          </Interaction.H2>
-          <P style={{
-            maxWidth: 974,
-            margin: '0 auto 30px auto',
-            textAlign: 'center'
-          }}>Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart.</P>
-          <TeaserBlock
-            teasers={getTeasersFromDocument(front)}
-            highlight={undefined}
-            onHighlight={() => {}}
-            lazy />
-          <P style={{ textAlign: 'center', marginTop: 20 }}>
-            Chronologie <Link route='overview' params={{ year: 2019 }} passHref><A>2019</A></Link>, <Link route='overview' params={{ year: 2018 }} passHref><A>2018</A></Link>
-          </P>
+          <div {...sharedStyles.signIn}>{
+            t.elements(
+              'marketing/signin',
+              { link: <Link key='link' route={'signin'}>
+                <a>{t('marketing/signin/link') }</a>
+              </Link>
+              }
+            )
+          }</div>
         </Container>
-      </div>}
+        {!loading && front && <div style={{
+          backgroundColor: negativeColors.containerBg,
+          color: negativeColors.text,
+          padding: '30px 20px',
+          paddingBottom: 0
+        }}>
+          <Container style={{
+            maxWidth: 1200,
+            padding: 0,
+            position: 'relative'
+          }}>
+            <Interaction.H2 style={{
+              color: negativeColors.text,
+              marginTop: 0,
+              marginBottom: 10,
+              textAlign: 'center'
+            }}>
+              {articles.totalCount} Produktionen
+            </Interaction.H2>
+            <P style={{
+              maxWidth: 974,
+              margin: '0 auto 30px auto',
+              textAlign: 'center'
+            }}>Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart.</P>
+            <TeaserBlock
+              teasers={getTeasersFromDocument(front)}
+              highlight={undefined}
+              onHighlight={() => {}}
+              overflow
+              lazy />
+            <div style={{
+              position: 'absolute',
+              bottom: 0,
+              height: 100,
+              left: 0,
+              right: 0,
+              background: 'linear-gradient(0deg, rgba(17,17,17,0.9) 0%, rgba(17,17,17,0.8) 30%, rgba(17,17,17,0) 100%)',
+              pointerEvents: 'none'
+            }} />
+            <P style={{
+              textAlign: 'center',
+              position: 'absolute',
+              bottom: 10,
+              left: '50%',
+              width: 280,
+              marginLeft: -140
+            }}>
+              Chronologie <Link route='overview' params={{ year: 2019 }} passHref><A>2019</A></Link>, <Link route='overview' params={{ year: 2018 }} passHref><A>2018</A></Link>
+            </P>
+          </Container>
+        </div>}
+      </div>
       <Container>
         {!loading && membershipStats && <div {...styles.communityWidget}>
           <Interaction.H2 style={{ marginBottom: 10 }}>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -200,8 +200,7 @@ class MarketingPage extends Component {
             first={6}
             statements={statements && statements.nodes}
             loading={loading}
-            t={t}
-            focus />
+            t={t} />
           <Interaction.P style={{ marginTop: 10 }}>
             <Link route='community' passHref>
               <Editorial.A>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -28,6 +28,7 @@ import { A, P } from '../Overview/Elements'
 import { buttonStyles, sharedStyles } from './styles'
 
 import { negativeColors } from '../Frame/constants'
+import ErrorMessage from '../ErrorMessage'
 
 const query = gql`
 query marketingMembershipStats {
@@ -100,7 +101,7 @@ class MarketingPage extends Component {
     this.onHighlight = highlight => this.setState({ highlight })
   }
   render () {
-    const { t, data: { loading, membershipStats, front, articles, statements, employees } } = this.props
+    const { t, data: { loading, error, membershipStats, front, articles, statements, employees } } = this.props
 
     return (
       <Fragment>
@@ -137,8 +138,9 @@ class MarketingPage extends Component {
                 }
               )}
             </div>
+            {error && <ErrorMessage error={error} style={{ textAlign: 'center' }} />}
           </Container>
-          <div {...styles.overviewContainer}>
+          {!error && <div {...styles.overviewContainer}>
             <Container style={{
               maxWidth: 1200,
               padding: 0,
@@ -178,9 +180,9 @@ class MarketingPage extends Component {
                 })}
               </P>
             </Container>
-          </div>
+          </div>}
         </div>
-        <Container style={{ maxWidth: SMALL_MAX_WIDTH }}>
+        {!error && <Container style={{ maxWidth: SMALL_MAX_WIDTH }}>
           <div {...sharedStyles.spacer} />
           <Interaction.H2 style={{ marginBottom: 10 }}>
             {t(
@@ -236,7 +238,7 @@ class MarketingPage extends Component {
             </Link>
           </Interaction.P>
           <div {...sharedStyles.spacer} />
-        </Container>
+        </Container>}
       </Fragment>
     )
   }

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -36,7 +36,7 @@ query marketingMembershipStats {
     count
   }
   front: document(path: "/") {
-    children(first: 60) {
+    children(first: 50) {
       nodes {
         body
       }
@@ -167,6 +167,7 @@ class MarketingPage extends Component {
                   teasers={getTeasersFromDocument(front)}
                   highlight={this.state.highlight}
                   onHighlight={this.onHighlight}
+                  maxHeight={520}
                   overflow
                   lazy />
               )} />

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -1,16 +1,20 @@
-import React, { Fragment } from 'react'
+import React, { Component, Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
+import { css } from 'glamor'
 import {
   Container,
   RawHtml,
   Interaction,
-  Editorial
+  Editorial,
+  Loader
 } from '@project-r/styleguide'
 
 import { countFormat } from '../../lib/utils/format'
 import withT from '../../lib/withT'
 import { Link } from '../../lib/routes'
+
+import { intersperse } from '../../lib/utils/helpers'
 
 import {
   List as TestimonialList,
@@ -63,116 +67,151 @@ ${testimonialFragments.TestimonialOnUser}
 `
 
 const SMALL_MAX_WIDTH = 974
+const styles = {
+  overviewContainer: css({
+    backgroundColor: negativeColors.containerBg,
+    color: negativeColors.text,
+    padding: '30px 20px',
+    paddingBottom: 0
+  }),
+  overviewBottomShadow: css({
+    position: 'absolute',
+    bottom: 0,
+    height: 100,
+    left: 0,
+    right: 0,
+    background: 'linear-gradient(0deg, rgba(17,17,17,0.9) 0%, rgba(17,17,17,0.8) 30%, rgba(17,17,17,0) 100%)',
+    pointerEvents: 'none'
+  }),
+  overviewBottomLinks: css({
+    textAlign: 'center',
+    position: 'absolute',
+    bottom: 10,
+    left: '50%',
+    width: 280,
+    marginLeft: -140
+  })
+}
 
-const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipStats, front, articles, statements, employees }, ...props }) => {
-  return (
-    <Fragment>
-      <div style={{ overflow: 'hidden' }}>
-        <Container>
-          <h1 {...sharedStyles.headline}>
-            <RawHtml
-              dangerouslySetInnerHTML={{
-                __html: t('marketing/title')
-              }}
-            />
-          </h1>
-          <p {...sharedStyles.lead}>{t('marketing/lead')}</p>
-          <div {...sharedStyles.actions}>
-            <div>
-              <Link route='pledge'>
-                <button {...buttonStyles.primary}>
-                  {t('marketing/join/button/label')}
+class MarketingPage extends Component {
+  constructor (props) {
+    super(props)
+    this.state = {}
+    this.onHighlight = highlight => this.setState({ highlight })
+  }
+  render () {
+    const { t, data: { loading, membershipStats, front, articles, statements, employees } } = this.props
+
+    return (
+      <Fragment>
+        <div style={{ overflow: 'hidden' }}>
+          <Container>
+            <h1 {...sharedStyles.headline}>
+              <RawHtml
+                dangerouslySetInnerHTML={{
+                  __html: t('marketing/title')
+                }}
+              />
+            </h1>
+            <p {...sharedStyles.lead}>{t('marketing/lead')}</p>
+            <div {...sharedStyles.actions}>
+              <div>
+                <Link route='pledge'>
+                  <button {...buttonStyles.primary}>
+                    {t('marketing/join/button/label')}
+                  </button>
+                </Link>
+              </div>
+              <Link route='preview'>
+                <button {...buttonStyles.standard}>
+                  {t('marketing/preview/button/label')}
                 </button>
               </Link>
             </div>
-            <Link route='preview'>
-              <button {...buttonStyles.standard}>
-                {t('marketing/preview/button/label')}
-              </button>
-            </Link>
-          </div>
-          <div {...sharedStyles.signIn}>{
-            t.elements(
-              'marketing/signin',
-              { link: <Link key='link' route={'signin'}>
-                <a>{t('marketing/signin/link') }</a>
-              </Link>
-              }
-            )
-          }</div>
-        </Container>
-        {!loading && front && <div style={{
-          backgroundColor: negativeColors.containerBg,
-          color: negativeColors.text,
-          padding: '30px 20px',
-          paddingBottom: 0
-        }}>
-          <Container style={{
-            maxWidth: 1200,
-            padding: 0,
-            position: 'relative'
-          }}>
-            <Interaction.H2 style={{
-              color: negativeColors.text,
-              marginTop: 0,
-              marginBottom: 10,
-              textAlign: 'center'
-            }}>
-              {articles.totalCount} Produktionen
-            </Interaction.H2>
-            <P style={{
-              maxWidth: SMALL_MAX_WIDTH,
-              margin: '0 auto 30px auto',
-              textAlign: 'center'
-            }}>Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart.</P>
-            <TeaserBlock
-              teasers={getTeasersFromDocument(front)}
-              highlight={undefined}
-              onHighlight={() => {}}
-              overflow
-              lazy />
-            <div style={{
-              position: 'absolute',
-              bottom: 0,
-              height: 100,
-              left: 0,
-              right: 0,
-              background: 'linear-gradient(0deg, rgba(17,17,17,0.9) 0%, rgba(17,17,17,0.8) 30%, rgba(17,17,17,0) 100%)',
-              pointerEvents: 'none'
-            }} />
-            <P style={{
-              textAlign: 'center',
-              position: 'absolute',
-              bottom: 10,
-              left: '50%',
-              width: 280,
-              marginLeft: -140
-            }}>
-              Chronologie <Link route='overview' params={{ year: 2019 }} passHref><A>2019</A></Link>, <Link route='overview' params={{ year: 2018 }} passHref><A>2018</A></Link>
-            </P>
+            <div {...sharedStyles.signIn}>
+              {t.elements(
+                'marketing/signin',
+                { link: <Link key='link' route={'signin'}>
+                  <a>{t('marketing/signin/link') }</a>
+                </Link>
+                }
+              )}
+            </div>
           </Container>
-        </div>}
-      </div>
-      <Container style={{ maxWidth: SMALL_MAX_WIDTH, paddingTop: 40 }}>
-        {!loading && membershipStats && <Fragment>
-          <Interaction.H2 style={{ marginBottom: 10, marginTop: 40 }}>
-            {countFormat(membershipStats.count)} Verlegerinnen und Verleger
+          <div {...styles.overviewContainer}>
+            <Container style={{
+              maxWidth: 1200,
+              padding: 0,
+              position: 'relative'
+            }}>
+              <Interaction.H2 style={{
+                color: negativeColors.text,
+                marginTop: 0,
+                marginBottom: 10,
+                textAlign: 'center'
+              }}>
+                {t('marketing/overview/title', {
+                  count: articles
+                    ? countFormat(articles.totalCount)
+                    : t('marketing/overview/defaultCount')
+                })}
+              </Interaction.H2>
+              <P style={{
+                maxWidth: SMALL_MAX_WIDTH,
+                margin: '0 auto 30px auto',
+                textAlign: 'center'
+              }}>{t('marketing/overview/lead')}</P>
+              <Loader loading={loading} style={{ minHeight: 600 }} render={() => (
+                <TeaserBlock
+                  teasers={getTeasersFromDocument(front)}
+                  highlight={this.state.highlight}
+                  onHighlight={this.onHighlight}
+                  overflow
+                  lazy />
+              )} />
+              <div {...styles.overviewBottomShadow} />
+              <P {...styles.overviewBottomLinks}>
+                {t.elements('marketing/overview/more', {
+                  years: intersperse([2019, 2018].map(year =>
+                    <Link key={year} route='overview' params={{ year }} passHref><A>{year}</A></Link>
+                  ), () => ', ')
+                })}
+              </P>
+            </Container>
+          </div>
+        </div>
+        <Container style={{ maxWidth: SMALL_MAX_WIDTH }}>
+          <div {...sharedStyles.spacer} />
+          <Interaction.H2 style={{ marginBottom: 10 }}>
+            {t(
+              'marketing/community/title',
+              {
+                count: membershipStats
+                  ? countFormat(membershipStats.count)
+                  : t('marketing/community/defaultCount')
+              }
+            )}
           </Interaction.H2>
           <TestimonialList
             singleRow
             minColumns={3}
             first={6}
-            statements={statements.nodes}
+            statements={statements && statements.nodes}
             loading={loading}
             t={t}
             focus />
           <Interaction.P style={{ marginTop: 10 }}>
             <Link route='community' passHref>
-              <Editorial.A>Weitere {statements.totalCount} Statements</Editorial.A>
+              <Editorial.A>
+                {t('marketing/community/moreStatements', {
+                  count: statements ? countFormat(statements.totalCount) : ''
+                })}
+              </Editorial.A>
             </Link>
           </Interaction.P>
-          <Interaction.H2 style={{ marginBottom: 10, marginTop: 40 }}>
-            Über 60 Mitwirkende
+          <div {...sharedStyles.spacer} />
+          <Interaction.H2 style={{ marginBottom: 10 }}>
+            {t('marketing/employees/title')}
           </Interaction.H2>
           <TestimonialList
             minColumns={3}
@@ -193,14 +232,14 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipSta
             focus />
           <Interaction.P style={{ marginTop: 10 }}>
             <Link route='legal/imprint' passHref>
-              <Editorial.A>Zum Impressum</Editorial.A>
+              <Editorial.A>{t('marketing/employees/more')}</Editorial.A>
             </Link>
           </Interaction.P>
-        </Fragment>}
-        <div {...sharedStyles.spacer} />
-      </Container>
-    </Fragment>
-  )
+          <div {...sharedStyles.spacer} />
+        </Container>
+      </Fragment>
+    )
+  }
 }
 
 export default compose(

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -14,7 +14,10 @@ import { countFormat } from '../../lib/utils/format'
 import withT from '../../lib/withT'
 import { Link } from '../../lib/routes'
 
-import { List as TestimonialList } from '../Testimonial/List'
+import {
+  List as TestimonialList,
+  fragments as testimonialFragments
+} from '../Testimonial/List'
 
 import TeaserBlock from '../Overview/TeaserBlock'
 import { getTeasersFromDocument } from '../Overview/utils'
@@ -54,17 +57,7 @@ query marketingMembershipStats {
   statements(first: 6) {
     totalCount
     nodes {
-      id
-      username
-      name
-      statement
-      credentials {
-        description
-      }
-      portrait
-      updatedAt
-      sequenceNumber
-      hasPublicProfile
+      ...TestimonialOnUser
     }
     pageInfo {
       hasNextPage
@@ -72,6 +65,7 @@ query marketingMembershipStats {
     }
   }
 }
+${testimonialFragments.TestimonialOnUser}
 `
 
 const styles = {

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -18,7 +18,7 @@ import { intersperse } from '../../lib/utils/helpers'
 
 import {
   List as TestimonialList,
-  fragments as testimonialFragments
+  testimonialFields
 } from '../Testimonial/List'
 
 import TeaserBlock from '../Overview/TeaserBlock'
@@ -47,7 +47,7 @@ query marketingMembershipStats {
     group
     name
     user {
-      ...TestimonialOnUser
+      ${testimonialFields}
     }
   }
   articles: documents(feed: true, first: 0, template: "article") {
@@ -56,7 +56,7 @@ query marketingMembershipStats {
   statements(first: 6) {
     totalCount
     nodes {
-      ...TestimonialOnUser
+      ${testimonialFields}
     }
     pageInfo {
       hasNextPage
@@ -64,7 +64,6 @@ query marketingMembershipStats {
     }
   }
 }
-${testimonialFragments.TestimonialOnUser}
 `
 
 const SMALL_MAX_WIDTH = 974

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -1,11 +1,9 @@
 import React, { Fragment } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
-import { css } from 'glamor'
 import {
   Container,
   RawHtml,
-  mediaQueries,
   Interaction,
   Editorial
 } from '@project-r/styleguide'
@@ -39,16 +37,12 @@ query marketingMembershipStats {
       }
     }
   }
-  employees {
+  employees(shuffle: 6) {
     title
-    name
     group
-    subgroup
+    name
     user {
-      id
-      hasPublicProfile
-      portrait
-      username
+      ...TestimonialOnUser
     }
   }
   articles: documents(feed: true, first: 0, template: "article") {
@@ -68,17 +62,9 @@ query marketingMembershipStats {
 ${testimonialFragments.TestimonialOnUser}
 `
 
-const styles = {
-  communityWidget: css({
-    margin: '18px auto 0 auto',
-    maxWidth: '974px',
-    [mediaQueries.mUp]: {
-      margin: '78px auto 0 auto'
-    }
-  })
-}
+const SMALL_MAX_WIDTH = 974
 
-const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipStats, front, articles, statements }, ...props }) => {
+const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipStats, front, articles, statements, employees }, ...props }) => {
   return (
     <Fragment>
       <div style={{ overflow: 'hidden' }}>
@@ -135,7 +121,7 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipSta
               {articles.totalCount} Produktionen
             </Interaction.H2>
             <P style={{
-              maxWidth: 974,
+              maxWidth: SMALL_MAX_WIDTH,
               margin: '0 auto 30px auto',
               textAlign: 'center'
             }}>Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart.</P>
@@ -167,9 +153,9 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipSta
           </Container>
         </div>}
       </div>
-      <Container>
-        {!loading && membershipStats && <div {...styles.communityWidget}>
-          <Interaction.H2 style={{ marginBottom: 10 }}>
+      <Container style={{ maxWidth: SMALL_MAX_WIDTH, paddingTop: 40 }}>
+        {!loading && membershipStats && <Fragment>
+          <Interaction.H2 style={{ marginBottom: 10, marginTop: 40 }}>
             {countFormat(membershipStats.count)} Verlegerinnen und Verleger
           </Interaction.H2>
           <TestimonialList
@@ -180,12 +166,37 @@ const MarketingPage = ({ me, t, crowdfundingName, loading, data: { membershipSta
             loading={loading}
             t={t}
             focus />
-          <Interaction.P style={{ marginTop: 20 }}>
+          <Interaction.P style={{ marginTop: 10 }}>
             <Link route='community' passHref>
               <Editorial.A>Weitere {statements.totalCount} Statements</Editorial.A>
             </Link>
           </Interaction.P>
-        </div>}
+          <Interaction.H2 style={{ marginBottom: 10, marginTop: 40 }}>
+            Über 60 Mitwirkende
+          </Interaction.H2>
+          <TestimonialList
+            minColumns={3}
+            first={6}
+            showCredentials
+            singleRow
+            statements={employees && employees.map(employee => ({
+              ...employee.user,
+              name: employee.name,
+              credentials: [
+                {
+                  description: employee.title || employee.group
+                }
+              ].filter(d => d.description)
+            }))}
+            loading={loading}
+            t={t}
+            focus />
+          <Interaction.P style={{ marginTop: 10 }}>
+            <Link route='legal/imprint' passHref>
+              <Editorial.A>Zum Impressum</Editorial.A>
+            </Link>
+          </Interaction.P>
+        </Fragment>}
         <div {...sharedStyles.spacer} />
       </Container>
     </Fragment>

--- a/components/Marketing/styles.js
+++ b/components/Marketing/styles.js
@@ -75,14 +75,15 @@ export const sharedStyles = {
     margin: '0 auto',
     fontWeight: 'normal',
     fontFamily: fontFamilies.serifTitle,
-    marginTop: '12px',
+    marginTop: 20,
     [mediaQueries.mUp]: {
       fontSize: '64px',
       lineHeight: '72px',
-      marginTop: '50px'
+      marginTop: 50
     }
   }),
   lead: css({
+    fontFamily: fontFamilies.serifRegular,
     fontSize: '16px',
     lineHeight: '26px',
     textAlign: 'center',
@@ -96,13 +97,13 @@ export const sharedStyles = {
   }),
   actions: css({
     maxWidth: '974px',
-    margin: '14px auto 23px auto',
+    margin: '14px auto 5px auto',
     '& > *': {
       marginBottom: '9px',
       width: '100%'
     },
     [mediaQueries.mUp]: {
-      margin: '80px auto',
+      margin: '80px auto 15px',
       display: 'flex',
       justifyContent: 'space-between',
       alignItems: 'stretch',
@@ -118,9 +119,9 @@ export const sharedStyles = {
       }
     }
   }),
-  signInLabel: css({
-    display: 'block',
+  signIn: css({
     color: colors.text,
+    textAlign: 'center',
     '& a': {
       cursor: 'pointer',
       color: colors.text,
@@ -137,8 +138,10 @@ export const sharedStyles = {
     },
     fontSize: '12px',
     lineHeight: '18px',
+    marginBottom: 23,
     [mediaQueries.mUp]: {
-      marginTop: '4px',
+      marginTop: 4,
+      marginBottom: 80,
       fontSize: '16px',
       lineHeight: '24px'
     }

--- a/components/Marketing/styles.js
+++ b/components/Marketing/styles.js
@@ -125,16 +125,10 @@ export const sharedStyles = {
     '& a': {
       cursor: 'pointer',
       color: colors.text,
-      textDecoration: 'underline'
-    },
-    [`'& ${prefixHover()}`]: {
-      color: colors.secondary
-    },
-    '& a:focus': {
-      color: colors.secondary
-    },
-    '& a:active': {
-      color: colors.primary
+      textDecoration: 'underline',
+      [`:focus, :active, ${prefixHover()}`]: {
+        color: colors.secondary
+      }
     },
     fontSize: '12px',
     lineHeight: '18px',

--- a/components/Overview/Elements.js
+++ b/components/Overview/Elements.js
@@ -2,13 +2,14 @@ import React, { Component } from 'react'
 import { negativeColors } from '../Frame/constants'
 
 import { css } from 'glamor'
-import { fontFamilies, Editorial } from '@project-r/styleguide'
+import { fontStyles, mediaQueries, Editorial } from '@project-r/styleguide'
 
 const styles = {
   p: css({
-    fontFamily: fontFamilies.sansSerifRegular,
-    fontSize: 17,
-    lineHeight: '26px',
+    ...fontStyles.sansSerifRegular16,
+    [mediaQueries.mUp]: {
+      ...fontStyles.sansSerifRegular21
+    },
     color: negativeColors.text,
     margin: 0
   })

--- a/components/Overview/TeaserBlock.js
+++ b/components/Overview/TeaserBlock.js
@@ -94,7 +94,7 @@ class TeaserBlock extends Component {
     const { columns } = SIZES.filter(size => size.minWidth <= innerWidth).pop()
 
     const perColumn = Math.round(this.measurements.length / columns)
-    const height = max(range(columns).map(column => {
+    let height = max(range(columns).map(column => {
       const begin = column * perColumn
       return sum(
         this.measurements
@@ -106,7 +106,14 @@ class TeaserBlock extends Component {
           )
           .map(measurement => measurement.height + PADDING)
       )
-    })) * (this.props.overflow ? 0.9 : 1)
+    }))
+
+    if (this.props.overflow) {
+      height *= 0.9
+      if (this.props.maxHeight) {
+        height = Math.min(height, this.props.maxHeight)
+      }
+    }
 
     if (this.state.width !== width || this.state.height !== height) {
       this.setState({ width, height })

--- a/components/Overview/TeaserBlock.js
+++ b/components/Overview/TeaserBlock.js
@@ -106,7 +106,7 @@ class TeaserBlock extends Component {
           )
           .map(measurement => measurement.height + PADDING)
       )
-    }))
+    })) * (this.props.overflow ? 0.9 : 1)
 
     if (this.state.width !== width || this.state.height !== height) {
       this.setState({ width, height })
@@ -125,7 +125,7 @@ class TeaserBlock extends Component {
   }
   render () {
     const { hover, width, height } = this.state
-    const { teasers, highlight, onHighlight, lazy } = this.props
+    const { teasers, highlight, onHighlight, lazy, overflow } = this.props
 
     const hoverOff = () => {
       // prevent flicker
@@ -138,7 +138,11 @@ class TeaserBlock extends Component {
     }
 
     return (
-      <div ref={this.blockRef} style={{ position: 'relative' }}>
+      <div ref={this.blockRef} style={{
+        position: 'relative',
+        marginTop: overflow ? -50 : 0,
+        bottom: overflow ? -50 : 0
+      }}>
         <LazyLoad key={height} visible={!lazy} attributes={{
           ...styles.container,
           ...css({
@@ -155,7 +159,10 @@ class TeaserBlock extends Component {
               return styles
             }, {})
           })
-        }} style={{ height }}>
+        }} style={{
+          height,
+          overflowX: overflow ? 'hidden' : undefined
+        }}>
           {teasers.map(teaser => {
             let touch
             const focus = event => {

--- a/components/Overview/utils.js
+++ b/components/Overview/utils.js
@@ -1,7 +1,7 @@
 import { ASSETS_SERVER_BASE_URL, RENDER_FRONTEND_BASE_URL } from '../../lib/constants'
 
 export const renderWidth = 1200
-export const getSmallImgSrc = teaser => `${ASSETS_SERVER_BASE_URL}/render?width=${renderWidth}&height=1&url=${encodeURIComponent(`${RENDER_FRONTEND_BASE_URL}/?extractId=${teaser.id}`)}&resize=200${teaser.contentHash ? `&permanentCacheKey=${encodeURIComponent(teaser.contentHash)}` : ''}`
+export const getSmallImgSrc = teaser => `${ASSETS_SERVER_BASE_URL}/render?viewport=${renderWidth}x1&url=${encodeURIComponent(`${RENDER_FRONTEND_BASE_URL}/?extractId=${teaser.id}`)}&resize=200${teaser.contentHash ? `&permanentCacheKey=${encodeURIComponent(teaser.contentHash)}` : ''}`
 
 export const getTeasersFromDocument = doc => {
   if (!doc) {

--- a/components/Overview/utils.js
+++ b/components/Overview/utils.js
@@ -2,3 +2,21 @@ import { ASSETS_SERVER_BASE_URL, RENDER_FRONTEND_BASE_URL } from '../../lib/cons
 
 export const renderWidth = 1200
 export const getSmallImgSrc = teaser => `${ASSETS_SERVER_BASE_URL}/render?width=${renderWidth}&height=1&url=${encodeURIComponent(`${RENDER_FRONTEND_BASE_URL}/?extractId=${teaser.id}`)}&resize=160`
+
+export const getTeasersFromDocument = doc => {
+  if (!doc) {
+    return []
+  }
+  const children = doc.children
+    ? doc.children.nodes.map(c => c.body)
+    : doc.content.children
+
+  return children.map(rootChild => {
+    return {
+      id: rootChild.data.id,
+      nodes: rootChild.identifier === 'TEASERGROUP'
+        ? rootChild.children
+        : [rootChild]
+    }
+  })
+}

--- a/components/Overview/utils.js
+++ b/components/Overview/utils.js
@@ -1,7 +1,7 @@
 import { ASSETS_SERVER_BASE_URL, RENDER_FRONTEND_BASE_URL } from '../../lib/constants'
 
 export const renderWidth = 1200
-export const getSmallImgSrc = teaser => `${ASSETS_SERVER_BASE_URL}/render?width=${renderWidth}&height=1&url=${encodeURIComponent(`${RENDER_FRONTEND_BASE_URL}/?extractId=${teaser.id}`)}&resize=160`
+export const getSmallImgSrc = teaser => `${ASSETS_SERVER_BASE_URL}/render?width=${renderWidth}&height=1&url=${encodeURIComponent(`${RENDER_FRONTEND_BASE_URL}/?extractId=${teaser.id}`)}&resize=200${teaser.contentHash ? `&permanentCacheKey=${encodeURIComponent(teaser.contentHash)}` : ''}`
 
 export const getTeasersFromDocument = doc => {
   if (!doc) {
@@ -14,6 +14,7 @@ export const getTeasersFromDocument = doc => {
   return children.map(rootChild => {
     return {
       id: rootChild.data.id,
+      contentHash: rootChild.data.contentHash,
       nodes: rootChild.identifier === 'TEASERGROUP'
         ? rootChild.children
         : [rootChild]

--- a/components/Testimonial/Detail.js
+++ b/components/Testimonial/Detail.js
@@ -20,8 +20,7 @@ const { H3, P } = Interaction
 const styles = {
   detail: css({
     width: '100%',
-    padding: '30px 45px',
-    float: 'left'
+    padding: '30px 45px'
   }),
   detailTitle: css({
     lineHeight: '20px'
@@ -80,7 +79,7 @@ const Detail = ({
           <VideoPlayer key={id} src={{ ...video, poster: portrait }} autoPlay />
         </div>
       ) : (
-        <SerifP>«{statement}»</SerifP>
+        statement ? <SerifP>«{statement}»</SerifP> : <br />
       )}
       {!!sequenceNumber && (
         <P {...styles.number}>

--- a/components/Testimonial/Detail.js
+++ b/components/Testimonial/Detail.js
@@ -12,7 +12,8 @@ import {
   P as SerifP,
   colors,
   linkRule,
-  VideoPlayer
+  VideoPlayer,
+  mediaQueries
 } from '@project-r/styleguide'
 
 const { H3, P } = Interaction
@@ -20,7 +21,10 @@ const { H3, P } = Interaction
 const styles = {
   detail: css({
     width: '100%',
-    padding: '30px 45px'
+    padding: '30px 0',
+    [mediaQueries.mUp]: {
+      padding: '30px 45px'
+    }
   }),
   detailTitle: css({
     lineHeight: '20px'

--- a/components/Testimonial/Detail.js
+++ b/components/Testimonial/Detail.js
@@ -13,7 +13,8 @@ import {
   colors,
   linkRule,
   VideoPlayer,
-  mediaQueries
+  mediaQueries,
+  inQuotes
 } from '@project-r/styleguide'
 
 const { H3, P } = Interaction
@@ -83,7 +84,7 @@ const Detail = ({
           <VideoPlayer key={id} src={{ ...video, poster: portrait }} autoPlay />
         </div>
       ) : (
-        statement ? <SerifP>«{statement}»</SerifP> : <br />
+        statement ? <SerifP>{inQuotes(statement)}</SerifP> : <br />
       )}
       {!!sequenceNumber && (
         <P {...styles.number}>

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -277,7 +277,7 @@ export class List extends Component {
 
     return (
       <Loader
-        loading={!statements || loading}
+        loading={loading}
         style={singleRow ? { minHeight: focus ? 380 : 150 } : undefined}
         error={error}
         render={() => {

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -407,11 +407,9 @@ export class List extends Component {
   }
 }
 
-const query = gql`
-query statements($seed: Float, $search: String, $focus: String, $after: String, $first: Int!) {
-  statements(seed: $seed, search: $search, focus: $focus, after: $after, first: $first) {
-    totalCount
-    nodes {
+export const fragments = {
+  TestimonialOnUser: gql`
+    fragment TestimonialOnUser on User {
       id
       username
       name
@@ -424,14 +422,25 @@ query statements($seed: Float, $search: String, $focus: String, $after: String, 
       sequenceNumber
       hasPublicProfile
     }
+  `
+}
+
+const query = gql`
+query statements($seed: Float, $search: String, $focus: String, $after: String, $first: Int!) {
+  statements(seed: $seed, search: $search, focus: $focus, after: $after, first: $first) {
+    totalCount
+    nodes {
+      ...TestimonialOnUser
+    }
     pageInfo {
       hasNextPage
       endCursor
     }
   }
-}`
+}
+${fragments.TestimonialOnUser}`
 
-export const ListWithQuery = compose(
+const ListWithQuery = compose(
   withT,
   graphql(query, {
     props: ({ data }) => {

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -416,30 +416,26 @@ export class List extends Component {
   }
 }
 
-export const fragments = {
-  TestimonialOnUser: gql`
-    fragment TestimonialOnUser on User {
-      id
-      username
-      name
-      statement
-      credentials {
-        description
-      }
-      portrait
-      updatedAt
-      sequenceNumber
-      hasPublicProfile
-    }
-  `
-}
+export const testimonialFields = `
+  id
+  username
+  name
+  statement
+  credentials {
+    description
+  }
+  portrait
+  updatedAt
+  sequenceNumber
+  hasPublicProfile
+`
 
 const query = gql`
 query statements($seed: Float, $search: String, $focus: String, $after: String, $first: Int!) {
   statements(seed: $seed, search: $search, focus: $focus, after: $after, first: $first) {
     totalCount
     nodes {
-      ...TestimonialOnUser
+      ${testimonialFields}
     }
     pageInfo {
       hasNextPage
@@ -447,7 +443,7 @@ query statements($seed: Float, $search: String, $focus: String, $after: String, 
     }
   }
 }
-${fragments.TestimonialOnUser}`
+`
 
 const ListWithQuery = compose(
   withT,

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Fragment, Component } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 import { css, merge } from 'glamor'
@@ -138,6 +138,10 @@ const styles = {
     right: PADDING + 5,
     top: PADDING + 5
   }),
+  more: css({
+    marginTop: 15,
+    padding: PADDING
+  }),
   options: css({
     marginBottom: 15
   })
@@ -168,7 +172,7 @@ export const Item = ({ previewImage, image, name, isActive, href, onClick, singl
 
 const AUTO_INFINITE = 300
 
-class List extends Component {
+export class List extends Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -261,7 +265,7 @@ class List extends Component {
     } = this.props
     const { columns, open } = this.state
 
-    const hasEndText = !search
+    const hasEndText = !search && isPage
 
     const gridStyles = !singleRow
       ? styles.grid
@@ -281,7 +285,7 @@ class List extends Component {
           const offset = i % columns
           const openId = open[row - 1]
           if (
-            openId && offset === 0
+            !singleRow && openId && offset === 0
           ) {
             const openItem = statements
               .find(statement => statement.id === openId)
@@ -309,7 +313,7 @@ class List extends Component {
                   return
                 }
                 e.preventDefault()
-                if (onSelect(id) === false) {
+                if (onSelect && onSelect(id) === false) {
                   return
                 }
                 this.setState((state) => ({
@@ -323,7 +327,7 @@ class List extends Component {
 
           const lastOpenId = open[row]
           if (
-            i === lastIndex && lastOpenId
+            !singleRow && i === lastIndex && lastOpenId
           ) {
             const openItem = statements
               .find(statement => statement.id === lastOpenId)
@@ -351,42 +355,52 @@ class List extends Component {
             image: `${CDN_FRONTEND_BASE_URL}/static/social-media/community.jpg`
           })
 
+        const singleRowOpenItem = (
+          singleRow &&
+          open[0] &&
+          statements.find(statement => statement.id === open[0])
+        )
+
         return (
-          <div {...gridStyles} ref={this.ref}>
-            {!!isPage && <Meta data={metaData} />}
-            {items}
-            <div style={{ clear: 'left', marginBottom: 20 }} />
-            {
-              statements.length >= AUTO_INFINITE &&
-              !this.state.endless &&
-              hasMore && (
-                <A
-                  href='#'
-                  onClick={e => {
-                    e.preventDefault()
-                    this.setState(
-                      () => ({
-                        endless: true
-                      }),
-                      () => {
-                        this.onScroll()
-                      }
-                    )
-                  }}
-                >
-                  {t('testimonial/infinite/endless', {
-                    count: AUTO_INFINITE,
-                    remaining: totalCount - AUTO_INFINITE
-                  })}
-                </A>
-              )
-            }
-            {!hasMore && hasEndText && (
-              <P>{t('testimonial/infinite/end', {
-                count: statements.length
-              })}</P>
-            )}
-          </div>
+          <Fragment>
+            <div {...gridStyles} ref={this.ref}>
+              {!!isPage && <Meta data={metaData} />}
+              {items}
+              <div style={{ marginBottom: 20 }} />
+              {
+                statements.length >= AUTO_INFINITE &&
+                !this.state.endless &&
+                hasMore && (
+                  <P {...styles.more}><A
+                    href='#'
+                    onClick={e => {
+                      e.preventDefault()
+                      this.setState(
+                        () => ({
+                          endless: true
+                        }),
+                        () => {
+                          this.onScroll()
+                        }
+                      )
+                    }}
+                  >
+                    {t('testimonial/infinite/endless', {
+                      count: AUTO_INFINITE,
+                      remaining: totalCount - AUTO_INFINITE
+                    })}
+                  </A></P>
+                )
+              }
+              {!hasMore && hasEndText && (
+                <P {...styles.more}>{t('testimonial/infinite/end', {
+                  count: statements.length
+                })}</P>
+              )}
+            </div>
+            {singleRowOpenItem && <Detail
+              t={t} data={singleRowOpenItem} />}
+          </Fragment>
         )
       }} />
     )

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -362,7 +362,7 @@ export class List extends Component {
               title: t('testimonial/meta/single/title', focusItem),
               description: t('testimonial/meta/single/description', focusItem),
               url: `${PUBLIC_BASE_URL}/community?id=${focusItem.id}`,
-              image: `${ASSETS_SERVER_BASE_URL}/render?width=1200&height=628&updatedAt=${encodeURIComponent(focusItem.updatedAt)}&url=${encodeURIComponent(`${PUBLIC_BASE_URL}/community?share=${focusItem.id}`)}`
+              image: `${ASSETS_SERVER_BASE_URL}/render?viewport=1200x628&updatedAt=${encodeURIComponent(focusItem.updatedAt)}&url=${encodeURIComponent(`${PUBLIC_BASE_URL}/community?share=${focusItem.id}`)}`
             })
             : ({
               pageTitle: t('testimonial/meta/pageTitle'),

--- a/components/Testimonial/List.js
+++ b/components/Testimonial/List.js
@@ -261,7 +261,8 @@ export class List extends Component {
       loading, error, statements, t,
       onSelect, focus, isPage,
       search, hasMore, totalCount,
-      singleRow, minColumns
+      singleRow, minColumns,
+      showCredentials
     } = this.props
     const { columns, open } = this.state
 
@@ -280,8 +281,8 @@ export class List extends Component {
           statements[0]
         )
 
-        statements.forEach(({ id, portrait, name }, i) => {
-          const row = Math.floor(i / columns)
+        statements.forEach(({ id, portrait, name, credentials }, i) => {
+          const row = singleRow ? 0 : Math.floor(i / columns)
           const offset = i % columns
           const openId = open[row - 1]
           if (
@@ -299,10 +300,13 @@ export class List extends Component {
           }
 
           const isActive = open[row] === id
+          const credential = showCredentials && credentials && credentials[0] && credentials[0].description
+          const label = [name, credential].filter(Boolean).join(', ')
+
           items.push((
             <Item key={id}
               image={portrait}
-              name={name}
+              name={label}
               isActive={isActive}
               singleRow={singleRow}
               minColumns={minColumns}

--- a/lib/hooks/useInfiniteScroll.js
+++ b/lib/hooks/useInfiniteScroll.js
@@ -1,0 +1,54 @@
+import React from 'react'
+
+/**
+ * Usage
+ * const [{ containerRef, infiniteScroll, loadingMore, loadingMoreError }, setInfiniteScroll] = useInfiniteScroll({ hasMore: true, loadMore: () => new Promise() })
+ * return (<div ref={containerRef}>
+ *  {children}
+ *  {loadingMore ? 'Loading...' : null}
+ *  {loadingMoreError && <ErrorMessage error={loadingMoreError} />}
+ *  {!infiniteScroll ? <button onClick={() => setInfiniteScroll(true)}>Load More & Start Infinite Scroll</button> : null}
+ * </div>)
+ */
+export const useInfiniteScroll = ({ hasMore, loadMore }) => {
+  const containerRef = React.useRef()
+  const [infiniteScroll, setInfiniteScroll] = React.useState(false)
+  const [loadingMore, setLoadingMore] = React.useState(false)
+  const [loadingMoreError, setLoadingMoreError] = React.useState(undefined)
+
+  React.useEffect(() => {
+    const onScroll = () => {
+      if (containerRef.current) {
+        const bbox = containerRef.current.getBoundingClientRect()
+        if (bbox.bottom < window.innerHeight * 5) {
+          setLoadingMore(true)
+          loadMore()
+            .then(() => {
+              setLoadingMore(false)
+              setLoadingMoreError(undefined)
+            })
+            .catch(error => {
+              setLoadingMore(false)
+              setInfiniteScroll(false)
+              setLoadingMoreError(error)
+            })
+        }
+      }
+    }
+    if (infiniteScroll && hasMore && !loadingMore) {
+      window.addEventListener('scroll', onScroll)
+      onScroll()
+      return () => window.removeEventListener('scroll', onScroll)
+    }
+  }, [infiniteScroll, hasMore, loadingMore])
+
+  return [
+    {
+      containerRef,
+      infiniteScroll,
+      loadingMore,
+      loadingMoreError
+    },
+    setInfiniteScroll
+  ]
+}

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-05-24T11:49:44.378Z",
+  "updated": "2019-05-24T12:39:29.854Z",
   "title": "live",
   "data": [
     {
@@ -2669,6 +2669,10 @@
     {
       "key": "shareholder/contact/phone/link",
       "value": "+41797874765"
+    },
+    {
+      "key": "front/chronology",
+      "value": "Chronologie {years}"
     },
     {
       "key": "front/loadMore",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-05-23T15:41:44.104Z",
+  "updated": "2019-05-24T11:49:44.378Z",
   "title": "live",
   "data": [
     {
@@ -2669,6 +2669,10 @@
     {
       "key": "shareholder/contact/phone/link",
       "value": "+41797874765"
+    },
+    {
+      "key": "front/loadMore",
+      "value": "Das waren die neuesten {count} Zeilen. Weitere {remaining} anschauen?"
     },
     {
       "key": "feed/loadMore",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-05-23T15:01:35.708Z",
+  "updated": "2019-05-23T15:41:44.104Z",
   "title": "live",
   "data": [
     {
@@ -4489,10 +4489,6 @@
     {
       "key": "overview/lead/pledgeButton",
       "value": "Kommen Sie an Bord!"
-    },
-    {
-      "key": "overview/after/pledge",
-      "value": null
     },
     {
       "key": "overview/after/pledgeButton",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-05-15T13:42:53.050Z",
+  "updated": "2019-05-22T16:24:26.402Z",
   "title": "live",
   "data": [
     {
@@ -343,12 +343,44 @@
       "value": "Jetzt anmelden"
     },
     {
+      "key": "marketing/overview/title",
+      "value": "{count} Produktionen"
+    },
+    {
+      "key": "marketing/overview/defaultCount",
+      "value": "Über 1000"
+    },
+    {
+      "key": "marketing/overview/lead",
+      "value": "Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart."
+    },
+    {
+      "key": "marketing/overview/more",
+      "value": "Chronologie {years}"
+    },
+    {
       "key": "marketing/community/title",
-      "value": "{count} Personen sind schon dabei"
+      "value": "{count} Verlegerinnen und Verleger"
+    },
+    {
+      "key": "marketing/community/defaultCount",
+      "value": "Über 17’000"
     },
     {
       "key": "marketing/community/link",
       "value": "Zur Community"
+    },
+    {
+      "key": "marketing/community/moreStatements",
+      "value": "Weitere {count} Statements"
+    },
+    {
+      "key": "marketing/employees/title",
+      "value": "Über 60 Mitwirkende"
+    },
+    {
+      "key": "marketing/employees/more",
+      "value": "Zum Impressum"
     },
     {
       "key": "marketing/signup/title",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-05-22T16:24:26.402Z",
+  "updated": "2019-05-23T15:01:35.708Z",
   "title": "live",
   "data": [
     {
@@ -352,7 +352,7 @@
     },
     {
       "key": "marketing/overview/lead",
-      "value": "Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge zu den wichtigsten Fragen der Gegenwart."
+      "value": "Die Republik erscheint von Montag bis Samstag – auf der Website, als Newsletter, in der App. Und liefert Ihnen täglich ein bis drei Beiträge."
     },
     {
       "key": "marketing/overview/more",
@@ -376,7 +376,7 @@
     },
     {
       "key": "marketing/employees/title",
-      "value": "Über 60 Mitwirkende"
+      "value": "Über 60 Macherinnen"
     },
     {
       "key": "marketing/employees/more",
@@ -4480,19 +4480,19 @@
     },
     {
       "key": "overview/lead/signIn",
-      "value": "Melden Sie sich an, um die Beiträge lesen zu können. Noch nicht Mitglied? {pledgeLink}"
+      "value": "Melden Sie sich an, um die Beiträge lesen zu können. Noch nicht Mitglied?"
     },
     {
       "key": "overview/lead/pledge",
-      "value": "Werden Sie Mitglied, um die Beiträge lesen zu können. {pledgeLink}"
+      "value": "Werden Sie Mitglied, um die Beiträge lesen zu können."
     },
     {
-      "key": "overview/lead/pledgeText",
+      "key": "overview/lead/pledgeButton",
       "value": "Kommen Sie an Bord!"
     },
     {
       "key": "overview/after/pledge",
-      "value": "Geniessen Sie die ruhigen Stunden zum Lesen:"
+      "value": null
     },
     {
       "key": "overview/after/pledgeButton",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7702,14 +7702,6 @@
         "react-icon-base": "2.1.0"
       }
     },
-    "react-infinite-scroller": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz",
-      "integrity": "sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "react-dom": "^16.8.0",
     "react-dropzone": "^4.3.0",
     "react-icons": "^2.2.7",
-    "react-infinite-scroller": "^1.2.1",
     "react-maskedinput": "^4.0.1",
     "react-textarea-autosize": "^7.0.4",
     "scroll-into-view": "^1.9.7",

--- a/pages/community.js
+++ b/pages/community.js
@@ -29,7 +29,7 @@ class CommunityPage extends Component {
       const order = query.order || 'ASC'
       const defaultSequenceNumber = order === 'DESC' ? Math.pow(10, 6) : 0
       return <Image query={query}
-        sequenceNumber={query.sequenceNumber || defaultSequenceNumber}
+        sequenceNumber={+query.sequenceNumber || defaultSequenceNumber}
         orderDirection={order}
         duration={+Math.max(1000, query.duration || 5000)} />
     }

--- a/pages/overview.js
+++ b/pages/overview.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import { graphql, compose } from 'react-apollo'
 import gql from 'graphql-tag'
 import { withRouter } from 'next/router'
@@ -19,7 +19,7 @@ import Frame from '../components/Frame'
 import { negativeColors } from '../components/Frame/constants'
 
 import TeaserBlock from '../components/Overview/TeaserBlock'
-import { A, P } from '../components/Overview/Elements'
+import { P } from '../components/Overview/Elements'
 import text18 from '../components/Overview/2018'
 import text19 from '../components/Overview/2019'
 import { getTeasersFromDocument } from '../components/Overview/utils'
@@ -151,17 +151,14 @@ class FrontOverview extends Component {
           {t.first([`overview/${year}/title`, 'overview/title'], { year })}
         </Interaction.H1>
 
-        <P>
+        <P style={{ marginBottom: 10 }}>
           {isMember
-            ? <Fragment>
-              {t.first([`overview/${year}/lead`, 'overview/lead'], { year }, '')}
-            </Fragment>
-            : t.elements(`overview/lead/${me ? 'pledge' : 'signIn'}`, {
-              pledgeLink: <Link key='pledge' route='pledge' passHref>
-                <A>{t('overview/lead/pledgeText')}</A>
-              </Link>
-            })}
+            ? t.first([`overview/${year}/lead`, 'overview/lead'], { year }, '')
+            : t.elements(`overview/lead/${me ? 'pledge' : 'signIn'}`)}
         </P>
+        {!isMember && <Link key='pledge' route='pledge' passHref>
+          <Button white>{t('overview/lead/pledgeButton')}</Button>
+        </Link>}
 
         <Loader loading={data.loading} error={data.error} style={{ minHeight: `calc(90vh)` }} render={() => {
           return teasersByMonth.map(({ key: month, values }, i) => {
@@ -189,14 +186,9 @@ class FrontOverview extends Component {
           })
         }} />
 
-        {!isMember && <Fragment>
-          <P style={{ marginBottom: 10, marginTop: 100 }}>
-            {t('overview/after/pledge')}
-          </P>
-          <Link key='pledge' route='pledge' passHref>
-            <Button white>{t('overview/after/pledgeButton')}</Button>
-          </Link>
-        </Fragment>}
+        {!isMember && <Link key='pledge' route='pledge' passHref>
+          <Button white style={{ marginTop: 100 }}>{t('overview/after/pledgeButton')}</Button>
+        </Link>}
       </Frame>
     )
   }


### PR DESCRIPTION
### Changes

- add magazin front preview teasers with links to `/2019`
- allow to expand statements, auto expand first
- add employee statements

### New Mobile Marketing Front

<img src="https://user-images.githubusercontent.com/410211/58198684-1726bd00-7ccf-11e9-8c13-ae4c1b1b9dc3.png" width="49%" title="after mobile" />

### New Desktop Marketing Front

![after](https://user-images.githubusercontent.com/410211/58198770-4d643c80-7ccf-11e9-937f-d5a7546d5dd1.png)
