### PR TITLE
Fix newsletter issue

### DIFF
--- a/lib/utils/mdast.js
+++ b/lib/utils/mdast.js
@@ -9,7 +9,7 @@ export const splitByTitle = content => {
   const splitIndex =
     content.children.findIndex(node => node.identifier === 'TITLE') + 1
   return {
-    title: splitIndex && splitChildren(content, 0, splitIndex),
+    title: splitIndex ? splitChildren(content, 0, splitIndex) : null,
     main: splitChildren(content, splitIndex)
   }
 }


### PR DESCRIPTION
Prevent non-existing title block to be set to `0`, which caused the following bug on titleless content (e.g. newsletter)
<img width="255" alt="Bildschirmfoto 2019-11-14 um 06 22 46" src="https://user-images.githubusercontent.com/3907984/68840935-f3fc2980-06c3-11ea-890f-c46ad783471a.png">
 