### PR TITLE
active discussions with highlight data query for new front

### DIFF
--- a/components/Discussion/Front.js
+++ b/components/Discussion/Front.js
@@ -1,0 +1,160 @@
+import React from 'react'
+import { compose, graphql } from 'react-apollo'
+import gql from 'graphql-tag'
+
+import { Loader } from '@project-r/styleguide'
+
+const query = gql`
+query getActiveDiscussions($lastDays: Int!, $highlightId: ID) {
+  highlight: comments(first: 1, focusId: $highlightId) {
+    id
+    nodes {
+      id
+      displayAuthor {
+        id
+        ...AuthorMetaData
+      }
+      discussion {
+        id
+        ...DiscussionMetaData
+        comments(first: 0) {
+          totalCount
+        }
+      }
+    }
+  }
+  activeDiscussions(lastDays: $lastDays) {
+    discussion {
+      id
+      ...DiscussionMetaData
+      comments(first: 2) {
+        totalCount
+        nodes {
+          id
+          preview(length: 240) {
+            string
+            more
+          }
+          displayAuthor {
+            id
+            ...AuthorMetaData
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment AuthorMetaData on DisplayUser {
+  id
+  name
+  slug
+  credential {
+    description
+    verified
+  }
+  profilePicture
+}
+
+fragment DiscussionMetaData on Discussion {
+  id
+  title
+  path
+  closed
+  document {
+    id
+    meta {
+      title
+      path
+      template
+      ownDiscussion {
+        id
+        closed
+      }
+    }
+  }
+}
+`
+
+const DiscussionFront = ({ data, highlight }) => {
+  if (data.loading || data.error) {
+    return <Loader loading={data.loading} error={data.error} />
+  }
+
+  // check that requested focus id was returned
+  const maybeHighlightComment = data.highlight.nodes[0]
+  const hasHighlight = maybeHighlightComment && maybeHighlightComment.id === highlight.id
+
+  let discussions = data.activeDiscussions.map(a => a.discussion)
+  if (hasHighlight) {
+    const highlightComment = {
+      ...maybeHighlightComment,
+      highlight: highlight.quote,
+      discussion: undefined
+    }
+    // ensure first discussion is the one with the highlight
+    let highlightDiscussion = discussions.find(d => d.id === maybeHighlightComment.discussion.id)
+    if (highlightDiscussion) {
+      discussions.splice(discussions.indexOf(highlightDiscussion), 1)
+    } else {
+      highlightDiscussion = maybeHighlightComment.discussion
+    }
+    discussions.unshift({
+      ...highlightDiscussion,
+      comments: {
+        totalCount: highlightDiscussion.comments.totalCount,
+        nodes: [highlightComment].concat(highlightDiscussion.comments.nodes || [])
+      }
+    })
+  }
+
+  const seenNames = new Set()
+  let remainingComments = 5
+
+  discussions = discussions.reduce(
+    (all, discussion, i) => {
+      let remainingCommentsPerDiscussion = i === 0 ? 2 : 1
+      // get comments from never before seen names
+      // - max 5 in total
+      // - max 2 for first discussion, max 1 for the rest
+      const nodes = discussion.comments.nodes.filter(comment => {
+        if (!remainingComments || !remainingCommentsPerDiscussion || seenNames.has(comment.displayAuthor.name)) {
+          return false
+        }
+        seenNames.add(comment.displayAuthor.name)
+        remainingComments -= 1
+        remainingCommentsPerDiscussion -= 1
+        return true
+      })
+
+      if (nodes.length) {
+        all.push({
+          ...discussion,
+          comments: {
+            ...discussion.comments,
+            nodes
+          }
+        })
+      }
+
+      return all
+    },
+    []
+  )
+
+  return <pre>{JSON.stringify({
+    hasHighlight,
+    discussions
+  }, undefined, 2)}</pre>
+}
+
+export default compose(
+  graphql(query, {
+    options: ({ lastDays, highlight: { id: highlightId } = {} }) => ({
+      variables: {
+        lastDays,
+        highlightId
+      }
+    })
+  })
+)(DiscussionFront)

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -27,6 +27,7 @@ import ArticleDiscussionHeadline from './ArticleDiscussionHeadline'
 import ArticleSearch from './ArticleSearch'
 import LatestComments from './LatestComments'
 import Discussion from '../Discussion/Discussion'
+import DiscussionFront from '../Discussion/Front'
 
 import {
   A,
@@ -217,6 +218,13 @@ class FeedbackPage extends Component {
     return (
       <Frame raw meta={pageMeta}>
         <Center {...styles.container}>
+          {/* tmp example, will be part of front document */}
+          <DiscussionFront
+            lastDays={3}
+            highlight={{
+              id: '50a17ba6-6864-4139-8c04-f53c02e19fe0',
+              quote: 'Gut möglich, dass es bis zu einer klimaneutralen Grossbank einen Generationenwechsel braucht.'
+            }} />
           <div {...styles.intro}>
             <WithMembership render={() => (
               <Interaction.P>


### PR DESCRIPTION
TMP place an advanced active discussion query on `/dialog`. Meant for new front 2.0.

Necessary Optimisations:
- [x] add support for limit in `activeDiscussions` query: https://github.com/orbiting/backends/blob/352d9731163a0d6c77c571ff25885a2c47a43236/packages/discussions/graphql/resolvers/_queries/activeDiscussions.js#L16

Possible Optimisations:
- [ ] move comment selecting logic by distinct author names to backend
- [ ] allow to query highlight comment active discussions? 
 
## Design

### Mobile

![front-dis-mobile](https://user-images.githubusercontent.com/410211/62655838-28dd3f80-b963-11e9-9c43-5b7d12270be2.png)

### Desktop

![front-dis-desktop](https://user-images.githubusercontent.com/410211/62655861-3abee280-b963-11e9-9794-8708e2aa4be0.png)

#### Two Comments of one Discussion

<img width="448" alt="front-dis-desktop-two-comments" src="https://user-images.githubusercontent.com/410211/62655892-48746800-b963-11e9-8db7-e5ca94c412f4.png">

