### PR TITLE
Remove list of paths on which to keep passed query

### DIFF
--- a/components/StatusError/index.js
+++ b/components/StatusError/index.js
@@ -48,7 +48,7 @@ export default compose(
     skip: props => props.statusCode !== 404 || !props.router.asPath,
     options: ({ router: { asPath } }) => ({
       variables: {
-        path: asPath
+        path: asPath.split('#')[0]
       }
     }),
     props: ({ data, ownProps: { serverContext, statusCode, router, inNativeApp, me } }) => {

--- a/components/StatusError/index.js
+++ b/components/StatusError/index.js
@@ -5,7 +5,7 @@ import { withRouter } from 'next/router'
 
 import withT from '../../lib/withT'
 import withInNativeApp from '../../lib/withInNativeApp'
-import { Router, cleanAsPath } from '../../lib/routes'
+import { Router } from '../../lib/routes'
 import { PUBLIC_BASE_URL } from '../../lib/constants'
 
 import Loader from '../Loader'
@@ -40,12 +40,6 @@ const StatusError = ({ statusCode, t, loading, children }) => (
   )} />
 )
 
-const redirectionPathWithQuery = [
-  '/pledge',
-  '/notifications',
-  '/merci'
-]
-
 export default compose(
   withT,
   withInNativeApp,
@@ -54,7 +48,7 @@ export default compose(
     skip: props => props.statusCode !== 404 || !props.router.asPath,
     options: ({ router: { asPath } }) => ({
       variables: {
-        path: cleanAsPath(asPath)
+        path: asPath
       }
     }),
     props: ({ data, ownProps: { serverContext, statusCode, router, inNativeApp, me } }) => {
@@ -66,15 +60,13 @@ export default compose(
       let loading = data.loading
 
       if (redirection) {
-        const [pathname, query] = router.asPath.split('?')
-        const withQuery = query && redirectionPathWithQuery.indexOf(pathname) !== -1
-        const target = `${redirection.target}${withQuery ? `?${query}` : ''}`
+        const { target, status } = redirection
         const targetIsExternal = target.startsWith('http') && !target.startsWith(PUBLIC_BASE_URL)
 
         if (serverContext) {
           if (!inNativeApp || !targetIsExternal) {
             serverContext.res.redirect(
-              redirection.status || 302,
+              status || 302,
               target
             )
           } else {
@@ -91,7 +83,7 @@ export default compose(
               window.location = target
             }
           }
-          if (redirection.status === 301) {
+          if (status === 301) {
             Router.replaceRoute(clientTarget).then(afterRouting)
           } else {
             Router.pushRoute(clientTarget).then(afterRouting)


### PR DESCRIPTION
Depends on https://github.com/orbiting/backends/pull/270

```gql
query { redirection(path:"/some-path?name=value") { target } }
```

If redirection is configured properly, `target` will overwrite query parameters passed in `path` and return in `target`.

Thus far they were stripped, and only kept for a dedicated set of URLs.