### PR TITLE
Revert Trial/Page change and update sommer campaign translations

### DIFF
--- a/components/Trial/Page.js
+++ b/components/Trial/Page.js
@@ -131,7 +131,7 @@ const Page = props => {
   )
   return (
     <Fragment>
-      <H1 style={{ marginBottom: 10 }}>
+      <H1 style={{ marginBottom: 20 }}>
         {t.first(
           getTranslationKeys('heading', { isSignedIn, hasAccess, campaign })
         )}
@@ -150,31 +150,10 @@ const Page = props => {
           </P>
         ))}
       <Form
-        key={`${accessCampaignId}-a`}
         initialEmail={initialEmail}
         accessCampaignId={accessCampaignId}
         campaign={campaign}
       />
-      {further
-        .split('\n\n')
-        .filter(Boolean)
-        .map((c, i) => (
-          <P key={i} style={{ marginTop: 40, marginBottom: 20 }}>
-            <RawHtml
-              dangerouslySetInnerHTML={{
-                __html: c
-              }}
-            />
-          </P>
-        ))}
-      {further && (
-        <Form
-          key={`${accessCampaignId}-b`}
-          initialEmail={initialEmail}
-          accessCampaignId={accessCampaignId}
-          campaign={campaign}
-        />
-      )}
     </Fragment>
   )
 }

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -6728,7 +6728,7 @@
     },
     {
       "key": "Trial/Page/sommer/intro",
-      "value": "Das digitale Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen. Die Republik ist komplett werbefrei. Und kompromisslos in der Qualität.\n\nUnser Ziel: Journalismus, der die Köpfe klarer, das Handeln mutiger, die Entscheidungen klüger macht. Und der das Gemeinsame stärkt: die Freiheit, den Rechtsstaat, die Demokratie.\n\n<b>Erhalten Sie für 21 Tage kostenlos und unverbindlich Zugang zu allen Artikeln und Podcasts der Republik zu erhalten – im Web, in der Republik-App oder als Newsletter:</b>"
+      "value": "Das digitale Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen. Wir recherchieren, fragen nach, ordnen ein und decken auf. Und liefern Ihnen Fakten und Zusammenhänge als Grundlage für Ihre eigenen Überlegungen und Entscheidungen.\n\nDie Republik ist komplett werbefrei. Und kompromisslos in der Qualität. Unser Ziel: Journalismus, der die Köpfe klarer, das Handeln mutiger, die Entscheidungen klüger macht. Und der das Gemeinsame stärkt: die Freiheit, den Rechtsstaat, die Demokratie.\n\n<b>Erhalten Sie für 21 Tage kostenlos und unverbindlich Zugang zu allen Artikeln und Podcasts der Republik – im Web, in der Republik-App oder als Newsletter:</b>"
     },
     {
       "key": "Trial/Form/sommer/button",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -6728,7 +6728,7 @@
     },
     {
       "key": "Trial/Page/sommer/intro",
-      "value": "Das digitale Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen. Wir recherchieren, fragen nach, ordnen ein und decken auf. Und liefern Ihnen Fakten und Zusammenhänge als Grundlage für Ihre eigenen Überlegungen und Entscheidungen.\n\nDie Republik ist komplett werbefrei. Und kompromisslos in der Qualität. Unser Ziel: Journalismus, der die Köpfe klarer, das Handeln mutiger, die Entscheidungen klüger macht. Und der das Gemeinsame stärkt: die Freiheit, den Rechtsstaat, die Demokratie.\n\n<b>Tragen Sie hier Ihre E-Mail-Adresse ein, um für 21 Tage kostenlos und unverbindlich Zugang zu allen Artikeln und Podcasts der Republik zu erhalten – im Web, in der Republik-App oder als Newsletter:</b>"
+      "value": "Das digitale Magazin für Politik, Wirtschaft, Gesellschaft und Kultur. Finanziert von seinen Leserinnen. Die Republik ist komplett werbefrei. Und kompromisslos in der Qualität.\n\nUnser Ziel: Journalismus, der die Köpfe klarer, das Handeln mutiger, die Entscheidungen klüger macht. Und der das Gemeinsame stärkt: die Freiheit, den Rechtsstaat, die Demokratie.\n\n<b>Erhalten Sie für 21 Tage kostenlos und unverbindlich Zugang zu allen Artikeln und Podcasts der Republik zu erhalten – im Web, in der Republik-App oder als Newsletter:</b>"
     },
     {
       "key": "Trial/Form/sommer/button",


### PR DESCRIPTION
Update translation strings and revert earlier changes to `Trial/Page`.

<img width="373" alt="Bildschirmfoto 2020-06-24 um 16 34 44" src="https://user-images.githubusercontent.com/331800/85576785-fdc21400-b638-11ea-960b-e97db700000a.png">
