### PR TITLE
Remove trackingId, default search first arg to 25, set first to 0 on aggregations

### DIFF
--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -98,7 +98,6 @@ class FeedbackPage extends Component {
     this.state = {
       loading: false,
       isMobile: true,
-      trackingId: undefined,
       searchValue: undefined
     }
 

--- a/components/Feedback/enhancers.js
+++ b/components/Feedback/enhancers.js
@@ -33,7 +33,6 @@ export const getArticleSearchResults = gql`
     $after: String
     $sort: SearchSortInput
     $filters: [SearchGenericFilterInput!]
-    $trackingId: ID
   ) {
     search(
       first: 5
@@ -41,7 +40,6 @@ export const getArticleSearchResults = gql`
       search: $search
       sort: $sort
       filters: $filters
-      trackingId: $trackingId
     ) {
       nodes {
         entity {

--- a/components/Questionnaire/ArticleQuestion.js
+++ b/components/Questionnaire/ArticleQuestion.js
@@ -203,7 +203,6 @@ const query = gql`
     $after: String
     $sort: SearchSortInput
     $filters: [SearchGenericFilterInput!]
-    $trackingId: ID
   ) {
     search(
       first: 5
@@ -211,7 +210,6 @@ const query = gql`
       search: $search
       sort: $sort
       filters: $filters
-      trackingId: $trackingId
     ) {
       nodes {
         entity {

--- a/components/Search/enhancers.js
+++ b/components/Search/enhancers.js
@@ -7,17 +7,10 @@ const getSearchAggregations = gql`
   query getSearchAggregations(
     $searchQuery: String
     $keys: [String!]
-    $trackingId: ID
     $filters: [SearchGenericFilterInput!]
   ) {
-    search(
-      first: 1
-      search: $searchQuery
-      filters: $filters
-      trackingId: $trackingId
-    ) {
+    search(first: 0, search: $searchQuery, filters: $filters) {
       totalCount
-      trackingId
       aggregations(keys: $keys) {
         key
         count
@@ -38,18 +31,15 @@ const getSearchResults = gql`
     $after: String
     $sort: SearchSortInput
     $filters: [SearchGenericFilterInput!]
-    $trackingId: ID
   ) {
     search(
-      first: 100
+      first: 25
       after: $after
       search: $searchQuery
       sort: $sort
       filters: $filters
-      trackingId: $trackingId
     ) {
       totalCount
-      trackingId
       aggregations {
         key
         count
@@ -158,8 +148,7 @@ export const withResults = graphql(getSearchResults, {
       data.fetchMore({
         variables: {
           after,
-          sort: ownProps.sort,
-          trackingId: ownProps.trackingId
+          sort: ownProps.sort
         },
         updateQuery: (previousResult, { fetchMoreResult }) => {
           const nodes = [


### PR DESCRIPTION
* Query search aggregations w/ `first: 0` as there are no nodes required
* Query search results w/ `first: 25` (instead of 100)

Reasoning behind `first: 25`:
* Technical and performance: Querying for 100 documents is costly due to backend discussion counter. Reducing amount of document requested speeds up response time in frontend.
* User experience: 100 results is pretty much. 25 felt in balance with having result in top 10 but still provide a little more "others" (Google, DuckDuckGo return 10 results.) Due to loading less, it feels snappier.

Also stripped `trackingId` which we won't really use any longer.