### PR TITLE
Dark mode for photo series

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ PUBLIKATOR_BASE_URL=http://localhost:3005
 # - usually CDN hostname which is pointing to the assets server + /frontend
 # CDN_FRONTEND_BASE_URL=
 
+# Disable SSR HTML Cache
+# SSR_CACHE=false
+
 CROWDFUNDING=TEST
 CROWDFUNDING_PLEDGE=PRESALE
 CROWDFUNDING_META=PROLONG

--- a/components/ActionBar/Article.js
+++ b/components/ActionBar/Article.js
@@ -73,7 +73,6 @@ class ArticleActionBar extends Component {
           title={title}
           shareOverlayTitle={t('article/share/title')}
           animate={animate}
-          fill={colors.text}
           dossierUrl={dossierUrl}
           onPdfClick={onPdfClick}
           pdfUrl={pdfUrl}

--- a/components/ActionBar/Bookmark.js
+++ b/components/ActionBar/Bookmark.js
@@ -8,7 +8,7 @@ import withT from '../../lib/withT'
 import { styles as iconLinkStyles } from '../IconLink'
 import IconDefault from 'react-icons/lib/md/bookmark-outline'
 import IconBookmarked from 'react-icons/lib/md/bookmark'
-import { colors } from '@project-r/styleguide'
+import { useColorContext } from '@project-r/styleguide'
 import { withRouter } from 'next/router'
 
 import {
@@ -28,6 +28,25 @@ const styles = {
     cursor: 'pointer',
     marginBottom: '-1px'
   })
+}
+
+const BookmarkIcon = ({ error, mutating, bookmarked, small }) => {
+  const [colorScheme] = useColorContext()
+  const Icon = bookmarked ? IconBookmarked : IconDefault
+  const size = small ? 23 : 27
+
+  return (
+    <Icon
+      size={size}
+      fill={
+        error
+          ? colorScheme.error
+          : mutating
+          ? colorScheme.disabled
+          : colorScheme.text
+      }
+    />
+  )
 }
 
 class Bookmark extends Component {
@@ -81,9 +100,7 @@ class Bookmark extends Component {
       return null
     }
     const { mutating, error } = this.state
-    const Icon = bookmarked ? IconBookmarked : IconDefault
     const title = t(`bookmark/title/${bookmarked ? 'bookmarked' : 'default'}`)
-    const size = small ? 23 : 27
 
     return (
       <button
@@ -93,9 +110,11 @@ class Bookmark extends Component {
         title={title}
         onClick={this.toggle}
       >
-        <Icon
-          size={size}
-          fill={error ? colors.error : mutating ? colors.disabled : colors.text}
+        <BookmarkIcon
+          small={small}
+          bookmarked={bookmarked}
+          error={error}
+          mutating={mutating}
         />
       </button>
     )

--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -241,7 +241,6 @@ ActionBar.propTypes = {
 }
 
 ActionBar.defaultProps = {
-  fill: colors.secondary,
   tweet: '',
   emailBody: '',
   emailAttachUrl: true,

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -37,6 +37,7 @@ import { userProgressFragment } from './Progress/api'
 import {
   AudioPlayer,
   Center,
+  ColorContext,
   colors,
   Interaction,
   mediaQueries
@@ -762,7 +763,13 @@ class ArticlePage extends Component {
                     <SSRCachingBoundary
                       cacheKey={`${article.id}${isMember ? ':isMember' : ''}`}
                     >
-                      {() => renderSchema(splitContent.main)}
+                      {() => (
+                        <ColorContext.Provider
+                          value={darkMode && colors.negative}
+                        >
+                          {renderSchema(splitContent.main)}
+                        </ColorContext.Provider>
+                      )}
                     </SSRCachingBoundary>
                   </ProgressComponent>
                 </ArticleGallery>

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -39,7 +39,6 @@ import {
   Center,
   colors,
   Interaction,
-  Editorial,
   mediaQueries
 } from '@project-r/styleguide'
 
@@ -572,6 +571,11 @@ class ArticlePage extends Component {
 
     const series = meta && meta.series
     const episodes = series && series.episodes
+    const darkMode =
+      article &&
+      article.content &&
+      article.content.meta &&
+      article.content.meta.darkMode
 
     const seriesNavButton = showSeriesNav && (
       <SeriesNavButton
@@ -650,6 +654,7 @@ class ArticlePage extends Component {
 
     return (
       <Frame
+        dark={darkMode}
         raw
         // Meta tags for a focus comment are rendered in Discussion/Commments.js
         meta={

--- a/components/Article/Progress/RestoreButton.js
+++ b/components/Article/Progress/RestoreButton.js
@@ -12,7 +12,11 @@ import { swissNumbers } from '../../../lib/utils/format'
 
 import sharedStyles from '../../sharedStyles'
 
-import { ProgressCircle, colors, mediaQueries } from '@project-r/styleguide'
+import {
+  ProgressCircle,
+  mediaQueries,
+  useColorContext
+} from '@project-r/styleguide'
 
 const RADIUS = 16
 const formatPercent = swissNumbers.format('.0%')
@@ -24,10 +28,7 @@ const styles = {
     '@media print': {
       display: 'none'
     },
-    background: '#fff',
-    borderTop: `1px solid ${colors.divider}`,
     cursor: 'pointer',
-    color: colors.text,
     position: 'fixed',
     zIndex: 10,
     bottom: 0,
@@ -40,7 +41,6 @@ const styles = {
     }
   }),
   button: css({
-    backgroundColor: '#fff',
     boxShadow: '0 0 0px 1px rgba(255, 255, 255, .25)',
     display: 'flex',
     flexDirection: 'column',
@@ -87,7 +87,6 @@ const styles = {
     }
   }),
   note: css({
-    color: colors.lightText,
     fontSize: 16,
     [mediaQueries.mUp]: {
       fontSize: 19
@@ -95,41 +94,60 @@ const styles = {
   })
 }
 
-class RestoreButton extends React.Component {
-  render() {
-    const { t, onClick, onClose, opacity, userProgress } = this.props
-
-    const title = t('progress/restore/title', {
-      percent: formatPercent(userProgress.percentage)
+const RestoreButton = ({ t, onClick, onClose, opacity, userProgress }) => {
+  const [colorScheme] = useColorContext()
+  const colors = {
+    container: css({
+      background: colorScheme.containerBg,
+      borderTop: `1px solid ${colorScheme.divider}`,
+      color: colorScheme.text
+    }),
+    button: css({
+      backgroundColor: colorScheme.containerBg
+    }),
+    note: css({
+      color: colorScheme.lightText
     })
-
-    return (
-      <div {...styles.container} style={{ opacity }} onClick={onClick}>
-        <button {...sharedStyles.plainButton} {...styles.button}>
-          <ProgressCircle
-            progress={userProgress.percentage * 100}
-            stroke='#000'
-            strokePlaceholder='#e9e9e9'
-            radius={RADIUS}
-            strokeWidth={3}
-          />
-          <DownIcon {...styles.buttonIcon} fill='#000' />
-        </button>
-        <div {...styles.label}>{title}</div>
-        <div {...styles.note}>
-          {datetime(t, new Date(userProgress.updatedAt), 'progress/restore')}
-        </div>
-        <button
-          {...styles.close}
-          {...sharedStyles.plainButton}
-          onClick={onClose}
-          title={t('progress/restore/close')}
-        >
-          <Close fill='#ccc' />
-        </button>
-      </div>
-    )
   }
+  const title = t('progress/restore/title', {
+    percent: formatPercent(userProgress.percentage)
+  })
+
+  return (
+    <div
+      {...styles.container}
+      {...colors.container}
+      style={{ opacity }}
+      onClick={onClick}
+    >
+      <button
+        {...sharedStyles.plainButton}
+        {...styles.button}
+        {...colors.button}
+      >
+        <ProgressCircle
+          progress={userProgress.percentage * 100}
+          stroke={colorScheme.fill}
+          strokePlaceholder={colorScheme.lightFill}
+          radius={RADIUS}
+          strokeWidth={3}
+        />
+        <DownIcon {...styles.buttonIcon} fill={colorScheme.fill} />
+      </button>
+      <div {...styles.label}>{title}</div>
+      <div {...styles.note} {...colors.note}>
+        {datetime(t, new Date(userProgress.updatedAt), 'progress/restore')}
+      </div>
+      <button
+        {...styles.close}
+        {...sharedStyles.plainButton}
+        onClick={onClose}
+        title={t('progress/restore/close')}
+      >
+        <Close fill='#ccc' />
+      </button>
+    </div>
+  )
 }
 
 RestoreButton.propTypes = {

--- a/components/Frame/index.js
+++ b/components/Frame/index.js
@@ -5,7 +5,8 @@ import {
   RawHtml,
   fontFamilies,
   mediaQueries,
-  colors
+  colors,
+  ColorContext
 } from '@project-r/styleguide'
 import Meta from './Meta'
 import Header from './Header'
@@ -95,58 +96,60 @@ const Index = ({
   pullable,
   dark
 }) => (
-  <div {...(footer || inNativeApp ? styles.bodyGrowerContainer : undefined)}>
-    {/* body growing only needed when rendering a footer */}
-    <div
-      {...(footer || inNativeApp ? styles.bodyGrower : undefined)}
-      {...(!cover ? styles.padHeader : undefined)}
-    >
-      {dark && (
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `html, body { background-color: ${colors.negative.containerBg}; color: ${colors.negative.text}; }`
-          }}
-        />
-      )}
-      {!!meta && <Meta data={meta} />}
-      <Header
-        dark={dark && !inNativeIOSApp}
-        me={me}
-        cover={cover}
-        onPrimaryNavExpandedChange={onPrimaryNavExpandedChange}
-        primaryNavExpanded={primaryNavExpanded}
-        secondaryNav={secondaryNav}
-        showSecondary={showSecondary}
-        formatColor={formatColor}
-        headerAudioPlayer={headerAudioPlayer}
-        pullable={pullable}
-      />
-      <noscript>
-        <Box style={{ padding: 30 }}>
-          <RawHtml
+  <ColorContext.Provider value={dark && colors.negative}>
+    <div {...(footer || inNativeApp ? styles.bodyGrowerContainer : undefined)}>
+      {/* body growing only needed when rendering a footer */}
+      <div
+        {...(footer || inNativeApp ? styles.bodyGrower : undefined)}
+        {...(!cover ? styles.padHeader : undefined)}
+      >
+        {dark && (
+          <style
             dangerouslySetInnerHTML={{
-              __html: t('noscript')
+              __html: `html, body { background-color: ${colors.negative.containerBg}; color: ${colors.negative.text}; }`
             }}
           />
-        </Box>
-      </noscript>
-      {me && me.prolongBeforeDate !== null && (
-        <ProlongBox
-          t={t}
-          prolongBeforeDate={me.prolongBeforeDate}
-          dark={dark}
+        )}
+        {!!meta && <Meta data={meta} />}
+        <Header
+          dark={dark && !inNativeIOSApp}
+          me={me}
+          cover={cover}
+          onPrimaryNavExpandedChange={onPrimaryNavExpandedChange}
+          primaryNavExpanded={primaryNavExpanded}
+          secondaryNav={secondaryNav}
+          showSecondary={showSecondary}
+          formatColor={formatColor}
+          headerAudioPlayer={headerAudioPlayer}
+          pullable={pullable}
         />
-      )}
-      {raw ? (
-        children
-      ) : (
-        <MainContainer>
-          <Content>{children}</Content>
-        </MainContainer>
-      )}
+        <noscript>
+          <Box style={{ padding: 30 }}>
+            <RawHtml
+              dangerouslySetInnerHTML={{
+                __html: t('noscript')
+              }}
+            />
+          </Box>
+        </noscript>
+        {me && me.prolongBeforeDate !== null && (
+          <ProlongBox
+            t={t}
+            prolongBeforeDate={me.prolongBeforeDate}
+            dark={dark}
+          />
+        )}
+        {raw ? (
+          children
+        ) : (
+          <MainContainer>
+            <Content>{children}</Content>
+          </MainContainer>
+        )}
+      </div>
+      {!inNativeApp && footer && <Footer />}
     </div>
-    {!inNativeApp && footer && <Footer />}
-  </div>
+  </ColorContext.Provider>
 )
 
 export default compose(

--- a/components/IconLink.js
+++ b/components/IconLink.js
@@ -2,7 +2,7 @@ import React, { useState, useRef, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { css } from 'glamor'
 
-import { mediaQueries, colors } from '@project-r/styleguide'
+import { mediaQueries, colors, useColorContext } from '@project-r/styleguide'
 
 import AudioIcon from 'react-icons/lib/md/volume-up'
 import ChartIcon from './Icons/Chart'
@@ -156,9 +156,11 @@ const IconLink = ({
   onClick,
   stacked
 }) => {
+  const [colorScheme] = useColorContext()
   const Icon = ICONS[icon]
   const [shouldAnimate, setShouldAnimate] = useState(false)
   const ref = useRef()
+  const computedFill = fill || colorScheme.text
 
   useEffect(() => {
     if (
@@ -201,15 +203,15 @@ const IconLink = ({
           <span {...styles.solid} style={{ width: size, height: size }} />
         )}
         <Icon
-          fill={fill}
+          fill={computedFill}
           size={size}
           {...(shouldAnimate &&
             css({
               position: 'relative',
               animation: `${css.keyframes({
-                '0%': { fill: fill || colors.text },
+                '0%': { fill: computedFill },
                 '33%': { fill: colors.primary },
-                '100%': { fill: fill || colors.text }
+                '100%': { fill: computedFill }
               })} 2.5s cubic-bezier(0.6, 0, 0.6, 1) alternate`
             }))}
         />

--- a/components/SSRCachingBoundary/index.js
+++ b/components/SSRCachingBoundary/index.js
@@ -9,13 +9,15 @@ if (!process.browser) {
     max: 1000 * 1000 * 200, // 200mb
     length: d => d.length
   })
-
+  const enabled = process.env.SSR_CACHE !== 'false'
   getHtml = (key, children) => {
-    if (cache.has(key)) {
+    if (cache.has(key) && enabled) {
       return cache.get(key)
     }
     const html = ReactDOMServer.renderToStaticMarkup(children())
-    cache.set(key, html)
+    if (enabled) {
+      cache.set(key, html)
+    }
     return html
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2048,9 +2048,9 @@
       }
     },
     "@project-r/styleguide": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-8.20.0.tgz",
-      "integrity": "sha512-uV9Q4XnFLUD5GcVqDgawDTdJhf7liuEcu8h2QtkKRCrpq2wzbxQN8ffOz3quaZorkFwBF46UQsgHEB3s0u/FMQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-8.21.0.tgz",
+      "integrity": "sha512-Nt5qEfBijpwXGby1A08bWwdrehX5+t/ZMh9Tt0LP4pGVi41lSltCZRmNYDWSeiIuvIN1G5fMBniCiAmX6ehzaw==",
       "requires": {
         "react-icons": "^2.2.7"
       }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^9.1.6",
-    "@project-r/styleguide": "^8.20.0",
+    "@project-r/styleguide": "^8.21.0",
     "@use-it/event-listener": "^0.1.3",
     "apollo-cache-inmemory": "^1.6.3",
     "apollo-client": "^2.6.4",


### PR DESCRIPTION
- get color mode from article metadata
- use React context to provide correct color scheme
- add color customisation support for elements such as reading position footer and icons

![Screenshot 2020-01-08 at 16 07 27](https://user-images.githubusercontent.com/3907984/71994383-ed5bdf80-3238-11ea-9fb2-4b437b2e734e.png)
![Screenshot 2020-01-08 at 16 07 39](https://user-images.githubusercontent.com/3907984/71994385-ed5bdf80-3238-11ea-83cd-d9805e6439a7.png)
![Screenshot 2020-01-08 at 16 07 53](https://user-images.githubusercontent.com/3907984/71994386-edf47600-3238-11ea-8e88-05dda94e7f8e.png)
![Screenshot 2020-01-08 at 16 13 29](https://user-images.githubusercontent.com/3907984/71994387-edf47600-3238-11ea-84fb-80716babd397.png)
