### PR TITLE
Add link to /konto#abos in UserGuidance

### DIFF
--- a/components/Account/UserGuidance.js
+++ b/components/Account/UserGuidance.js
@@ -62,6 +62,11 @@ const UserGuidance = ({ t, inNativeIOSApp, signOut }) => (
                       {t('Account/noActiveMembership/signOutLink')}
                     </Editorial.A>
                   ),
+                  membershipsLink: (
+                    <Editorial.A key='account-memberships' href='/konto#abos'>
+                      {t('Account/noActiveMembership/membershipsLink')}
+                    </Editorial.A>
+                  ),
                   pledgeLink: (
                     <Link route='pledge' key='pledge' passHref>
                       <Editorial.A>
@@ -87,8 +92,4 @@ const UserGuidance = ({ t, inNativeIOSApp, signOut }) => (
   </Box>
 )
 
-export default compose(
-  withT,
-  withInNativeApp,
-  withSignOut
-)(UserGuidance)
+export default compose(withT, withInNativeApp, withSignOut)(UserGuidance)

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -603,10 +603,6 @@
       "value": "Bitte überprüfen Sie Ihre Angaben und korrigieren beziehungs­weise ergänzen Sie."
     },
     {
-      "key": "Account/noActiveMembership",
-      "value": "Leider existiert unter Ihrer E-Mail-Adresse kein laufendes Abonnement. Dieses Problem kann mehrere Ursachen haben:\n<br /><br />\n<ul>\n<li>Sie haben ein gültiges Abonnement. Aber Sie haben die falsche E-Mail-Adresse eingegeben. Der Computer erkennt nur die E-Mail-Adresse, die Sie uns beim ersten Mal gegeben haben.<br /><b>Lösung:</b> Probieren Sie Ihre anderen E-Mail-Adressen hier: {signInLink} (<b>Tipp:</b> mit grosser Wahrscheinlcihkeit ist es dieselbe Adresse, auf der Sie auch unseren Newsletter erhalten.)</li>\n<li>Ihr Abonnement ist ausgelaufen. Wir freuen uns, Sie nach einer kurzen Pause wieder an Bord zu haben.<br /><b>Lösung:</b> Sie können das problemlos weiter unten auf dieser Seite tun. (Dort finden Sie auch alle Details zu Ihren früheren Abonnements.)</li>\n<li>Sie haben noch kein Abonnement. <b>Lösung:</b> Sie können in wenigen Minuten eines haben. {pledgeLink}<br />\n<li>Sie sind bei uns dabei. Aber ausschliesslich als Spenderin oder Spender – das freut uns. Aber um uns zu lesen, brauchen Sie zusätzlich noch ein reguläres Abonnement. <b>Lösung:</b> {pledgeLink}</li>\n</ul>\n<br /><br />\nLiegt Ihr Fall komplexer, dann melden Sie sich bei unserem Erste-Hilfe-Team: kontakt@republik.ch. Wir werden versuchen, Ihnen so schnell wie möglich weiterzuhelfen. \n<br /><br />\nDanke für Ihre Mühe!"
-    },
-    {
       "key": "Account/noActiveMembership/before",
       "value": "Leider existiert unter Ihrer E-Mail-Adresse kein laufendes Abonnement. Das kann mehrere Ursachen haben:"
     },
@@ -632,7 +628,11 @@
     },
     {
       "key": "Account/noActiveMembership/solution2",
-      "value": "{solution}  Sie können das problemlos weiter unten auf dieser Seite tun. (Dort finden Sie auch alle Details zu Ihren früheren Abonnements.)"
+      "value": "{solution} Sie können das problemlos {membershipsLink}. (Dort finden Sie auch alle Details zu Ihren früheren Abonnements.)"
+    },
+    {
+      "key": "Account/noActiveMembership/membershipsLink",
+      "value": "in Ihrem Konto reaktivieren"
     },
     {
       "key": "Account/noActiveMembership/issue3",


### PR DESCRIPTION
Update wording and add link to `/konto#abos` in a solution in `UserGuidance`. (Also remove obsolete translation key `Account/noActiveMembership`.)

**Before**

<img width="520" alt="Bildschirmfoto 2020-04-27 um 13 11 29" src="https://user-images.githubusercontent.com/331800/80365921-a990f280-8888-11ea-8d3c-0467856aee98.png">

**After**

<img width="526" alt="Bildschirmfoto 2020-04-27 um 13 11 15" src="https://user-images.githubusercontent.com/331800/80365926-aac21f80-8888-11ea-998d-1562563433e2.png">