### PR TITLE
feat gallery: interval and startIndex query props

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -784,7 +784,9 @@ class ArticlePage extends Component {
                   article={article}
                   show={!!router.query.gallery}
                   interval={+router.query.interval}
-                  startIndex={+router.query.startIndex}
+                  startIndex={
+                    router.query.startIndex && +router.query.startIndex
+                  }
                   ref={this.galleryRef}
                 >
                   <ProgressComponent article={article}>

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -783,6 +783,8 @@ class ArticlePage extends Component {
                 <ArticleGallery
                   article={article}
                   show={!!router.query.gallery}
+                  interval={+router.query.interval}
+                  startIndex={+router.query.startIndex}
                   ref={this.galleryRef}
                 >
                   <ProgressComponent article={article}>

--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -106,8 +106,7 @@ class ArticleGallery extends Component {
   }
 
   render() {
-    const { children } = this.props
-    const { article } = this.props
+    const { children, article, startIndex, interval } = this.props
     const { show, startItemSrc, galleryItems } = this.state
     const enabled = get(article, 'content.meta.gallery', true)
     return (
@@ -117,6 +116,8 @@ class ArticleGallery extends Component {
             onClose={this.toggleGallery}
             items={galleryItems}
             startItemSrc={startItemSrc}
+            startIndex={startIndex}
+            interval={interval}
           />
         )}
         {children}
@@ -126,7 +127,10 @@ class ArticleGallery extends Component {
 }
 
 ArticleGallery.propTypes = {
-  article: PropTypes.object.isRequired
+  article: PropTypes.object.isRequired,
+  show: PropTypes.bool,
+  interval: PropTypes.number,
+  startIndex: PropTypes.number
 }
 
 ArticleGallery.childContextTypes = {

--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -15,18 +15,26 @@ const removeQuery = (url = '') => url.split('?')[0]
 
 const MAX_SPREAD_ZOOM = 2
 
-const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
+const Gallery = ({
+  items,
+  onClose,
+  startItemSrc,
+  startIndex = null,
+  children,
+  interval,
+  t
+}) => {
   const galleryRef = React.useRef(null)
 
   React.useEffect(() => {
     if (galleryRef) {
-      const startIndex = items.findIndex(
-        i => removeQuery(i.src) === removeQuery(startItemSrc)
-      )
+      const startItemIndex =
+        startItemSrc &&
+        items.findIndex(i => removeQuery(i.src) === removeQuery(startItemSrc))
 
       const options = {
         modal: true,
-        index: startIndex,
+        index: startIndex !== null ? startIndex : startItemIndex || 0,
         closeOnScroll: false,
         maxSpreadZoom: MAX_SPREAD_ZOOM,
         shareEl: false,
@@ -74,6 +82,18 @@ const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
       })
       gallery.listen('close', onClose)
       gallery.init()
+
+      if (interval) {
+        const intervalId = setInterval(() => {
+          gallery.next()
+        }, interval * 1000)
+
+        gallery.listen('pointerDown', function() {
+          clearInterval(intervalId)
+        })
+
+        return () => clearInterval(intervalId)
+      }
     }
   }, [items])
 

--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -28,9 +28,10 @@ const Gallery = ({
 
   React.useEffect(() => {
     if (galleryRef) {
-      const startItemIndex =
-        startItemSrc &&
-        items.findIndex(i => removeQuery(i.src) === removeQuery(startItemSrc))
+      const startItemSrcQuery = removeQuery(startItemSrc)
+      const startItemIndex = items.findIndex(
+        i => removeQuery(i.src) === startItemSrcQuery
+      )
 
       const options = {
         modal: true,


### PR DESCRIPTION
- new gallery props: `interval=[seconds]`, `startIndex=[number]`
- new `startIndex` overwrites existing `startItemIndex`  
- interval makes gallery forwarding through the images until it's closed or the user interacted

https://republik.love/2020/03/08/bilder?gallery=1&interval=3&startIndex=90