### PR TITLE
show parent comment teaser in RootCommentOverlay

### DIFF
--- a/components/Discussion/Comments.js
+++ b/components/Discussion/Comments.js
@@ -395,6 +395,10 @@ const Comments = props => {
                 <RootCommentOverlay
                   discussionId={discussion.id}
                   parent={parent}
+                  parentComment={discussion.comments.nodes.find(
+                    c => c.id === parent
+                  )}
+                  discussion={discussion}
                   onClose={() => {
                     const result = getFocusRoute(discussion)
                     return (

--- a/components/Discussion/Discussion.js
+++ b/components/Discussion/Discussion.js
@@ -1,8 +1,13 @@
 import React from 'react'
+import { compose } from 'react-apollo'
 
 import DiscussionCommentComposer from './DiscussionCommentComposer'
 import NotificationOptions from './NotificationOptions'
 import Comments from './Comments'
+import withT from '../../lib/withT'
+import CommentLink from './CommentLink'
+
+import { CommentTeaser } from '@project-r/styleguide'
 
 const DEFAULT_DEPTH = 3
 
@@ -15,7 +20,10 @@ const Discussion = ({
   board,
   parent,
   parentId = null,
-  rootCommentOverlay
+  parentComment,
+  discussion,
+  rootCommentOverlay,
+  t
 }) => {
   /*
    * DiscussionOrder ('DATE' | 'VOTES' | 'REPLIES')
@@ -35,21 +43,38 @@ const Discussion = ({
   }, [setNow])
 
   const depth = board ? 1 : DEFAULT_DEPTH
+  console.log({ rootCommentOverlay, parentComment, parentId, discussion })
 
   return (
     <div data-discussion-id={discussionId}>
+      {rootCommentOverlay && parentComment && (
+        <CommentTeaser
+          key={parentComment.id}
+          id={parentComment.id}
+          t={t}
+          displayAuthor={parentComment.displayAuthor}
+          preview={{ string: parentComment.text }}
+          createdAt={parentComment.createdAt}
+          updatedAt={parentComment.updatedAt}
+          tags={parentComment.tags}
+          parentIds={parentComment.parentIds}
+          discussion={discussion}
+          Link={CommentLink}
+        />
+      )}
+
+      <DiscussionCommentComposer
+        discussionId={discussionId}
+        orderBy={orderBy}
+        focusId={focusId}
+        depth={depth}
+        parentId={parentId}
+        parent={parentComment}
+        now={now}
+      />
+
       {!rootCommentOverlay && (
-        <>
-          <DiscussionCommentComposer
-            discussionId={discussionId}
-            orderBy={orderBy}
-            focusId={focusId}
-            depth={depth}
-            parentId={parentId}
-            now={now}
-          />
-          <NotificationOptions discussionId={discussionId} mute={mute} />
-        </>
+        <NotificationOptions discussionId={discussionId} mute={mute} />
       )}
 
       <div style={{ margin: '20px 0' }}>
@@ -71,4 +96,4 @@ const Discussion = ({
   )
 }
 
-export default Discussion
+export default compose(withT)(Discussion)

--- a/components/Discussion/DiscussionCommentComposer.js
+++ b/components/Discussion/DiscussionCommentComposer.js
@@ -36,7 +36,8 @@ const DiscussionCommentComposer = props => {
     discussionUserCanComment,
     discussionPreferences,
     now,
-    parentId
+    parentId,
+    parent
   } = props
 
   /*
@@ -136,7 +137,7 @@ const DiscussionCommentComposer = props => {
                 autoCredential.description
               )
             }
-            return props.submitComment(null, text, tags).then(
+            return props.submitComment(parent, text, tags).then(
               () => {
                 setActive(false)
                 return { ok: true }

--- a/components/Discussion/RootCommentOverlay.js
+++ b/components/Discussion/RootCommentOverlay.js
@@ -12,7 +12,7 @@ import { compose } from 'react-apollo'
 import { withRouter } from 'next/router'
 
 export const RootCommentOverlay = compose(withRouter)(
-  ({ router, discussionId, parent, onClose }) => {
+  ({ router, discussionId, parent, parentComment, discussion, onClose }) => {
     return (
       <Overlay onClose={onClose}>
         <OverlayToolbar>
@@ -29,6 +29,8 @@ export const RootCommentOverlay = compose(withRouter)(
             discussionId={discussionId}
             focusId={router.query.focus}
             parentId={parent}
+            parentComment={parentComment}
+            discussion={discussion}
             rootCommentOverlay
           />
         </OverlayBody>


### PR DESCRIPTION
Inspired by reddit. What would you think about this approach?

Advantages to showing the discussion from the parent on:
- answers start at level 0, more space
- the discussion about the post feels more like a separate discussion
- no special queries

Disadvantages:
- people might get confused if they submit a reply or a post
- For the sake of demonstration I used `CommentTeaser`, but that's clearly not ideal (no md, top line, link, etc.). So exporting `Comment` from the styleguide or something equivalent would be needed.

![Screenshot from 2020-01-24 16-40-20](https://user-images.githubusercontent.com/3500621/73081669-52196a00-3ec8-11ea-914f-7c67989145e5.png)

Feel free to trash this PR.


