### PR TITLE
added step to styleguide link instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Here are the steps:
 ```
 cd ../styleguide
 npm i
+# run dev before linking
+npm run dev
 npm link
 
 cd ../republik-frontend


### PR DESCRIPTION
Hey there, 

When installing the front-end and trying to link the styleguide I ran into a confusing issue. Because the styleguide's main entry point  in package.json is defined as `"main": "./lib/lib.js"`, and this file is only created after running `npm run dev` - the link won't work brefre, as npm will assume the module points to nowhere.

