### PR TITLE
Feat Authorize with Access Token

### DIFF
--- a/components/Auth/AccessTokenAuthorization.js
+++ b/components/Auth/AccessTokenAuthorization.js
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from 'react'
+
+import { Loader } from '@project-r/styleguide'
+
+import withAuthorizeSession from './withAuthorizeSession'
+
+const AccessTokenAuthorization = ({ email, accessToken, authorizeSession }) => {
+  const [loaderProps, setLoaderProps] = useState({ loading: true })
+
+  useEffect(() => {
+    setLoaderProps({ loading: true })
+    authorizeSession({
+      email,
+      tokens: [{ type: 'AUTHORIZE_TOKEN', payload: accessToken }]
+    }).catch(error => {
+      setLoaderProps({ error })
+    })
+  }, [email, accessToken])
+
+  return <Loader {...loaderProps} />
+}
+
+export default withAuthorizeSession(AccessTokenAuthorization)

--- a/components/Auth/AccessTokenAuthorization.js
+++ b/components/Auth/AccessTokenAuthorization.js
@@ -1,10 +1,18 @@
 import React, { useState, useEffect } from 'react'
+import { compose } from 'react-apollo'
 
 import { Loader } from '@project-r/styleguide'
 
 import withAuthorizeSession from './withAuthorizeSession'
+import withMe from '../../lib/apollo/withMe'
 
-const AccessTokenAuthorization = ({ email, accessToken, authorizeSession }) => {
+const AccessTokenAuthorization = ({
+  email,
+  accessToken,
+  authorizeSession,
+  me,
+  onSuccess
+}) => {
   const [loaderProps, setLoaderProps] = useState({ loading: true })
 
   useEffect(() => {
@@ -17,7 +25,13 @@ const AccessTokenAuthorization = ({ email, accessToken, authorizeSession }) => {
     })
   }, [email, accessToken])
 
+  useEffect(() => {
+    if (me) {
+      onSuccess(me)
+    }
+  }, [me, onSuccess])
+
   return <Loader {...loaderProps} />
 }
 
-export default withAuthorizeSession(AccessTokenAuthorization)
+export default compose(withAuthorizeSession, withMe)(AccessTokenAuthorization)

