### PR TITLE
Add editorial job to jobs page

### DIFF
--- a/components/Frame/Footer.js
+++ b/components/Frame/Footer.js
@@ -174,6 +174,10 @@ class Footer extends Component {
                 <a>{t('footer/about')}</a>
               </Link>
               <br />
+              <Link route='jobs'>
+                <a>{t('footer/jobs')}</a>
+              </Link>
+              <br />
               <Link route='events'>
                 <a>{t('footer/events')}</a>
               </Link>

--- a/pages/jobs.js
+++ b/pages/jobs.js
@@ -136,7 +136,7 @@ export default compose(
           </Editorial.UL>
           <br />
           <br />
-          <Anchor id='community'>
+          <Anchor id='editorial'>
             <H2>Redaktorin mit Fokus Inland und Politik</H2>
           </Anchor>
           <P>

--- a/pages/jobs.js
+++ b/pages/jobs.js
@@ -128,11 +128,60 @@ export default compose(
           </P>
           <H1>Offene Stellen</H1>
           <Editorial.UL>
+            <LI><A href='#editorial'>Redaktor...</A></LI>
             <LI><A href='#community'>Community Builder & Partnership Management</A></LI>
             <LI><A href='#it'>Designerin</A></LI>
             <LI><A href='#it'>React-Entwickler</A></LI>
             <LI><A href='#it'>Backend-Entwicklerin</A></LI>
           </Editorial.UL>
+          <br />
+          <br />
+          <Anchor id='community'>
+            <H2>Redaktor...</H2>
+          </Anchor>
+          <P>
+            Rolle...
+          </P>
+          <Editorial.UL>
+            <LI>Skill #1</LI>
+          </Editorial.UL>
+          <P>
+            Pitch...
+          </P>
+          <P>Stellenprozent</P>
+
+          <H3>Was wir bieten</H3>
+          <br />
+          <Editorial.UL>
+            <LI>Konkurrenzfähiger Einheitslohn</LI>
+            <LI>Kreatives, unkonventionelles Arbeitsumfeld</LI>
+            <LI>Viel Gestaltungsspielraum</LI>
+            <LI>Zentraler Arbeitsort an der Langstrasse in Zürich</LI>
+          </Editorial.UL>
+
+          <P>
+            Detaillierte Rolle bei Republik...
+          </P>
+
+          <H3>Wie bewerben?</H3>
+          <P style={{ marginBottom: 10 }}>
+            Fragen & Bewerbungen an: <A href='mailto:bewerbung@republik.ch'>bewerbung@republik.ch</A>.
+          </P>
+          <TestimonialList
+            share={false}
+            minColumns={3}
+            showCredentials
+            statements={communityContacts.map(employee => ({
+              ...employee.user,
+              name: employee.name,
+              credentials: [
+                {
+                  description: employee.title || employee.group
+                }
+              ].filter(d => d.description)
+            }))}
+            t={t} />
+          <P>Wir freuen uns auf deine Bewerbung.</P>
           <br />
           <br />
           <Anchor id='community'>

--- a/pages/jobs.js
+++ b/pages/jobs.js
@@ -128,7 +128,7 @@ export default compose(
           </P>
           <H1>Offene Stellen</H1>
           <Editorial.UL>
-            <LI><A href='#editorial'>Redaktor...</A></LI>
+            <LI><A href='#editorial'>Redaktorin mit Fokus Inland und Politik</A></LI>
             <LI><A href='#community'>Community Builder & Partnership Management</A></LI>
             <LI><A href='#it'>Designerin</A></LI>
             <LI><A href='#it'>React-Entwickler</A></LI>
@@ -137,31 +137,29 @@ export default compose(
           <br />
           <br />
           <Anchor id='community'>
-            <H2>Redaktor...</H2>
+            <H2>Redaktorin mit Fokus Inland und Politik</H2>
           </Anchor>
           <P>
-            Rolle...
+            Damit du für diese Rolle in Frage kommst, bist du bereits einige Jahre als Journalistin tätig und hast ein besonderes Interesse an den Bereichen Inland, Politik und Bundeshaus. Du bist gut vernetzt in Bern wie auch dem Rest der Schweiz.
           </P>
-          <Editorial.UL>
-            <LI>Skill #1</LI>
-          </Editorial.UL>
           <P>
-            Pitch...
+            Du verstehst die Wichtigkeit von unabhängigem Journalismus und bringst Energie und Lust mit, um Beiträge zu realisieren, die aufdecken, hinterfragen und analysieren. Du denkst über den Tellerrand hinaus, bist neugierig, kritisch und eigenständig. Du magst interdisziplinäres Arbeiten, bringst deine Ideen ein und treibst die Umsetzung journalistischer Projekte aktiv voran. Zudem hast du eine Vorstellung davon, wie der Politikjournalismus bei der Republik, einem modernen, digitalen Magazin, in Zukunft aussehen sollte.
           </P>
-          <P>Stellenprozent</P>
+          <P>
+            Du übernimmst gerne Verantwortung und fühlst dich wohl in einem dynamischen, sich stetig verändernden Umfeld. Du arbeitest gerne im Team, legst Wert auf offene Kommunikation und nutzt Kritik, um dich weiterzuentwickeln. Auch schätzt du den Austausch und Dialog mit der Community und beteiligst dich gerne aktiv daran.
+          </P>
+          <P>
+            Hast du Lust, zusammen mit anderen kreativen Köpfen Journalismus zu machen, der bewegt und überrascht? Dann bewirb dich, wir freuen uns!
+          </P>
+          <P>Ab September oder nach Vereinbarung, 60 bis 80 Prozent.</P>
 
           <H3>Was wir bieten</H3>
           <br />
           <Editorial.UL>
             <LI>Konkurrenzfähiger Einheitslohn</LI>
             <LI>Kreatives, unkonventionelles Arbeitsumfeld</LI>
-            <LI>Viel Gestaltungsspielraum</LI>
-            <LI>Zentraler Arbeitsort an der Langstrasse in Zürich</LI>
+            <LI>Arbeitsorte Zürich und Bern</LI>
           </Editorial.UL>
-
-          <P>
-            Detaillierte Rolle bei Republik...
-          </P>
 
           <H3>Wie bewerben?</H3>
           <P style={{ marginBottom: 10 }}>
@@ -181,7 +179,6 @@ export default compose(
               ].filter(d => d.description)
             }))}
             t={t} />
-          <P>Wir freuen uns auf deine Bewerbung.</P>
           <br />
           <br />
           <Anchor id='community'>


### PR DESCRIPTION
This Pull Request contains an initial version for a new job opening and also adds a link to jobs page in footer.

![localhost_3010_jobs (2)](https://user-images.githubusercontent.com/331800/61203921-0fdac900-a6ec-11e9-8db1-5a06b221c128.png)

based on [Redaktorin mit Fokus Inland und Politik 60%-80%](https://docs.google.com/document/d/10BN3-o20XJ8NN8aZNWEUm6U_plE7SO-VFuiTUcwcNjc/edit?usp=sharing)