### PR TITLE
Spread voucher claim link in footer, marketing and signin pages

### DIFF
--- a/components/Account/Memberships/Claim.js
+++ b/components/Account/Memberships/Claim.js
@@ -231,17 +231,17 @@ class ClaimMembership extends Component {
     const contextLead = t.first([
       `memberships/claim/${context}/lead`,
       'memberships/claim/lead'
-    ], {}, false)
+    ], undefined, '')
 
     const contextBody = t.first([
       `memberships/claim/${context}/body`,
       'memberships/claim/body'
-    ], {}, false)
+    ], undefined, '')
 
     const contextAddendum = t.first([
       `memberships/claim/${context}/addendum`,
       'memberships/claim/addendum'
-    ], {}, false)
+    ], undefined, '')
 
     if (polling) {
       return (

--- a/components/Account/Memberships/Claim.js
+++ b/components/Account/Memberships/Claim.js
@@ -238,6 +238,11 @@ class ClaimMembership extends Component {
       'memberships/claim/body'
     ], {}, false)
 
+    const contextAddendum = t.first([
+      `memberships/claim/${context}/addendum`,
+      'memberships/claim/addendum'
+    ], {}, false)
+
     if (polling) {
       return (
         <Poller
@@ -320,6 +325,13 @@ class ClaimMembership extends Component {
           onChange={(_, value, shouldValidate) => {
             this.handleVoucherCode(value, shouldValidate, t)
           }} />
+        <br />
+        <br />
+        {contextAddendum &&
+          <RawHtml type={P} dangerouslySetInnerHTML={{
+            __html: contextAddendum
+          }} />
+        }
         <br />
         <br />
         {!!this.state.showErrors && errorMessages.length > 0 && (

--- a/components/Account/UserGuidance.js
+++ b/components/Account/UserGuidance.js
@@ -4,6 +4,7 @@ import { css } from 'glamor'
 
 import { Link } from '../../lib/routes'
 import withT from '../../lib/withT'
+import withInNativeApp from '../../lib/withInNativeApp'
 
 import { withSignOut } from '../Auth/SignOut'
 import Box from '../Frame/Box'
@@ -20,51 +21,70 @@ const styles = {
   })
 }
 
-const ISSUES = [1, 2, 3, 4]
+const ISSUES = [
+  { issue: 1 },
+  { issue: 2, hideInNativeIOSApp: true },
+  { issue: 3, hideInNativeIOSApp: true },
+  { issue: 4, hideInNativeIOSApp: true },
+  { issue: 5 }
+]
 
-const UserGuidance = ({ t, signOut }) => (
+const UserGuidance = ({ t, inNativeIOSApp, signOut }) => (
   <Box>
     <MainContainer>
       <Interaction.P>{t('Account/noActiveMembership/before')}</Interaction.P>
       <ul {...styles.list}>
-        {ISSUES.map(index => (
-          <li key={index}>
-            <P>
-              {t(`Account/noActiveMembership/issue${index}`)}
-              <br />
-              {t.elements(`Account/noActiveMembership/solution${index}`, {
-                solution: (
-                  <b key='solution'>
-                    {t('Account/noActiveMembership/solution')}
-                  </b>
-                ),
-                signOutLink: (
-                  <Editorial.A
-                    key='signOut'
-                    href='#abmelden'
-                    onClick={e => {
-                      e.preventDefault()
-                      signOut()
-                    }}
-                  >
-                    {t('Account/noActiveMembership/signOutLink')}
-                  </Editorial.A>
-                ),
-                pledgeLink: (
-                  <Link route='pledge' key='pledge' passHref>
-                    <Editorial.A>
-                      {t('Account/noActiveMembership/pledgeLink')}
+        {ISSUES.map(({ issue, hideInNativeIOSApp = false }) => {
+          if (inNativeIOSApp && hideInNativeIOSApp) {
+            return null
+          }
+
+          return (
+            <li key={issue}>
+              <P>
+                {t(`Account/noActiveMembership/issue${issue}`)}
+                <br />
+                {t.elements(`Account/noActiveMembership/solution${issue}`, {
+                  solution: (
+                    <b key='solution'>
+                      {t('Account/noActiveMembership/solution')}
+                    </b>
+                  ),
+                  signOutLink: (
+                    <Editorial.A
+                      key='signOut'
+                      href='#abmelden'
+                      onClick={e => {
+                        e.preventDefault()
+                        signOut()
+                      }}
+                    >
+                      {t('Account/noActiveMembership/signOutLink')}
                     </Editorial.A>
-                  </Link>
-                )
-              })}
-            </P>
-          </li>
-        ))}
+                  ),
+                  pledgeLink: (
+                    <Link route='pledge' key='pledge' passHref>
+                      <Editorial.A>
+                        {t('Account/noActiveMembership/pledgeLink')}
+                      </Editorial.A>
+                    </Link>
+                  ),
+                  claimLink: (
+                    <Link route='claim' key='claim' passHref>
+                      <Editorial.A>
+                        {t('Account/noActiveMembership/claimLink')}
+                      </Editorial.A>
+                    </Link>
+                  )
+                })}
+              </P>
+            </li>
+          )
+        })}
       </ul>
       <Interaction.P>{t('Account/noActiveMembership/after')}</Interaction.P>
     </MainContainer>
   </Box>
 )
 
-export default compose(withT, withSignOut)(UserGuidance)
+export default compose(withT, withInNativeApp, withSignOut)(UserGuidance)

--- a/components/Account/index.js
+++ b/components/Account/index.js
@@ -96,7 +96,7 @@ class Account extends Component {
         return (
           <Fragment>
             {hasAccessGrants && !hasActiveMemberships && <AccessGrants />}
-            {!hasAccessGrants && !hasMemberships && !inNativeIOSApp && <UserGuidance />}
+            {!hasAccessGrants && !hasMemberships && <UserGuidance />}
             <MainContainer>
               <Content>
                 {!merci && <H1>
@@ -105,13 +105,12 @@ class Account extends Component {
                   })}
                 </H1>}
                 <Anchors />
-                {hasMemberships && inNativeIOSApp &&
+                {inNativeIOSApp &&
                 <Box style={{ padding: 14, marginBottom: 20 }}>
                   <P>
                     {t('account/ios/box')}
                   </P>
-                </Box>
-                }
+                </Box>}
                 {hasPledges && <AccountAnchor id='statement'>
                   <GiveStatement pkg={hasProlongPledge ? 'PROLONG' : undefined} />
                 </AccountAnchor>}

--- a/components/Auth/withMembership.js
+++ b/components/Auth/withMembership.js
@@ -9,7 +9,7 @@ import Frame from '../Frame'
 import SignIn from './SignIn'
 import Me from './Me'
 
-import { Interaction, linkRule } from '@project-r/styleguide'
+import { Interaction, Editorial, linkRule } from '@project-r/styleguide'
 
 import withAuthorization, { PageCenter } from './withAuthorization'
 import { withMembership } from './checkRoles'
@@ -27,14 +27,40 @@ export const UnauthorizedMessage = compose(
         <br />
         <Me
           beforeSignedInAs={(
-            <Interaction.P style={{ marginBottom: 20 }}>
-              {t('withMembership/ios/unauthorized/noMembership')}
-            </Interaction.P>
+            <Fragment>
+              <Interaction.P style={{ marginBottom: 20 }}>
+                {t('withMembership/ios/unauthorized/noMembership')}
+              </Interaction.P>
+              <Interaction.P style={{ marginBottom: 20 }}>
+                {t.elements('withMembership/ios/unauthorized/claimText', {
+                  claimLink: (
+                    <Link route='claim' key='claim' passHref>
+                      <Editorial.A>
+                        {t('withMembership/ios/unauthorized/claimLink')}
+                      </Editorial.A>
+                    </Link>
+                  )
+                })}
+              </Interaction.P>
+            </Fragment>
           )}
           beforeSignInForm={(
-            <Interaction.P style={{ marginBottom: 20 }}>
-              {t('withMembership/ios/unauthorized/signIn')}
-            </Interaction.P>
+            <Fragment>
+              <Interaction.P style={{ marginBottom: 20 }}>
+                {t('withMembership/ios/unauthorized/signIn')}
+              </Interaction.P>
+              <Interaction.P>
+                {t.elements('withMembership/ios/unauthorized/claimText', {
+                  claimLink: (
+                    <Link route='claim' key='claim' passHref>
+                      <Editorial.A>
+                        {t('withMembership/ios/unauthorized/claimLink')}
+                      </Editorial.A>
+                    </Link>
+                  )
+                })}
+              </Interaction.P>
+            </Fragment>
           )} />
       </Fragment>
     )

--- a/components/Frame/Footer.js
+++ b/components/Frame/Footer.js
@@ -251,6 +251,12 @@ class Footer extends Component {
                   <br />
                 </Fragment>
               )}
+              <Fragment>
+                <Link route='claim'>
+                  <a>{t('footer/me/claim')}</a>
+                </Link>
+                <br />
+              </Fragment>
               <Link route='faq'>
                 <a>{t('footer/me/faq')}</a>
               </Link>

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -24,6 +24,7 @@ import {
 import TeaserBlock from '../Overview/TeaserBlock'
 import { getTeasersFromDocument } from '../Overview/utils'
 import { A, P } from '../Overview/Elements'
+import UserGuidance from '../Account/UserGuidance'
 
 import { buttonStyles, sharedStyles } from './styles'
 
@@ -32,6 +33,15 @@ import ErrorMessage from '../ErrorMessage'
 
 const query = gql`
 query marketingMembershipStats {
+  me {
+    id
+    memberships {
+      id
+    }
+    accessGrants {
+      id
+    }
+  }
   membershipStats {
     count
   }
@@ -100,10 +110,16 @@ class MarketingPage extends Component {
     this.onHighlight = highlight => this.setState({ highlight })
   }
   render () {
-    const { t, data: { loading, error, membershipStats, front, articles, statements, employees } } = this.props
+    const { t, data: { loading, error, me, membershipStats, front, articles, statements, employees } } = this.props
+
+    const hasMembershipOrAccessGrant = me && (
+      (me.memberships && me.memberships.length > 0) ||
+      (me.accessGrants && me.accessGrants.length > 0)
+    )
 
     return (
       <Fragment>
+        {!loading && me && !hasMembershipOrAccessGrant && <UserGuidance />}
         <div style={{ overflow: 'hidden' }}>
           <Container>
             <h1 {...sharedStyles.headline}>
@@ -135,7 +151,16 @@ class MarketingPage extends Component {
                   <a>{t('marketing/signin/link') }</a>
                 </Link>
                 }
-              )}
+              )}{' – '}
+              {t.elements('marketing/claim', {
+                claimLink: (
+                  <Link route='claim' key='claim' passHref>
+                    <Editorial.A>
+                      {t('marketing/claim/link')}
+                    </Editorial.A>
+                  </Link>
+                )
+              })}
             </div>
             {error && <ErrorMessage error={error} style={{ textAlign: 'center' }} />}
           </Container>

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-06-17T09:04:52.168Z",
+  "updated": "2019-06-17T13:28:29.323Z",
   "title": "live",
   "data": [
     {
@@ -204,7 +204,7 @@
     },
     {
       "key": "withMembership/ios/unauthorized/claimLink",
-      "value": "Gutschein einlösen"
+      "value": "Jetzt einlösen"
     },
     {
       "key": "signIn/button",
@@ -348,7 +348,7 @@
     },
     {
       "key": "marketing/claim/link",
-      "value": "Gutschein einlösen"
+      "value": "Jetzt einlösen"
     },
     {
       "key": "marketing/overview/title",
@@ -780,7 +780,7 @@
     },
     {
       "key": "Account/noActiveMembership/issue5",
-      "value": "Sie haben einen uneingelösten Gutschein zur Hand."
+      "value": "Sie haben einen Gutschein, diesen aber noch nicht eingelöst."
     },
     {
       "key": "Account/noActiveMembership/solution5",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-06-17T13:28:29.323Z",
+  "updated": "2019-06-17T14:50:51.230Z",
   "title": "live",
   "data": [
     {
@@ -3484,7 +3484,7 @@
     },
     {
       "key": "memberships/claim/addendum",
-      "value": "Wir schützen Ihre Privatsphäre. Wenn wir Informationen weitergeben, zeigen wir das an. In diesem Fall: Die Herausgeberin des Gutscheins wird einsehen können, dass Sie den Gutschein eingelöst haben."
+      "value": "Wir schützen Ihre Privatsphäre. Wenn wir Informationen weitergeben, zeigen wir das an. In diesem Fall: Die Herausgeberin des Gutscheins wird sehen können, dass Sie den Gutschein eingelöst haben."
     },
     {
       "key": "memberships/claim/button",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-06-12T15:45:21.500Z",
+  "updated": "2019-06-17T09:04:52.168Z",
   "title": "live",
   "data": [
     {
@@ -136,19 +136,11 @@
     },
     {
       "key": "pages/claim/meta/title",
-      "value": "Gutscheincode einlösen"
+      "value": "Gutschein einlösen"
     },
     {
       "key": "pages/claim/meta/description",
-      "value": "Lösen Sie hier Ihren Gutscheincode ein."
-    },
-    {
-      "key": "pages/claim/access/meta/title",
-      "value": "Gutscheincode einlösen (Zugriff teilen)"
-    },
-    {
-      "key": "pages/claim/access/meta/description",
-      "value": "Mit Ihrem Gutscheincode den geteilten Zugriff aktivieren."
+      "value": "Lösen Sie hier Ihren Gutschein ein."
     },
     {
       "key": "Frame/Popover/myaccount",
@@ -207,6 +199,14 @@
       "value": "Die Nutzung der App erfordert eine Mitgliedschaft oder ein Abo bei der Republik. "
     },
     {
+      "key": "withMembership/ios/unauthorized/claimText",
+      "value": "Sie haben einen Gutschein? {claimLink}."
+    },
+    {
+      "key": "withMembership/ios/unauthorized/claimLink",
+      "value": "Gutschein einlösen"
+    },
+    {
       "key": "signIn/button",
       "value": "Anmelden"
     },
@@ -236,7 +236,7 @@
     },
     {
       "key": "signIn/polling/APP/text",
-      "value": "Wir haben Ihnen auf Ihre Republik-App <b>eine Benachrichtigung</b> geschickt. Bitte prüfen Sie Ihr Smartphone oder Tablet."
+      "value": "Wir haben Ihnen auf Ihre Republik-App <b>eine Benachrichtigung</b> geschickt. Bitte prüfen Sie Ihr Smartphone oder Tablet. Schliessen Sie diese Seite nicht."
     },
     {
       "key": "signIn/polling/EMAIL_TOKEN/title",
@@ -244,7 +244,7 @@
     },
     {
       "key": "signIn/polling/EMAIL_TOKEN/text",
-      "value": "Wir haben Ihnen <b>eine E-Mail</b> geschickt, mit der Sie diesen Zugriff freischalten können."
+      "value": "Wir haben Ihnen <b>eine E-Mail</b> geschickt, mit der Sie diesen Zugriff freischalten können. Schliessen Sie diese Seite nicht."
     },
     {
       "key": "signIn/polling/switch/APP",
@@ -343,6 +343,14 @@
       "value": "Jetzt anmelden"
     },
     {
+      "key": "marketing/claim",
+      "value": "Sie haben einen Gutschein? {claimLink}"
+    },
+    {
+      "key": "marketing/claim/link",
+      "value": "Gutschein einlösen"
+    },
+    {
       "key": "marketing/overview/title",
       "value": "{count} Produktionen"
     },
@@ -436,7 +444,7 @@
     },
     {
       "key": "marketing/offers/claim",
-      "value": "Gutscheincode einlösen"
+      "value": "Gutschein einlösen"
     },
     {
       "key": "marketing/feuilleton/title",
@@ -769,6 +777,18 @@
     {
       "key": "Account/noActiveMembership/solution4",
       "value": "{solution} {pledgeLink}"
+    },
+    {
+      "key": "Account/noActiveMembership/issue5",
+      "value": "Sie haben einen uneingelösten Gutschein zur Hand."
+    },
+    {
+      "key": "Account/noActiveMembership/solution5",
+      "value": "{solution} Sie können {claimLink}."
+    },
+    {
+      "key": "Account/noActiveMembership/claimLink",
+      "value": "den Gutschein jetzt einlösen"
     },
     {
       "key": "Account/noActiveMembership/after",
@@ -1604,7 +1624,7 @@
     },
     {
       "key": "footer/me/claim",
-      "value": "Gutscheincode einlösen"
+      "value": "Gutschein einlösen"
     },
     {
       "key": "footer/me/share",
@@ -3448,7 +3468,7 @@
     },
     {
       "key": "memberships/claim/lead",
-      "value": "Willkommen an Bord! Hier können Sie Ihren Gutscheincode einlösen."
+      "value": "Gutschein einlösen"
     },
     {
       "key": "memberships/claim/voucherCode/label",
@@ -3461,6 +3481,10 @@
     {
       "key": "memberships/claim/voucherCode/label/error/unrecognized",
       "value": "Gutscheincode nicht erkannt"
+    },
+    {
+      "key": "memberships/claim/addendum",
+      "value": "Wir schützen Ihre Privatsphäre. Wenn wir Informationen weitergeben, zeigen wir das an. In diesem Fall: Die Herausgeberin des Gutscheins wird einsehen können, dass Sie den Gutschein eingelöst haben."
     },
     {
       "key": "memberships/claim/button",

--- a/pages/signin.js
+++ b/pages/signin.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { withRouter } from 'next/router'
 import { compose } from 'react-apollo'
 import SignIn from '../components/Auth/SignIn'
@@ -9,7 +9,8 @@ import withMe from '../lib/apollo/withMe'
 import withT from '../lib/withT'
 import withMembership from '../components/Auth/withMembership'
 import withInNativeApp from '../lib/withInNativeApp'
-import { Interaction } from '@project-r/styleguide'
+import { Link } from '../lib/routes'
+import { Interaction, Editorial } from '@project-r/styleguide'
 
 class SigninPage extends Component {
   componentDidMount () {
@@ -43,9 +44,24 @@ class SigninPage extends Component {
           {me
             ? <Loader loading />
             : <SignIn email={router.query.email} beforeForm={inNativeIOSApp
-              ? <Interaction.P style={{ marginBottom: 20 }}>
-                {t('withMembership/ios/unauthorized/signIn')}
-              </Interaction.P>
+              ? (
+                <Fragment>
+                  <Interaction.P style={{ marginBottom: 20 }}>
+                    {t('withMembership/ios/unauthorized/signIn')}
+                  </Interaction.P>
+                  <Interaction.P>
+                    {t.elements('withMembership/ios/unauthorized/claimText', {
+                      claimLink: (
+                        <Link route='claim' key='claim' passHref>
+                          <Editorial.A>
+                            {t('withMembership/ios/unauthorized/claimLink')}
+                          </Editorial.A>
+                        </Link>
+                      )
+                    })}
+                  </Interaction.P>
+                </Fragment>
+              )
               : undefined
             } noReload />}
         </PageCenter>


### PR DESCRIPTION
Adds a claim link onto several location. Due to some AppStore payment compliance restrictions, iOS gets fewer changes. This pull request also adds a privacy notice to claim page, indicating that a claimed voucher code will be signaled to its original issuer.

Voucher claim link is visible anytime in footer on all devices:

![Browser, Footer](https://user-images.githubusercontent.com/331800/59601227-b8086c80-9103-11e9-938f-11b294466a1f.png)

On Marketing page there is an additional link below actions buttons and next to sign in links.

![Browser, Marketing](https://user-images.githubusercontent.com/331800/59601263-d0788700-9103-11e9-899b-2d70ccf91cc6.png)

As there is no Marketing page on iOS and Login page is shown, it shows an additional link to claim page:

![iOS, Marketing](https://user-images.githubusercontent.com/331800/59601344-03bb1600-9104-11e9-8d0c-db59619c10a1.png)

If a user is logged in but hasn't a membership yet, a "user guidance" section with several bullet points is shown on a user account page.

This "user guidance" section is now visible on Marketing page as well, and includes a link to claim voucher:

![Browser, Marketing, User](https://user-images.githubusercontent.com/331800/59601444-40870d00-9104-11e9-96d7-0366cd6c603c.png)

This "user guidance" section was not visible to logged in iOS users on their account page. It now comes with a shortened of that list which won't address buying any membership as to comply with Apple App Store policies:

![iOS, Konto](https://user-images.githubusercontent.com/331800/59601515-7c21d700-9104-11e9-8b62-908af792a45d.png)

Claim page now includes a privacy notice on how we might signal voucher issuers whether a code was claimed by whom:
 
![Browser, Claim](https://user-images.githubusercontent.com/331800/59601575-b4c1b080-9104-11e9-9c4b-49ad74300dee.png)

![Mobile, Claim](https://user-images.githubusercontent.com/331800/59601568-a6739480-9104-11e9-8b6c-ec5300ebff4c.png)

 
Technical changes:

* Show UserGuidance on Marketing page
* Show trimmed UserGuidance on iOS devices
* Change wording from "Claim voucher code" to "Claim voucher"
* Add privacy statement on Claim page

ToDos:

- [x] Proof-read wording
- [x] Get Careteam feedback