--- a/components/Auth/AccessTokenAuthorization.js
+++ b/components/Auth/AccessTokenAuthorization.js
@@ -19,7 +19,7 @@ const AccessTokenAuthorization = ({
     setLoaderProps({ loading: true })
     authorizeSession({
       email,
-      tokens: [{ type: 'AUTHORIZE_TOKEN', payload: accessToken }]
+      tokens: [{ type: 'ACCESS_TOKEN', payload: accessToken }]
     }).catch(error => {
       setLoaderProps({ error })
     })

--- a/components/Auth/CodeAuthorization.js
+++ b/components/Auth/CodeAuthorization.js
@@ -1,6 +1,5 @@
 import React, { Component, Fragment } from 'react'
-import { Mutation, compose } from 'react-apollo'
-import gql from 'graphql-tag'
+import { compose } from 'react-apollo'
 import { merge, css } from 'glamor'
 
 import {
@@ -17,25 +16,11 @@ import withMe, { meQuery } from '../../lib/apollo/withMe'
 import { scrollIt } from '../../lib/utils/scroll'
 import MdDone from 'react-icons/lib/md/done'
 
+import withAuthorizeSession from './withAuthorizeSession'
+
 const { H3, P, Emphasis } = Interaction
 
 const CODE_LENGTH = 6
-
-const AUTHORIZE_SESSION = gql`
-  mutation authorizeSession(
-    $email: String!
-    $tokens: [SignInToken!]!
-    $consents: [String!]
-    $requiredFields: RequiredUserFields
-  ) {
-    authorizeSession(
-      email: $email
-      tokens: $tokens
-      consents: $consents
-      requiredFields: $requiredFields
-    )
-  }
-`
 
 const styles = {
   button: css({
@@ -111,13 +96,22 @@ class CodeAuthorization extends Component {
   }
 
   render() {
-    const { tokenType, email, onCancel, t, minimal, darkMode } = this.props
-    const { code, dirty, error } = this.state
+    const {
+      tokenType,
+      email,
+      onCancel,
+      t,
+      minimal,
+      darkMode,
+      authorizeSession
+    } = this.props
+    const { code, dirty, error, mutating } = this.state
 
     const handleMutateError = () => {
       this.setState(() => ({
         error: t('Auth/CodeAuthorization/code/invalid'),
-        dirty: true
+        dirty: true,
+        mutating: false
       }))
     }
 
@@ -127,121 +121,103 @@ class CodeAuthorization extends Component {
       minimal && darkMode && styles.minimalHelpDarkMode
     )
 
+    const onSubmit = e => {
+      e && e.preventDefault()
+
+      this.setState({ mutating: true })
+      authorizeSession({
+        email,
+        tokens: [{ type: tokenType, payload: this.state.payload }]
+      }).catch(handleMutateError)
+    }
+
+    const autoSubmit = () => {
+      if (this.state.payload && this.state.payload.length === CODE_LENGTH) {
+        onSubmit()
+      }
+    }
+
     return (
-      <Mutation mutation={AUTHORIZE_SESSION} awaitRefetchQueries>
-        {(mutate, { loading }) => {
-          const onSubmit = e => {
-            e && e.preventDefault()
-
-            mutate({
-              variables: {
-                email,
-                tokens: [{ type: tokenType, payload: this.state.payload }]
-              },
-              refetchQueries: [{ query: meQuery }]
-            }).catch(handleMutateError)
-          }
-
-          const autoSubmit = () => {
-            if (
-              this.state.payload &&
-              this.state.payload.length === CODE_LENGTH
-            ) {
-              onSubmit()
-            }
-          }
-
-          return (
-            <form onSubmit={onSubmit} ref={this.formRef}>
-              {minimal ? (
-                <ul {...listStyle} style={{ marginTop: 20 }}>
-                  <li>
-                    {t.elements('Auth/CodeAuthorization/description', {
-                      emphasis: (
-                        <Emphasis key='emphasis'>
-                          {t(
-                            'Auth/CodeAuthorization/description/emphasis/email',
-                            { email: email }
-                          )}
-                        </Emphasis>
-                      )
+      <form onSubmit={onSubmit} ref={this.formRef}>
+        {minimal ? (
+          <ul {...listStyle} style={{ marginTop: 20 }}>
+            <li>
+              {t.elements('Auth/CodeAuthorization/description', {
+                emphasis: (
+                  <Emphasis key='emphasis'>
+                    {t('Auth/CodeAuthorization/description/emphasis/email', {
+                      email: email
                     })}
-                  </li>
-                </ul>
-              ) : (
-                <Fragment>
-                  <H3>{t('Auth/CodeAuthorization/title')}</H3>
-                  <P {...styles.description}>
-                    {t.elements('Auth/CodeAuthorization/description', {
-                      emphasis: (
-                        <Emphasis key='emphasis'>
-                          {t('Auth/CodeAuthorization/description/emphasis')}
-                        </Emphasis>
-                      )
-                    })}
-                  </P>
-                </Fragment>
-              )}
-              <Field
-                renderInput={props => <input {...props} pattern={'[0-9]*'} />}
-                label={t('Auth/CodeAuthorization/code/label')}
-                value={code}
-                autoComplete={'false'}
-                error={dirty && error}
-                black={minimal && !darkMode}
-                white={minimal && darkMode}
-                icon={
-                  minimal &&
-                  (loading ? (
-                    <InlineSpinner size='30px' />
-                  ) : (
-                    <MdDone
-                      style={{ cursor: 'pointer' }}
-                      size={30}
-                      onClick={onSubmit}
-                    />
-                  ))
-                }
-                onChange={(_, value, shouldValidate) => {
-                  this.setState(
-                    checkCode({ value, shouldValidate, t }),
-                    autoSubmit
-                  )
-                }}
+                  </Emphasis>
+                )
+              })}
+            </li>
+          </ul>
+        ) : (
+          <Fragment>
+            <H3>{t('Auth/CodeAuthorization/title')}</H3>
+            <P {...styles.description}>
+              {t.elements('Auth/CodeAuthorization/description', {
+                emphasis: (
+                  <Emphasis key='emphasis'>
+                    {t('Auth/CodeAuthorization/description/emphasis')}
+                  </Emphasis>
+                )
+              })}
+            </P>
+          </Fragment>
+        )}
+        <Field
+          renderInput={props => <input {...props} pattern={'[0-9]*'} />}
+          label={t('Auth/CodeAuthorization/code/label')}
+          value={code}
+          autoComplete={'false'}
+          error={dirty && error}
+          black={minimal && !darkMode}
+          white={minimal && darkMode}
+          icon={
+            minimal &&
+            (mutating ? (
+              <InlineSpinner size='30px' />
+            ) : (
+              <MdDone
+                style={{ cursor: 'pointer' }}
+                size={30}
+                onClick={onSubmit}
               />
-              {!minimal && (
-                <div {...styles.button}>
-                  {loading ? (
-                    <InlineSpinner />
-                  ) : (
-                    <Button
-                      block
-                      type='submit'
-                      primary
-                      disabled={!code || error || loading}
-                    >
-                      {t('Auth/CodeAuthorization/button/label')}
-                    </Button>
-                  )}
-                </div>
-              )}
-              <ul {...listStyle}>
-                <li>
-                  <A href='#' onClick={onCancel}>
-                    {t('Auth/CodeAuthorization/help/cancelLink')}
-                  </A>
-                </li>
-                <li>{t('Auth/CodeAuthorization/help/lastResort')}</li>
-              </ul>
-            </form>
-          )
-        }}
-      </Mutation>
+            ))
+          }
+          onChange={(_, value, shouldValidate) => {
+            this.setState(checkCode({ value, shouldValidate, t }), autoSubmit)
+          }}
+        />
+        {!minimal && (
+          <div {...styles.button}>
+            {mutating ? (
+              <InlineSpinner />
+            ) : (
+              <Button
+                block
+                type='submit'
+                primary
+                disabled={!code || error || mutating}
+              >
+                {t('Auth/CodeAuthorization/button/label')}
+              </Button>
+            )}
+          </div>
+        )}
+        <ul {...listStyle}>
+          <li>
+            <A href='#' onClick={onCancel}>
+              {t('Auth/CodeAuthorization/help/cancelLink')}
+            </A>
+          </li>
+          <li>{t('Auth/CodeAuthorization/help/lastResort')}</li>
+        </ul>
+      </form>
     )
   }
 }
 
-export default compose(
-  withMe,
-  withT
-)(CodeAuthorization)
+export default compose(withMe, withT, withAuthorizeSession)(CodeAuthorization)

--- a/components/Auth/CodeAuthorization.js
+++ b/components/Auth/CodeAuthorization.js
@@ -12,7 +12,7 @@ import {
 } from '@project-r/styleguide'
 
 import withT from '../../lib/withT'
-import withMe, { meQuery } from '../../lib/apollo/withMe'
+import withMe from '../../lib/apollo/withMe'
 import { scrollIt } from '../../lib/utils/scroll'
 import MdDone from 'react-icons/lib/md/done'
 

--- a/components/Auth/SignIn.js
+++ b/components/Auth/SignIn.js
@@ -202,12 +202,14 @@ const signInMutation = gql`
     $context: String
     $consents: [String!]
     $tokenType: SignInTokenType
+    $accessToken: ID
   ) {
     signIn(
       email: $email
       context: $context
       consents: $consents
       tokenType: $tokenType
+      accessToken: $accessToken
     ) {
       phrase
       tokenType
@@ -218,13 +220,11 @@ const signInMutation = gql`
 
 export const withSignIn = graphql(signInMutation, {
   props: ({ mutate }) => ({
-    signIn: (email, context = 'signIn', consents, tokenType) =>
-      mutate({ variables: { email, context, consents, tokenType } })
+    signIn: (email, context = 'signIn', consents, tokenType, accessToken) =>
+      mutate({
+        variables: { email, context, consents, tokenType, accessToken }
+      })
   })
 })
 
-export default compose(
-  withApollo,
-  withSignIn,
-  withT
-)(SignIn)
+export default compose(withApollo, withSignIn, withT)(SignIn)

--- a/components/Auth/SwitchBoard.js
+++ b/components/Auth/SwitchBoard.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import CodeAuthorization from './CodeAuthorization'
+import AccessTokenAuthorization from './AccessTokenAuthorization'
 import Poller from './Poller'
 
 import withT from '../../lib/withT'
@@ -9,8 +10,11 @@ import withT from '../../lib/withT'
 import { SUPPORTED_TOKEN_TYPES } from '../constants'
 
 const SwitchBoard = props => {
-  if (props.tokenType && props.tokenType === 'EMAIL_CODE') {
+  if (props.tokenType === 'EMAIL_CODE') {
     return <CodeAuthorization {...props} />
+  }
+  if (props.tokenType === 'AUTHORIZE_TOKEN') {
+    return <AccessTokenAuthorization {...props} />
   }
 
   return <Poller {...props} />

--- a/components/Auth/SwitchBoard.js
+++ b/components/Auth/SwitchBoard.js
@@ -11,14 +11,14 @@ import { SUPPORTED_TOKEN_TYPES } from '../constants'
 
 const SWITCH_BOARD_SUPPORTED_TOKEN_TYPES = SUPPORTED_TOKEN_TYPES.concat([
   'EMAIL_CODE',
-  'AUTHORIZE_TOKEN'
+  'ACCESS_TOKEN'
 ])
 
 const SwitchBoard = props => {
   if (props.tokenType === 'EMAIL_CODE') {
     return <CodeAuthorization {...props} />
   }
-  if (props.tokenType === 'AUTHORIZE_TOKEN') {
+  if (props.tokenType === 'ACCESS_TOKEN') {
     return <AccessTokenAuthorization {...props} />
   }
 

--- a/components/Auth/SwitchBoard.js
+++ b/components/Auth/SwitchBoard.js
@@ -9,6 +9,11 @@ import withT from '../../lib/withT'
 
 import { SUPPORTED_TOKEN_TYPES } from '../constants'
 
+const SWITCH_BOARD_SUPPORTED_TOKEN_TYPES = SUPPORTED_TOKEN_TYPES.concat([
+  'EMAIL_CODE',
+  'AUTHORIZE_TOKEN'
+])
+
 const SwitchBoard = props => {
   if (props.tokenType === 'EMAIL_CODE') {
     return <CodeAuthorization {...props} />
@@ -21,12 +26,11 @@ const SwitchBoard = props => {
 }
 
 SwitchBoard.propTypes = {
-  tokenType: PropTypes.oneOf(SUPPORTED_TOKEN_TYPES.concat('EMAIL_CODE'))
-    .isRequired,
+  tokenType: PropTypes.oneOf(SWITCH_BOARD_SUPPORTED_TOKEN_TYPES).isRequired,
   email: PropTypes.string.isRequired,
   phrase: PropTypes.string.isRequired,
   alternativeFirstFactors: PropTypes.arrayOf(
-    PropTypes.oneOf(SUPPORTED_TOKEN_TYPES.concat('EMAIL_CODE'))
+    PropTypes.oneOf(SWITCH_BOARD_SUPPORTED_TOKEN_TYPES)
   ).isRequired,
   onSuccess: PropTypes.func,
   onCancel: PropTypes.func,

--- a/components/Auth/withAuthorizeSession.js
+++ b/components/Auth/withAuthorizeSession.js
@@ -1,0 +1,31 @@
+import gql from 'graphql-tag'
+import { graphql, compose } from 'react-apollo'
+
+import { meQuery } from '../../lib/apollo/withMe'
+
+const mutation = gql`
+  mutation authorizeSession(
+    $email: String!
+    $tokens: [SignInToken!]!
+    $consents: [String!]
+    $requiredFields: RequiredUserFields
+  ) {
+    authorizeSession(
+      email: $email
+      tokens: $tokens
+      consents: $consents
+      requiredFields: $requiredFields
+    )
+  }
+`
+
+export default graphql(mutation, {
+  props: ({ mutate }) => ({
+    authorizeSession: variables =>
+      mutate({
+        variables,
+        refetchQueries: [{ query: meQuery }],
+        awaitRefetchQueries: true
+      })
+  })
+})

--- a/components/Trial/Form.js
+++ b/components/Trial/Form.js
@@ -58,7 +58,7 @@ const styles = {
   })
 }
 
-const REQUIRED_CONSENTS = ['PRIVACY', 'TOS']
+const REQUIRED_CONSENTS = ['PRIVACY']
 
 const Form = props => {
   const {
@@ -80,14 +80,15 @@ const Form = props => {
 
   const utmParams = getUtmParams(query)
 
-  const [consents, setConsents] = useState([])
+  const [consents, setConsents] = useState(query.token ? REQUIRED_CONSENTS : [])
   const [email, setEmail] = useState({ value: initialEmail || '' })
   const [serverError, setServerError] = useState('')
-  const [phrase, setPhrase] = useState('')
   const [signingIn, setSigningIn] = useState(false)
   const [showButtons, setShowButtons] = useState(false)
   const [loading, setLoading] = useState(false)
-  const [tokenType, setTokenType] = useState('EMAIL_CODE')
+
+  const [switchBoardProps, setSwitchBoardProps] = useState()
+
   const [showErrors, setShowErrors] = useState(false)
   const [autoRequestAccess, setAutoRequestAccess] = useState(false)
 
@@ -125,10 +126,12 @@ const Form = props => {
       beforeSignIn && beforeSignIn()
 
       return props
-        .signIn(email.value, 'trial', consents, tokenType)
+        .signIn(email.value, 'trial', consents, 'EMAIL_CODE', query.token)
         .then(({ data: { signIn } }) => {
-          setTokenType(signIn.tokenType)
-          setPhrase(signIn.phrase)
+          setSwitchBoardProps({
+            ...signIn,
+            accessToken: query.token
+          })
 
           setLoading(false)
           setSigningIn(true)
@@ -294,8 +297,7 @@ const Form = props => {
         >
           <SwitchBoard
             email={email.value}
-            tokenType={tokenType}
-            phrase={phrase}
+            {...switchBoardProps}
             alternativeFirstFactors={[]}
             onCancel={reset}
             onTokenTypeChange={reset}

--- a/components/Trial/Form.js
+++ b/components/Trial/Form.js
@@ -73,14 +73,15 @@ const Form = props => {
     meRefetch,
     t,
     minimal,
-    darkMode
+    darkMode,
+    initialEmail
   } = props
   const { viaActiveMembership, viaAccessGrant } = trialEligibility
 
   const utmParams = getUtmParams(query)
 
   const [consents, setConsents] = useState([])
-  const [email, setEmail] = useState({ value: '' })
+  const [email, setEmail] = useState({ value: initialEmail || '' })
   const [serverError, setServerError] = useState('')
   const [phrase, setPhrase] = useState('')
   const [signingIn, setSigningIn] = useState(false)

--- a/components/Trial/Page.js
+++ b/components/Trial/Page.js
@@ -41,13 +41,16 @@ const getTranslationKey = (name, { isAuthorized, hasAccess, campaign }) => {
   ]
 }
 
+const ALLOWED_CAMPAIGNS = ['covid-19-uhr-newsletter']
+
 const Page = props => {
   const {
     trialEligibility,
     me,
     router: { query },
     t,
-    inNativeIOSApp
+    inNativeIOSApp,
+    initialEmail
   } = props
   const { viaActiveMembership, viaAccessGrant } = trialEligibility
   const campaign = query.campaign || query.utm_campaign
@@ -60,8 +63,8 @@ const Page = props => {
     (trailCampaignes[campaign] && trailCampaignes[campaign].accessCampaignId) ||
     TRIAL_CAMPAIGN
 
-  // tmp: no trial in March
-  if (!hasAccess) {
+  // only allow specific trials
+  if (!hasAccess && !ALLOWED_CAMPAIGNS.includes(campaign)) {
     return (
       <>
         <H1 style={{ marginBottom: 40 }}>{t('Trial/Page/disabled/title')}</H1>
@@ -105,7 +108,7 @@ const Page = props => {
           }
         )}
       </P>
-      <Form accessCampaignId={accessCampaignId} />
+      <Form initialEmail={initialEmail} accessCampaignId={accessCampaignId} />
     </Fragment>
   )
 }

--- a/pages/trial.js
+++ b/pages/trial.js
@@ -7,8 +7,24 @@ import Trial from '../components/Trial/Page'
 import withT from '../lib/withT'
 import { CDN_FRONTEND_BASE_URL, PUBLIC_BASE_URL } from '../lib/constants'
 
+import isEmail from 'validator/lib/isEmail'
+import * as base64u from '../lib/utils/base64u'
+
 const Page = ({ router, t }) => {
-  const { campaign } = router.query
+  const { campaign, email } = router.query
+  let initialEmail = email
+
+  if (initialEmail !== undefined) {
+    try {
+      if (base64u.match(initialEmail)) {
+        initialEmail = base64u.decode(initialEmail)
+      }
+    } catch (e) {}
+
+    if (!isEmail(initialEmail)) {
+      initialEmail = ''
+    }
+  }
 
   const meta = {
     pageTitle: t.first([
@@ -26,12 +42,9 @@ const Page = ({ router, t }) => {
 
   return (
     <Frame meta={meta}>
-      <Trial />
+      <Trial initialEmail={initialEmail} />
     </Frame>
   )
 }
 
-export default compose(
-  withRouter,
-  withT
-)(Page)
+export default compose(withRouter, withT)(Page)


### PR DESCRIPTION
Allow to sign in with access token `AUTHORIZE_TOKEN` via `query.token` on trial page.

Other changes:
- allow specific trial campaigns
- support base64u email prefill via query
- refactor `authorizeSession` mutation to dedup code