### PR TITLE
VotePage: move results behind isEditor flag until publication day

### DIFF
--- a/components/Vote/201907/VotePage.js
+++ b/components/Vote/201907/VotePage.js
@@ -7,6 +7,7 @@ import Frame from '../../Frame'
 import { DiscussionIconLinkWithoutEnhancer } from '../../Discussion/IconLink'
 import { Link } from '../../../lib/routes'
 import SignIn from '../../Auth/SignIn'
+import { withEditor } from '../../Auth/checkRoles'
 import Collapsible from '../Collapsible'
 import Voting from '../Voting'
 import {
@@ -86,7 +87,7 @@ class VotePage extends Component {
   }
 
   render () {
-    const { vt, data } = this.props
+    const { vt, data, isEditor } = this.props
 
     const meta = {
       title: vt('vote/201907/page/title'),
@@ -127,7 +128,7 @@ class VotePage extends Component {
             .map(d => now > new Date(d.endDate))
             .every(Boolean)
 
-          const hasResults = votings
+          const hasResults = isEditor && votings
             .map(d => d.result)
             .every(Boolean)
 
@@ -164,15 +165,15 @@ class VotePage extends Component {
           return (
             <Fragment>
               {hasResults && <Fragment>
-                <Title>{ vt('vote/result/title') }</Title>
-                <Body dangerousHTML={vt('vote/result/lead')} />
+                <Title>{ vt('vote/201907/result/title') }</Title>
+                <Body dangerousHTML={vt('vote/201907/result/lead')} />
                 <VoteResult
                   votings={VOTINGS.map(({ id, slug }) => ({
                     id,
                     data: data[slug]
                   }))}
                 />
-                <Body dangerousHTML={vt('vote/result/after')} />
+                <Body dangerousHTML={vt('vote/201907/result/after')} />
                 <div style={{ height: 80 }} />
               </Fragment>}
               {hasEnded && !hasResults && (
@@ -185,6 +186,7 @@ class VotePage extends Component {
                 </div>
               )}
               <Fragment>
+                <a {...styles.anchor} id='budget' />
                 <Title>
                   <RawHtml
                     dangerouslySetInnerHTML={{
@@ -325,5 +327,6 @@ const query = gql`
 
 export default compose(
   voteT,
+  withEditor,
   graphql(query)
 )(VotePage)

--- a/components/Vote/translations-vote.json
+++ b/components/Vote/translations-vote.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-07-15T11:23:17.091Z",
+  "updated": "2019-07-15T11:33:16.106Z",
   "title": "live",
   "data": [
     {
@@ -667,7 +667,7 @@
       "value": "Danke an alle, die sich am demokratischen Experiment beteiligt haben."
     },
     {
-      "key": "Willkommen zu den Resultaten der Urabstimmung von Project R. Die Abstimmungen fanden vom 4. bis zum 14.&nbsp;Juli 2019 statt. Die Gesamtstimmbeteiligung betrug 14,2&nbsp;%. Eingeladen waren alle Verlegerinnen und Verleger der «Republik», die 16’236 Mitglieder der Project R Genossenschaft. 2305 von Ihnen haben teilgenommen, herzlichen Dank!",
+      "key": "vote/result/title",
       "value": "So haben Sie entschieden"
     },
     {

--- a/components/Vote/translations-vote.json
+++ b/components/Vote/translations-vote.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-07-15T10:31:58.712Z",
+  "updated": "2019-07-15T11:23:17.091Z",
   "title": "live",
   "data": [
     {
@@ -8,7 +8,7 @@
     },
     {
       "key": "vote/201907/result/lead",
-      "value": "Willkommen zu den Resultaten der ersten Urabstimmung von Project R. Die Abstimmungen fanden vom 4. bis zum 14.&nbsp;Juli 2019 statt. Die Gesamtstimmbeteiligung betrug 14,2&nbsp;%. Eingeladen waren alle Verlegerinnen und Verleger der «Republik», die 16’236 Mitglieder der Project R Genossenschaft. 2305 von Ihnen haben teilgenommen, herzlichen Dank!"
+      "value": "Willkommen zu den Resultaten der Urabstimmung von Project R. Die Abstimmung fand vom 4. bis zum 14.&nbsp;Juli 2019 statt. Die Gesamtstimmbeteiligung betrug 14,2&nbsp;%. Eingeladen waren alle Verlegerinnen und Verleger der «Republik», die 16’236 Mitglieder der Project R Genossenschaft. 2305 von Ihnen haben teilgenommen, herzlichen Dank!"
     },
     {
       "key": "vote/201907/result/after",

--- a/components/Vote/translations-vote.json
+++ b/components/Vote/translations-vote.json
@@ -1,7 +1,19 @@
 {
-  "updated": "2019-07-04T08:21:01.264Z",
+  "updated": "2019-07-15T10:31:58.712Z",
   "title": "live",
   "data": [
+    {
+      "key": "vote/201907/result/title",
+      "value": "So haben Sie entschieden"
+    },
+    {
+      "key": "vote/201907/result/lead",
+      "value": "Willkommen zu den Resultaten der ersten Urabstimmung von Project R. Die Abstimmungen fanden vom 4. bis zum 14.&nbsp;Juli 2019 statt. Die Gesamtstimmbeteiligung betrug 14,2&nbsp;%. Eingeladen waren alle Verlegerinnen und Verleger der «Republik», die 16’236 Mitglieder der Project R Genossenschaft. 2305 von Ihnen haben teilgenommen, herzlichen Dank!"
+    },
+    {
+      "key": "vote/201907/result/after",
+      "value": "Vielen Dank für Ihr Vertrauen, Ihr Engagement, <a href=\"/vote/juli19/diskutieren\">Ihre Fragen und Ihre Kritik</a>. Lesen Sie zu den Resultaten auch unseren <a href=\"https://project-r.construction/newsletter/2018-10-31-resultate-urabstimmung-umfrage\">Newsletter</a>."
+    },
     {
       "key": "info/201907/title",
       "value": "Herzlich willkommen auf unserer Abstimmungsplattform!"
@@ -655,7 +667,7 @@
       "value": "Danke an alle, die sich am demokratischen Experiment beteiligt haben."
     },
     {
-      "key": "vote/result/title",
+      "key": "Willkommen zu den Resultaten der Urabstimmung von Project R. Die Abstimmungen fanden vom 4. bis zum 14.&nbsp;Juli 2019 statt. Die Gesamtstimmbeteiligung betrug 14,2&nbsp;%. Eingeladen waren alle Verlegerinnen und Verleger der «Republik», die 16’236 Mitglieder der Project R Genossenschaft. 2305 von Ihnen haben teilgenommen, herzlichen Dank!",
       "value": "So haben Sie entschieden"
     },
     {


### PR DESCRIPTION
We'd like to be able to preview the results section on prod internally before we actually publish. So I'm moving results behind the `isEditor` flag for now and will remove that code on Wednesday.

Plus preliminary text copy and an anchor for deeplinking the budget.