### PR TITLE
fix gallery: don't upscale images

### DIFF
--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -56,8 +56,10 @@ const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
 
       gallery.listen('gettingData', function(index, item) {
         const sizeInfo = imageSizeInfo(item.src)
-        const maxWidth =
+        const maxWidth = Math.min(
+          sizeInfo.width,
           Math.ceil((window.innerWidth * MAX_SPREAD_ZOOM) / 500) * 500
+        )
         const resizeUrl = imageResizeUrl(item.src, maxWidth)
         const aspectRatio = sizeInfo.height / sizeInfo.width
         item.src = resizeUrl


### PR DESCRIPTION
This PR ensures images in the gallery are not upsized compared to the original. On big screens this bug adds significant loadtime, wasts CDN space and bandwidth.
Example from the wild: https://cdn.repub.ch/s3/republik-assets/github/republik/article-gesichter-der-shoah/images/e8d4e2119b1cbcc390de939bebcb0972b550c433.jpeg.webp?size=1920x2400&resize=4500

@tpreusse @garamond I wasn't sure to fix it here or in [mdast-react-render](https://github.com/orbiting/mdast/blob/ec24cb380f4489e134a3fc3f7481f7efa310dde7/packages/mdast-react-render/src/utils.js#L31). What's the better option?