### PR TITLE
fix(notifications): Add "newsletter" and faulty type to known types to opt-in for a newsletter

### DIFF
--- a/lib/translations.json
+++ b/lib/translations.json
@@ -3623,6 +3623,14 @@
       "value": "Newsletter-Anmeldung"
     },
     {
+      "key": "notifications/newsletter-subscript-disabledion/title",
+      "value": "Newsletter-Anmeldung"
+    },
+    {
+      "key": "notifications/newsletter/title",
+      "value": "Newsletter-Anmeldung"
+    },
+    {
       "key": "macNewsletterSubscription/button",
       "value": "bestätigen"
     },

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -124,12 +124,17 @@ const fixAmpsInQuery = rawQuery => {
 }
 
 const knownTypes = [
-  'token-authorization',
-  'newsletter-subscription',
   'email-confirmed',
-  'session-denied',
   'invalid-email',
   'invalid-token',
+  // Deprecated (superseeded by "newsletter")
+  'newsletter-subscription', 
+  // Deprecated (superseeded by "newsletter")
+  // Workaround to handle "script" replacements in email clients
+  'newsletter-subscript-disabledion', 
+  'newsletter',
+  'session-denied',
+  'token-authorization',
   'unavailable'
 ]
 
@@ -173,7 +178,14 @@ const Page = ({ router: { query: rawQuery }, t, me, inNativeApp }) => {
         context={context}
       />
     )
-  } else if (type === 'newsletter-subscription') {
+  } else if ([
+    // Deprecated (superseeded by "newsletter")
+    'newsletter-subscription', 
+    // Deprecated (superseeded by "newsletter")
+    // Workaround to handle "script" replacements in email clients
+    'newsletter-subscript-disabledion', 
+    'newsletter'
+  ].includes(type)) {
     logoTarget = '_blank'
     content = (
       <MacNewsletterSubscription


### PR DESCRIPTION
Page "notifications" handles these types now, too:

- `newsletter` (new default)
- `newsletter-subscript-disabledion` (workaround for invasive email clients)

Type `newsletter-subscript-disabledion` and existing `newsletter-subscription` marked (a comment) as deperacted.

Backend will generate confirmation links with `newsletter` once https://github.com/orbiting/backends/pull/399 is deployed.