### PR TITLE
Dialog Refactor

### DIFF
--- a/components/Discussion/CommentLink.js
+++ b/components/Discussion/CommentLink.js
@@ -7,7 +7,7 @@ import {
   PUBLIC_BASE_URL
 } from '../../lib/constants'
 
-const getFocusRoute = (discussion, commentId) => {
+export const getFocusRoute = (discussion, commentId) => {
   if (discussion.id === GENERAL_FEEDBACK_DISCUSSION_ID) {
     return {
       route: 'discussion',

--- a/components/Discussion/Comments.js
+++ b/components/Discussion/Comments.js
@@ -94,7 +94,7 @@ const Comments = props => {
    * Fetching comment that is in focus.
    */
   const [
-    { currentFocus, focusLoading, focusError },
+    { currentFocusId, focusLoading, focusError },
     setFocusState
   ] = React.useState({})
   const fetchFocus = () => {
@@ -147,8 +147,8 @@ const Comments = props => {
        * To make sure we don't run 'focusSelector()' multiple times, we store
        * the focused comment in the component state.
        */
-      if (currentFocus !== focus) {
-        setFocusState(p => ({ ...p, currentFocus: focus }))
+      if (currentFocusId !== focus.id) {
+        setFocusState(p => ({ ...p, currentFocusId: focus.id }))
 
         /*
          * Wrap 'focusSelector()' in a timeout to work around a bug. See

--- a/components/Discussion/IconLink.js
+++ b/components/Discussion/IconLink.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import { css } from 'glamor'
 
 import Link from '../Link/Href'
@@ -31,6 +31,29 @@ const styles = {
   })
 }
 
+const IconWithCount = ({ count, small }) => {
+  const size = small ? 22 : 24
+  const fontSize = small ? '15px' : undefined
+  const lineHeight = small ? '20px' : undefined
+
+  return (
+    <>
+      <span {...styles.icon}>
+        <Icon size={size} fill={colors.primary} />
+      </span>
+      {count > 0 && (
+        <span
+          {...iconLinkStyles.text}
+          {...styles.text}
+          style={{ fontSize, lineHeight }}
+        >
+          {count}
+        </span>
+      )}
+    </>
+  )
+}
+
 class IconLink extends Component {
   render() {
     const {
@@ -42,30 +65,10 @@ class IconLink extends Component {
       style,
       small
     } = this.props
-    const size = small ? 22 : 24
-    const fontSize = small ? '15px' : undefined
-    const lineHeight = small ? '20px' : undefined
     const patchedStyle = {
       marginLeft: small ? 0 : 20,
       ...style
     }
-
-    const content = (
-      <Fragment>
-        <span {...styles.icon}>
-          <Icon size={size} fill={colors.primary} />
-        </span>
-        {discussionCommentsCount > 0 && (
-          <span
-            {...iconLinkStyles.text}
-            {...styles.text}
-            style={{ fontSize, lineHeight }}
-          >
-            {discussionCommentsCount}
-          </span>
-        )}
-      </Fragment>
-    )
 
     if (discussionPage) {
       return (
@@ -79,7 +82,7 @@ class IconLink extends Component {
           {...styles.a}
           style={patchedStyle}
         >
-          {content}
+          <IconWithCount small={small} count={discussionCommentsCount} />
         </a>
       )
     }
@@ -87,7 +90,7 @@ class IconLink extends Component {
     return (
       <Link href={path} query={query} passHref>
         <a {...iconLinkStyles.link} {...styles.a} style={patchedStyle}>
-          {content}
+          <IconWithCount small={small} count={discussionCommentsCount} />
         </a>
       </Link>
     )

--- a/components/Feedback/ActiveDiscussions.js
+++ b/components/Feedback/ActiveDiscussions.js
@@ -84,13 +84,11 @@ class ActiveDiscussions extends Component {
     const activeDiscussions =
       data &&
       data.activeDiscussions &&
-      data.activeDiscussions
-        .filter(
-          activeDiscussion =>
-            activeDiscussion.discussion.id !== ignoreDiscussionId &&
-            !activeDiscussion.discussion.closed
-        )
-        .slice(0, 10)
+      data.activeDiscussions.filter(
+        activeDiscussion =>
+          activeDiscussion.discussion.id !== ignoreDiscussionId &&
+          !activeDiscussion.discussion.closed
+      )
 
     return (
       <Loader
@@ -129,8 +127,7 @@ class ActiveDiscussions extends Component {
 
 ActiveDiscussions.propTypes = {
   discussionId: PropTypes.string,
-  ignoreDiscussionId: PropTypes.string,
-  onChange: PropTypes.func
+  ignoreDiscussionId: PropTypes.string
 }
 
 export default compose(withActiveDiscussions)(ActiveDiscussions)

--- a/components/Feedback/ActiveDiscussions.js
+++ b/components/Feedback/ActiveDiscussions.js
@@ -59,6 +59,8 @@ const ActiveDiscussionItem = ({
   onClick,
   label,
   selected,
+  count,
+  countIcon,
   path
 }) => (
   <DiscussionLink discussion={discussion} passHref>
@@ -71,6 +73,8 @@ const ActiveDiscussionItem = ({
         newPage={!!path}
         selected={selected}
         iconSize={24}
+        count={count}
+        countIcon={countIcon}
         Wrapper={Interaction.P}
       />
     </a>
@@ -98,7 +102,7 @@ class ActiveDiscussions extends Component {
           return (
             <div>
               {activeDiscussions &&
-                activeDiscussions.map(activeDiscussion => {
+                activeDiscussions.map((activeDiscussion, i) => {
                   const discussion = activeDiscussion.discussion
                   const selected =
                     discussionId && discussionId === discussion.id
@@ -114,6 +118,8 @@ class ActiveDiscussions extends Component {
                       selected={selected}
                       discussion={discussion}
                       path={path}
+                      count={activeDiscussion.count}
+                      countIcon={i === 0}
                     />
                   )
                 })}

--- a/components/Feedback/ActiveDiscussions.js
+++ b/components/Feedback/ActiveDiscussions.js
@@ -70,7 +70,6 @@ const ActiveDiscussionItem = ({
     >
       <ArticleItem
         title={label}
-        newPage={!!path}
         selected={selected}
         iconSize={24}
         count={count}

--- a/components/Feedback/ArticleItem.js
+++ b/components/Feedback/ArticleItem.js
@@ -7,16 +7,22 @@ import NewPage from 'react-icons/lib/md/open-in-new'
 
 import { Interaction, colors } from '@project-r/styleguide'
 
+import Icon from '../Icons/Discussion'
+
 const { P } = Interaction
 
 const styles = {
   container: css({
     display: 'inline-block',
     position: 'relative',
-    maxWidth: '100%',
+    width: '100%',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis'
+  }),
+  count: css({
+    fontFeatureSettings: '"tnum" 1, "kern" 1',
+    color: colors.primary
   }),
   icon: css({
     position: 'absolute',
@@ -39,17 +45,31 @@ const ArticleItem = ({
   newPage,
   selected,
   iconSize,
+  count,
+  countIcon,
   Wrapper = DefaultWrapper
 }) => (
   <Wrapper
     {...styles.container}
     style={{
-      paddingRight: newPage && iconSize ? `${iconSize * 1.5}px` : undefined
+      paddingRight:
+        countIcon && count
+          ? 30
+          : 0 + count
+          ? 5 + String(count).length * 15
+          : 0 + newPage && iconSize
+          ? iconSize * 1.5
+          : 0
     }}
   >
     <span style={{ color: selected ? colors.primary : undefined }}>
       {title}
     </span>
+    {count && (
+      <span {...styles.icon} {...styles.count}>
+        {countIcon && <Icon size={24} fill={colors.primary} />} {count}
+      </span>
+    )}
     {newPage && (
       <span {...styles.icon} title={t('feedback/articleItem/newPage/title')}>
         <NewPage size={iconSize} fill={colors.disabled} />

--- a/components/Feedback/ArticleItem.js
+++ b/components/Feedback/ArticleItem.js
@@ -3,8 +3,6 @@ import { css } from 'glamor'
 
 import withT from '../../lib/withT'
 
-import NewPage from 'react-icons/lib/md/open-in-new'
-
 import { Interaction, colors } from '@project-r/styleguide'
 
 import Icon from '../Icons/Discussion'
@@ -42,7 +40,6 @@ const DefaultWrapper = ({ children, ...props }) => (
 const ArticleItem = ({
   t,
   title,
-  newPage,
   selected,
   iconSize,
   count,
@@ -54,11 +51,9 @@ const ArticleItem = ({
     style={{
       paddingRight:
         countIcon && count
-          ? 30
+          ? iconSize + 6
           : 0 + count
           ? 5 + String(count).length * 15
-          : 0 + newPage && iconSize
-          ? iconSize * 1.5
           : 0
     }}
   >
@@ -67,12 +62,7 @@ const ArticleItem = ({
     </span>
     {count && (
       <span {...styles.icon} {...styles.count}>
-        {countIcon && <Icon size={24} fill={colors.primary} />} {count}
-      </span>
-    )}
-    {newPage && (
-      <span {...styles.icon} title={t('feedback/articleItem/newPage/title')}>
-        <NewPage size={iconSize} fill={colors.disabled} />
+        {countIcon && <Icon size={iconSize} fill={colors.primary} />} {count}
       </span>
     )}
   </Wrapper>

--- a/components/Feedback/ArticleSearch.js
+++ b/components/Feedback/ArticleSearch.js
@@ -153,7 +153,6 @@ class ArticleSearch extends Component {
                 text: (
                   <ArticleItem
                     title={meta.title}
-                    newPage={!!linkedDiscussion}
                     iconSize={24}
                     Wrapper={Interaction.P}
                   />

--- a/components/Feedback/DiscussionTitle.js
+++ b/components/Feedback/DiscussionTitle.js
@@ -25,24 +25,9 @@ const ArticleDiscussionHeadline = ({ t, discussionId, meta, documentMeta }) => {
 
   return (
     <>
-      <WithMembership
-        render={() => (
-          <Fragment>
-            {t.elements('feedback/autoArticle/selected/headline', {
-              link: ArticleLink
-            })}
-          </Fragment>
-        )}
-      />
-      <WithoutMembership
-        render={() => (
-          <Fragment>
-            {t.elements('feedback/autoArticle/selected/headline', {
-              link: <Fragment>{inQuotes(articleMeta.title)}</Fragment>
-            })}
-          </Fragment>
-        )}
-      />
+      {t.elements('feedback/autoArticle/selected/headline', {
+        link: ArticleLink
+      })}
     </>
   )
 }

--- a/components/Feedback/DiscussionTitle.js
+++ b/components/Feedback/DiscussionTitle.js
@@ -24,7 +24,7 @@ const ArticleDiscussionHeadline = ({ t, discussionId, meta, documentMeta }) => {
   )
 
   return (
-    <Interaction.H3>
+    <>
       <WithMembership
         render={() => (
           <Fragment>
@@ -43,7 +43,7 @@ const ArticleDiscussionHeadline = ({ t, discussionId, meta, documentMeta }) => {
           </Fragment>
         )}
       />
-    </Interaction.H3>
+    </>
   )
 }
 

--- a/components/Feedback/LatestComments.js
+++ b/components/Feedback/LatestComments.js
@@ -62,8 +62,6 @@ const LatestComments = ({ t, data, fetchMore }) => {
                   discussion.document &&
                   discussion.document.meta) ||
                 {}
-              const isGeneral = discussion.id === GENERAL_FEEDBACK_DISCUSSION_ID
-              const newPage = !isGeneral && meta.template === 'discussion'
 
               return (
                 <CommentTeaser
@@ -78,7 +76,6 @@ const LatestComments = ({ t, data, fetchMore }) => {
                   parentIds={parentIds}
                   Link={CommentLink}
                   discussion={discussion}
-                  newPage={newPage}
                 />
               )
             })}

--- a/components/Feedback/LatestComments.js
+++ b/components/Feedback/LatestComments.js
@@ -3,6 +3,7 @@ import { compose } from 'react-apollo'
 import { css } from 'glamor'
 import { withComments } from './enhancers'
 import withT from '../../lib/withT'
+import InfiniteScroll from '../Frame/InfiniteScroll'
 
 import { GENERAL_FEEDBACK_DISCUSSION_ID } from '../../lib/constants'
 
@@ -36,59 +37,52 @@ const LatestComments = ({ t, data, fetchMore }) => {
       error={data.error}
       render={() => {
         const { comments } = data
-        const { pageInfo } = comments
+        const { pageInfo, totalCount } = comments
         return (
-          <div>
-            {comments &&
-              comments.nodes.map(node => {
-                const {
-                  id,
-                  discussion,
-                  preview,
-                  displayAuthor,
-                  createdAt,
-                  updatedAt,
-                  tags,
-                  parentIds
-                } = node
-                const meta =
-                  (discussion &&
-                    discussion.document &&
-                    discussion.document.meta) ||
-                  {}
-                const isGeneral =
-                  discussion.id === GENERAL_FEEDBACK_DISCUSSION_ID
-                const newPage = !isGeneral && meta.template === 'discussion'
+          <InfiniteScroll
+            hasMore={pageInfo.hasNextPage}
+            loadMore={() => fetchMore({ after: pageInfo.endCursor })}
+            totalCount={totalCount}
+            currentCount={comments.nodes.length}
+            loadMoreKey={'feed/loadMore/comments'}
+          >
+            {comments.nodes.map(node => {
+              const {
+                id,
+                discussion,
+                preview,
+                displayAuthor,
+                createdAt,
+                updatedAt,
+                tags,
+                parentIds
+              } = node
+              const meta =
+                (discussion &&
+                  discussion.document &&
+                  discussion.document.meta) ||
+                {}
+              const isGeneral = discussion.id === GENERAL_FEEDBACK_DISCUSSION_ID
+              const newPage = !isGeneral && meta.template === 'discussion'
 
-                return (
-                  <CommentTeaser
-                    key={id}
-                    id={id}
-                    t={t}
-                    displayAuthor={displayAuthor}
-                    preview={preview}
-                    createdAt={createdAt}
-                    updatedAt={updatedAt}
-                    tags={tags}
-                    parentIds={parentIds}
-                    Link={CommentLink}
-                    discussion={discussion}
-                    newPage={newPage}
-                  />
-                )
-              })}
-            {pageInfo.hasNextPage && (
-              <button
-                {...styles.button}
-                {...linkRule}
-                onClick={() => {
-                  fetchMore({ after: pageInfo.endCursor })
-                }}
-              >
-                {t('feedback/fetchMore')}
-              </button>
-            )}
-          </div>
+              return (
+                <CommentTeaser
+                  key={id}
+                  id={id}
+                  t={t}
+                  displayAuthor={displayAuthor}
+                  preview={preview}
+                  createdAt={createdAt}
+                  updatedAt={updatedAt}
+                  tags={tags}
+                  parentIds={parentIds}
+                  Link={CommentLink}
+                  discussion={discussion}
+                  newPage={newPage}
+                />
+              )
+            })}
+          </InfiniteScroll>
         )
       }}
     />

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -20,7 +20,7 @@ import { HEADER_HEIGHT, HEADER_HEIGHT_MOBILE } from '../constants'
 import Frame from '../Frame'
 
 import ActiveDiscussions from './ActiveDiscussions'
-import ArticleDiscussionHeadline from './ArticleDiscussionHeadline'
+import DiscussionTitle from './DiscussionTitle'
 import ArticleSearch from './ArticleSearch'
 import LatestComments from './LatestComments'
 import Discussion from '../Discussion/Discussion'
@@ -32,7 +32,8 @@ import {
   Interaction,
   Editorial,
   Label,
-  mediaQueries
+  mediaQueries,
+  colors
 } from '@project-r/styleguide'
 import FontSizeSync from '../FontSize/Sync'
 import FontSizeAdjust from '../FontSize/Adjust'
@@ -60,37 +61,12 @@ const styles = {
     marginBottom: 20,
     position: 'relative'
   }),
-  tabButton: css({
-    flexGrow: 1,
-    width: '100%',
-    [tabMq]: {
-      width: '50%'
-    }
-  }),
-  tabButton2: css({
-    marginTop: -1,
-    [tabMq]: {
-      marginTop: 0,
-      marginLeft: -1
-    }
-  }),
-  articleHeadline: css({
-    margin: '30px 0 20px 0',
-    [mediaQueries.mUp]: {
-      margin: '40px 0 20px 0'
-    }
-  }),
-  activeDiscussions: css({
+  h3: css({
     marginTop: 30,
     [mediaQueries.mUp]: {
-      marginTop: 40
-    }
-  }),
-  selectedHeadline: css({
-    margin: '40px 0 26px 0',
-    [mediaQueries.mUp]: {
-      margin: '60px 0 30px 0'
-    }
+      marginTop: 60
+    },
+    marginBottom: 20
   })
 }
 
@@ -100,7 +76,6 @@ class FeedbackPage extends Component {
 
     this.state = {
       loading: false,
-      isMobile: true,
       searchValue: undefined
     }
 
@@ -134,76 +109,6 @@ class FeedbackPage extends Component {
         searchValue: null
       })
     }
-
-    this.handleResize = () => {
-      const isMobile = window.innerWidth < mediaQueries.mBreakPoint
-      if (isMobile !== this.state.isMobile) {
-        this.setState({ isMobile })
-      }
-    }
-
-    this.selectArticleTab = () => {
-      const {
-        router: { query }
-      } = this.props
-      const isSelected = query.t === 'article'
-      Router.pushRoute(
-        'discussion',
-        isSelected ? undefined : { t: 'article' },
-        { shallow: true }
-      )
-    }
-
-    this.selectGeneralTab = () => {
-      const {
-        router: { query }
-      } = this.props
-      const isSelected = query.t === 'general'
-      Router.pushRoute(
-        'discussion',
-        isSelected ? undefined : { t: 'general' },
-        { shallow: true }
-      )
-    }
-
-    this.scrollToArticleDiscussion = () => {
-      const {
-        router: { query }
-      } = this.props
-      if (
-        !query.focus &&
-        this.articleRef &&
-        query.t === 'article' &&
-        query.id
-      ) {
-        const headerHeight =
-          window.innerWidth < mediaQueries.mBreakPoint
-            ? HEADER_HEIGHT_MOBILE
-            : HEADER_HEIGHT
-        setTimeout(() => {
-          const { top } = this.articleRef.getBoundingClientRect()
-          window.scrollTo({
-            top: top - headerHeight - 20,
-            left: 0,
-            behavior: 'smooth'
-          })
-        }, 100)
-      }
-    }
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.handleResize)
-    this.handleResize()
-    this.scrollToArticleDiscussion()
-  }
-
-  componentDidUpdate() {
-    this.scrollToArticleDiscussion()
-  }
-
-  componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize)
   }
 
   render() {
@@ -230,7 +135,7 @@ class FeedbackPage extends Component {
         }
 
     return (
-      <Frame raw meta={pageMeta}>
+      <Frame raw meta={pageMeta} formatColor={colors.primary}>
         <FontSizeSync />
         <Center {...styles.container}>
           <div {...styles.intro}>
@@ -253,62 +158,42 @@ class FeedbackPage extends Component {
                 />
               )}
             />
-            <WithMembership
-              render={() => (
-                <>
-                  <Interaction.H1>{t('feedback/title')}</Interaction.H1>
-                  <br />
-                  <Interaction.P>
-                    {t('feedback/lead')}
-                    {!!tab && (
-                      <>
-                        {' '}
-                        <Link route='discussion' passHref>
-                          <A>{t('feedback/link/overview')}</A>
-                        </Link>
-                      </>
-                    )}
-                    {tab !== 'general' && (
-                      <>
-                        {' '}
-                        <Link
-                          route='discussion'
-                          params={{ t: 'general' }}
-                          passHref
-                        >
-                          <A>{t('feedback/link/general')}</A>
-                        </Link>
-                      </>
-                    )}
-                  </Interaction.P>
-                </>
-              )}
-            />
+            {!tab && (
+              <WithMembership
+                render={() => (
+                  <>
+                    <Interaction.Headline>
+                      {t('feedback/title')}
+                    </Interaction.Headline>
+                    <br />
+                    <Interaction.P>{t('feedback/lead')}</Interaction.P>
+                  </>
+                )}
+              />
+            )}
           </div>
           {!!tab && (
-            <div {...styles.selectedHeadline}>
-              <div
-                style={{
-                  display: 'block',
-                  textAlign: 'right',
-                  marginTop: 3,
-                  float: 'right',
-                  width: 50
-                }}
-              >
-                <FontSizeAdjust t={t} />
-              </div>
-              {tab === 'article' && (
-                <ArticleDiscussionHeadline discussionId={activeDiscussionId} />
-              )}
-              {tab === 'general' && (
-                <Interaction.H3>{t('feedback/general/title')}</Interaction.H3>
-              )}
+            <div style={{ marginBottom: 30 }}>
+              <Editorial.Format color={colors.primary}>
+                <Link route='discussion' passHref>
+                  <a style={{ color: 'inherit', textDecoration: 'none' }}>
+                    {t('feedback/title')}
+                  </a>
+                </Link>
+              </Editorial.Format>
+              <Interaction.H1>
+                {tab === 'article' && (
+                  <DiscussionTitle discussionId={activeDiscussionId} />
+                )}
+                {tab === 'general' && t('feedback/general/title')}
+              </Interaction.H1>
+              <br />
+              <FontSizeAdjust t={t} />
             </div>
           )}
           {!tab && (
             <>
-              <Interaction.H3 style={{ marginTop: 10, marginBottom: 10 }}>
+              <Interaction.H3 {...styles.h3}>
                 {t('marketing/community/title/plain')}
               </Interaction.H3>
               <TestimonialList
@@ -336,19 +221,14 @@ class FeedbackPage extends Component {
                       onChange={this.onChangeFromSearch}
                       onReset={this.onReset}
                     />*/}
-                    <div {...styles.activeDiscussions}>
-                      <Interaction.H3
-                        style={{ display: 'block', marginBottom: 10 }}
-                      >
-                        {t('feedback/activeDiscussions/label')}
-                      </Interaction.H3>
-                      <ActiveDiscussions
-                        discussionId={activeDiscussionId}
-                        onChange={this.onChangeFromActiveDiscussions}
-                        onReset={this.onReset}
-                        ignoreDiscussionId={GENERAL_FEEDBACK_DISCUSSION_ID}
-                      />
-                    </div>
+                    <Interaction.H3 {...styles.h3}>
+                      {t('feedback/activeDiscussions/label')}
+                    </Interaction.H3>
+                    <ActiveDiscussions
+                      discussionId={activeDiscussionId}
+                      first={5}
+                      ignoreDiscussionId={GENERAL_FEEDBACK_DISCUSSION_ID}
+                    />
                   </Fragment>
                 )}
               />
@@ -366,11 +246,9 @@ class FeedbackPage extends Component {
             <WithMembership
               render={() => (
                 <Fragment>
-                  <div {...styles.selectedHeadline}>
-                    <Interaction.H3>
-                      {t('feedback/latestComments/headline')}
-                    </Interaction.H3>
-                  </div>
+                  <Interaction.H3 {...styles.h3}>
+                    {t('feedback/latestComments/headline')}
+                  </Interaction.H3>
                   <LatestComments />
                 </Fragment>
               )}

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -166,10 +166,6 @@ class FeedbackPage extends Component {
       )
     }
 
-    this.setArticleRef = ref => {
-      this.articleRef = ref
-    }
-
     this.scrollToArticleDiscussion = () => {
       const {
         router: { query }
@@ -238,19 +234,16 @@ class FeedbackPage extends Component {
         <FontSizeSync />
         <Center {...styles.container}>
           <div {...styles.intro}>
-            <WithMembership
-              render={() => <Interaction.P>{t('feedback/lead')}</Interaction.P>}
-            />
             <WithoutMembership
               render={() => (
                 <UnauthorizedMessage
                   {...{
                     me,
                     unauthorizedTexts: {
-                      title: t('feedback/unauthorized/title'),
+                      title: t('feedback/title'),
                       description: t.elements('feedback/unauthorized', {
                         buyLink: (
-                          <Link key='pledge' route='pledge'>
+                          <Link key='pledge' route='pledge' passHref>
                             <A>{t('feedback/unauthorized/buyText')}</A>
                           </Link>
                         )
@@ -260,86 +253,59 @@ class FeedbackPage extends Component {
                 />
               )}
             />
+            <WithMembership
+              render={() => (
+                <>
+                  <Interaction.H1>{t('feedback/title')}</Interaction.H1>
+                  <br />
+                  <Interaction.P>
+                    {t('feedback/lead')}
+                    {!!tab && (
+                      <>
+                        {' '}
+                        <Link route='discussion' passHref>
+                          <A>{t('feedback/link/overview')}</A>
+                        </Link>
+                      </>
+                    )}
+                    {tab !== 'general' && (
+                      <>
+                        {' '}
+                        <Link
+                          route='discussion'
+                          params={{ t: 'general' }}
+                          passHref
+                        >
+                          <A>{t('feedback/link/general')}</A>
+                        </Link>
+                      </>
+                    )}
+                  </Interaction.P>
+                </>
+              )}
+            />
           </div>
-          <WithMembership
-            render={() => (
-              <Fragment>
-                <div {...styles.tab}>
-                  <div
-                    {...styles.tabButton}
-                    {...styles.tabButton2}
-                    style={{ zIndex: 1 }}
-                  >
-                    <Button
-                      block
-                      dimmed={tab && tab !== 'article'}
-                      onClick={this.selectArticleTab}
-                    >
-                      {t('feedback/article/button')}
-                    </Button>
-                  </div>
-                  <div
-                    {...styles.tabButton}
-                    {...styles.tabButton2}
-                    style={{
-                      zIndex: tab === 'general' ? 1 : undefined
-                    }}
-                  >
-                    <Button
-                      block
-                      dimmed={tab && tab !== 'general'}
-                      onClick={this.selectGeneralTab}
-                    >
-                      {t('feedback/general/button')}
-                    </Button>
-                  </div>
-                </div>
-                {!GENERAL_FEEDBACK_DISCUSSION_ID && (
-                  <div style={{ color: 'red', marginTop: 20 }}>
-                    GENERAL_FEEDBACK_DISCUSSION_ID is undefined in .env
-                  </div>
-                )}
-              </Fragment>
-            )}
-          />
-          {tab === 'article' && (
-            <Fragment>
-              <WithMembership
-                render={() => (
-                  <Fragment>
-                    <div {...styles.articleHeadline}>
-                      <Interaction.H3>
-                        {t('feedback/article/headline')}
-                      </Interaction.H3>
-                    </div>
-                    <ArticleSearch
-                      value={searchValue}
-                      onChange={this.onChangeFromSearch}
-                      onReset={this.onReset}
-                    />
-                    <div {...styles.activeDiscussions}>
-                      <Label style={{ display: 'block', marginBottom: 10 }}>
-                        {t('feedback/activeDiscussions/label')}
-                      </Label>
-                      <ActiveDiscussions
-                        discussionId={activeDiscussionId}
-                        onChange={this.onChangeFromActiveDiscussions}
-                        onReset={this.onReset}
-                        ignoreDiscussionId={GENERAL_FEEDBACK_DISCUSSION_ID}
-                      />
-                    </div>
-                  </Fragment>
-                )}
-              />
-              <div {...styles.selectedHeadline} ref={this.setArticleRef}>
-                <ArticleDiscussionHeadline discussionId={activeDiscussionId} />
+          {!!tab && (
+            <div {...styles.selectedHeadline}>
+              <div
+                style={{
+                  display: 'block',
+                  textAlign: 'right',
+                  marginTop: 3,
+                  float: 'right',
+                  width: 50
+                }}
+              >
+                <FontSizeAdjust t={t} />
               </div>
-            </Fragment>
+              {tab === 'article' && (
+                <ArticleDiscussionHeadline discussionId={activeDiscussionId} />
+              )}
+              {tab === 'general' && (
+                <Interaction.H3>{t('feedback/general/title')}</Interaction.H3>
+              )}
+            </div>
           )}
-          <FontSizeAdjust
-            t={t}
-            style={{ display: 'block', textAlign: 'right' }}
-          />
           {!tab && (
             <>
               <Interaction.H3 style={{ marginTop: 10, marginBottom: 10 }}>
@@ -356,6 +322,36 @@ class FeedbackPage extends Component {
                   <Editorial.A>{t('marketing/community/link')}</Editorial.A>
                 </Link>
               </div>
+
+              <WithMembership
+                render={() => (
+                  <Fragment>
+                    {/*<div {...styles.articleHeadline}>
+                      <Interaction.H3>
+                        {t('feedback/article/headline')}
+                      </Interaction.H3>
+                    </div>
+                    <ArticleSearch
+                      value={searchValue}
+                      onChange={this.onChangeFromSearch}
+                      onReset={this.onReset}
+                    />*/}
+                    <div {...styles.activeDiscussions}>
+                      <Interaction.H3
+                        style={{ display: 'block', marginBottom: 10 }}
+                      >
+                        {t('feedback/activeDiscussions/label')}
+                      </Interaction.H3>
+                      <ActiveDiscussions
+                        discussionId={activeDiscussionId}
+                        onChange={this.onChangeFromActiveDiscussions}
+                        onReset={this.onReset}
+                        ignoreDiscussionId={GENERAL_FEEDBACK_DISCUSSION_ID}
+                      />
+                    </div>
+                  </Fragment>
+                )}
+              />
             </>
           )}
           {activeDiscussionId && (

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -33,7 +33,8 @@ import {
   Editorial,
   Label,
   mediaQueries,
-  colors
+  colors,
+  InfoBoxListItem
 } from '@project-r/styleguide'
 import FontSizeSync from '../FontSize/Sync'
 import FontSizeAdjust from '../FontSize/Adjust'
@@ -48,18 +49,6 @@ const styles = {
     [mediaQueries.mUp]: {
       padding: '55px 0 120px 0'
     }
-  }),
-  intro: css({
-    marginBottom: 30,
-    [mediaQueries.mUp]: {
-      marginBottom: 40
-    }
-  }),
-  tab: css({
-    display: 'flex',
-    flexWrap: 'wrap',
-    marginBottom: 20,
-    position: 'relative'
   }),
   h3: css({
     marginTop: 30,
@@ -138,40 +127,44 @@ class FeedbackPage extends Component {
       <Frame raw meta={pageMeta} formatColor={colors.primary}>
         <FontSizeSync />
         <Center {...styles.container}>
-          <div {...styles.intro}>
-            <WithoutMembership
-              render={() => (
-                <UnauthorizedMessage
-                  {...{
-                    me,
-                    unauthorizedTexts: {
-                      title: t('feedback/title'),
-                      description: t.elements('feedback/unauthorized', {
-                        buyLink: (
-                          <Link key='pledge' route='pledge' passHref>
-                            <A>{t('feedback/unauthorized/buyText')}</A>
-                          </Link>
-                        )
-                      })
-                    }
-                  }}
-                />
-              )}
-            />
-            {!tab && (
+          {!tab && (
+            <>
+              <Interaction.Headline>{t('feedback/title')}</Interaction.Headline>
+              <br />
               <WithMembership
                 render={() => (
                   <>
-                    <Interaction.Headline>
-                      {t('feedback/title')}
-                    </Interaction.Headline>
-                    <br />
                     <Interaction.P>{t('feedback/lead')}</Interaction.P>
+
+                    <Editorial.UL compact>
+                      <InfoBoxListItem>
+                        <p>
+                          <Link
+                            route='discussion'
+                            params={{ t: 'general' }}
+                            passHref
+                          >
+                            <A>{t('feedback/link/general')}</A>
+                          </Link>
+                        </p>
+                      </InfoBoxListItem>
+                      <InfoBoxListItem>
+                        <p>
+                          <Link
+                            route='format'
+                            params={{ slug: 'debatte' }}
+                            passHref
+                          >
+                            <A>{t('feedback/link/format')}</A>
+                          </Link>
+                        </p>
+                      </InfoBoxListItem>
+                    </Editorial.UL>
                   </>
                 )}
               />
-            )}
-          </div>
+            </>
+          )}
           {!!tab && (
             <div style={{ marginBottom: 30 }}>
               <Editorial.Format color={colors.primary}>
@@ -191,23 +184,32 @@ class FeedbackPage extends Component {
               <FontSizeAdjust t={t} />
             </div>
           )}
+          <WithoutMembership
+            render={() => (
+              <>
+                <UnauthorizedMessage
+                  {...{
+                    me,
+                    unauthorizedTexts: {
+                      title: ' ',
+                      description: t.elements('feedback/unauthorized', {
+                        buyLink: (
+                          <Link key='pledge' route='pledge' passHref>
+                            <A>{t('feedback/unauthorized/buyText')}</A>
+                          </Link>
+                        )
+                      })
+                    }
+                  }}
+                />
+                <br />
+                <br />
+                <br />
+              </>
+            )}
+          />
           {!tab && (
             <>
-              <Interaction.H3 {...styles.h3}>
-                {t('marketing/community/title/plain')}
-              </Interaction.H3>
-              <TestimonialList
-                singleRow
-                minColumns={3}
-                first={5}
-                share={false}
-              />
-              <div style={{ marginTop: 10 }}>
-                <Link route='community' passHref>
-                  <Editorial.A>{t('marketing/community/link')}</Editorial.A>
-                </Link>
-              </div>
-
               <WithMembership
                 render={() => (
                   <Fragment>
@@ -232,6 +234,21 @@ class FeedbackPage extends Component {
                   </Fragment>
                 )}
               />
+
+              <Interaction.H3 {...styles.h3}>
+                {t('marketing/community/title/plain')}
+              </Interaction.H3>
+              <TestimonialList
+                singleRow
+                minColumns={3}
+                first={5}
+                share={false}
+              />
+              <div style={{ marginTop: 10 }}>
+                <Link route='community' passHref>
+                  <A>{t('marketing/community/link')}</A>
+                </Link>
+              </div>
             </>
           )}
           {activeDiscussionId && (

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -164,6 +164,11 @@ class FeedbackPage extends Component {
                 )}
                 {tab === 'general' && t('feedback/general/title')}
               </Interaction.H1>
+              {tab === 'general' && (
+                <Interaction.P style={{ marginTop: 10 }}>
+                  {t('feedback/general/lead')}
+                </Interaction.P>
+              )}
               <br />
               <FontSizeAdjust t={t} />
             </div>

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -135,31 +135,15 @@ class FeedbackPage extends Component {
                 render={() => (
                   <>
                     <Interaction.P>{t('feedback/lead')}</Interaction.P>
-
-                    <Editorial.UL compact>
-                      <InfoBoxListItem>
-                        <p>
-                          <Link
-                            route='discussion'
-                            params={{ t: 'general' }}
-                            passHref
-                          >
-                            <A>{t('feedback/link/general')}</A>
-                          </Link>
-                        </p>
-                      </InfoBoxListItem>
-                      <InfoBoxListItem>
-                        <p>
-                          <Link
-                            route='format'
-                            params={{ slug: 'debatte' }}
-                            passHref
-                          >
-                            <A>{t('feedback/link/format')}</A>
-                          </Link>
-                        </p>
-                      </InfoBoxListItem>
-                    </Editorial.UL>
+                    <Interaction.P style={{ marginTop: 10 }}>
+                      <Link
+                        route='discussion'
+                        params={{ t: 'general' }}
+                        passHref
+                      >
+                        <A>{t('feedback/link/general')}</A>
+                      </Link>
+                    </Interaction.P>
                   </>
                 )}
               />
@@ -210,6 +194,20 @@ class FeedbackPage extends Component {
           />
           {!tab && (
             <>
+              <Interaction.H3 {...styles.h3}>
+                {t('marketing/community/title/plain')}
+              </Interaction.H3>
+              <TestimonialList
+                singleRow
+                minColumns={3}
+                first={5}
+                share={false}
+              />
+              <div style={{ marginTop: 10 }}>
+                <Link route='community' passHref>
+                  <A>{t('marketing/community/link')}</A>
+                </Link>
+              </div>
               <WithMembership
                 render={() => (
                   <Fragment>
@@ -234,21 +232,6 @@ class FeedbackPage extends Component {
                   </Fragment>
                 )}
               />
-
-              <Interaction.H3 {...styles.h3}>
-                {t('marketing/community/title/plain')}
-              </Interaction.H3>
-              <TestimonialList
-                singleRow
-                minColumns={3}
-                first={5}
-                share={false}
-              />
-              <div style={{ marginTop: 10 }}>
-                <Link route='community' passHref>
-                  <A>{t('marketing/community/link')}</A>
-                </Link>
-              </div>
             </>
           )}
           {activeDiscussionId && (

--- a/components/Feedback/enhancers.js
+++ b/components/Feedback/enhancers.js
@@ -2,8 +2,8 @@ import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
 const getActiveDiscussions = gql`
-  query getActiveDiscussions($lastDays: Int!) {
-    activeDiscussions(lastDays: $lastDays) {
+  query getActiveDiscussions($lastDays: Int!, $first: Int) {
+    activeDiscussions(lastDays: $lastDays, first: $first) {
       count
       discussion {
         id
@@ -159,7 +159,8 @@ const getDiscussionDocumentMeta = gql`
 export const withActiveDiscussions = graphql(getActiveDiscussions, {
   options: props => ({
     variables: {
-      lastDays: props.lastDays || 3
+      lastDays: props.lastDays || 3,
+      first: props.first
     }
   })
 })

--- a/components/Frame/InfiniteScroll.js
+++ b/components/Frame/InfiniteScroll.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { A, Spinner } from '@project-r/styleguide'
 import withT from '../../lib/withT'
+import { countFormat } from '../../lib/utils/format'
 import { useInfiniteScroll } from '../../lib/hooks/useInfiniteScroll'
 import ErrorMessage from '../ErrorMessage'
 import { css, merge } from 'glamor'
@@ -46,8 +47,8 @@ const InfiniteScroll = ({
             }}
           >
             {t(loadMoreKey || 'feed/loadMore', {
-              count: currentCount,
-              remaining: totalCount - currentCount
+              count: countFormat(currentCount),
+              remaining: countFormat(totalCount - currentCount)
             })}
           </A>
         )}

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -221,15 +221,15 @@ const Nav = ({
               <NavLink route='feed' active={active} closeHandler={closeHandler}>
                 {t('navbar/feed')}
               </NavLink>
-              <NavLink
-                route='discussion'
-                active={active}
-                closeHandler={closeHandler}
-              >
-                {t('navbar/discussion')}
-              </NavLink>
             </>
           )}
+          <NavLink
+            route='discussion'
+            active={active}
+            closeHandler={closeHandler}
+          >
+            {t('navbar/discussion')}
+          </NavLink>
           <NavLink route='sections' active={active} closeHandler={closeHandler}>
             {t('nav/sections')}
           </NavLink>

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-15T20:01:43.865Z",
+  "updated": "2020-01-15T22:38:19.624Z",
   "title": "live",
   "data": [
     {
@@ -3744,19 +3744,19 @@
     },
     {
       "key": "feedback/lead",
-      "value": "Teilen Sie Ihr Wissen und Ihre Perspektive."
+      "value": "Die Republik ist nur so stark wie Ihre Community. Teilen Sie Ihr Wissen und Ihre Perspektive."
     },
     {
       "key": "feedback/general/title",
       "value": "Allgemeines Feedback"
     },
     {
-      "key": "feedback/link/overview",
-      "value": "Zur Übersicht."
+      "key": "feedback/link/general",
+      "value": "Allgemeines Feedback zur Republik"
     },
     {
-      "key": "feedback/link/general",
-      "value": "Allgemeines Feedback zur Republik."
+      "key": "feedback/link/format",
+      "value": "Kuratierten Debatte"
     },
     {
       "key": "feedback/article/headline",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-15T23:44:52.336Z",
+  "updated": "2020-01-16T08:51:18.369Z",
   "title": "live",
   "data": [
     {
@@ -3756,7 +3756,7 @@
     },
     {
       "key": "feedback/link/format",
-      "value": "Kuratierte Debatte"
+      "value": "Kuratierte Debatten"
     },
     {
       "key": "feedback/article/headline",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-16T12:33:05.191Z",
+  "updated": "2020-01-16T13:00:00.503Z",
   "title": "live",
   "data": [
     {
@@ -3749,6 +3749,10 @@
     {
       "key": "feedback/general/title",
       "value": "Allgemeines Feedback"
+    },
+    {
+      "key": "feedback/general/lead",
+      "value": "Hier können Sie Wünsche, Kritik und Lob an die Adresse der Republik einbringen."
     },
     {
       "key": "feedback/link/general",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-15T22:38:19.624Z",
+  "updated": "2020-01-15T23:44:52.336Z",
   "title": "live",
   "data": [
     {
@@ -3756,7 +3756,7 @@
     },
     {
       "key": "feedback/link/format",
-      "value": "Kuratierten Debatte"
+      "value": "Kuratierte Debatte"
     },
     {
       "key": "feedback/article/headline",
@@ -3785,10 +3785,6 @@
     {
       "key": "feedback/articleItem/newPage/title",
       "value": "Zur Debattenseite"
-    },
-    {
-      "key": "feedback/fetchMore",
-      "value": "Mehr Beiträge"
     },
     {
       "key": "tokenAuthorization/error",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-15T18:00:10.065Z",
+  "updated": "2020-01-15T20:01:43.865Z",
   "title": "live",
   "data": [
     {
@@ -3731,8 +3731,8 @@
       "value": "Dialog"
     },
     {
-      "key": "feedback/unauthorized/title",
-      "value": "Republik-Dialog"
+      "key": "feedback/title",
+      "value": "Dialog"
     },
     {
       "key": "feedback/unauthorized",
@@ -3744,15 +3744,19 @@
     },
     {
       "key": "feedback/lead",
-      "value": "Teilen Sie Ihr Wissen und Ihre Perspektive. Reden wir miteinander über die Republik und ihren Journalismus. Wo möchten Sie mitreden?"
+      "value": "Teilen Sie Ihr Wissen und Ihre Perspektive."
     },
     {
-      "key": "feedback/general/button",
-      "value": "Allgemeines"
+      "key": "feedback/general/title",
+      "value": "Allgemeines Feedback"
     },
     {
-      "key": "feedback/article/button",
-      "value": "Unsere Stücke"
+      "key": "feedback/link/overview",
+      "value": "Zur Übersicht."
+    },
+    {
+      "key": "feedback/link/general",
+      "value": "Allgemeines Feedback zur Republik."
     },
     {
       "key": "feedback/article/headline",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-01-16T08:51:18.369Z",
+  "updated": "2020-01-16T12:33:05.191Z",
   "title": "live",
   "data": [
     {
@@ -3752,11 +3752,7 @@
     },
     {
       "key": "feedback/link/general",
-      "value": "Allgemeines Feedback zur Republik"
-    },
-    {
-      "key": "feedback/link/format",
-      "value": "Kuratierte Debatten"
+      "value": "Ich möchte ein allgemeines Feedback zur Republik abgeben."
     },
     {
       "key": "feedback/article/headline",


### PR DESCRIPTION
Changes
- rm tabs
- move active debates onto initial view
- add a community row to initial view (already on master)
- show comment count in active debates
- add link to curated debates
- green line everywhere
- small dialog tag for navigating back (like article formats)
- infinite scrolling
- link back to article for guests too
- remove focus on reload click

![screencapture-localhost-3010-dialog-2020-01-16-09_16_44](https://user-images.githubusercontent.com/410211/72505846-0835e180-3841-11ea-9936-697bf82d38d4.png)
![screencapture-localhost-3010-dialog-2020-01-16-09_17_05](https://user-images.githubusercontent.com/410211/72505851-09ffa500-3841-11ea-868a-48df3f733e5a.png)
