### PR TITLE
larger mobile header

### DIFF
--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -86,7 +86,7 @@ const FeedbackPage = props => {
 
   return (
     <Frame
-      hasOverviewNav={true}
+      hasOverviewNav={!tab}
       raw
       meta={pageMeta}
       formatColor={colors.primary}

--- a/components/Frame/HeaderNew.js
+++ b/components/Frame/HeaderNew.js
@@ -40,16 +40,6 @@ import {
   TRANSITION_MS
 } from '../constants'
 
-const isActiveRoute = (active, route, params = {}) =>
-  !!active &&
-  active.route === route &&
-  Object.keys(params).every(key => active.params[key] === params[key])
-
-const isFront = router => {
-  const active = matchPath(router.asPath)
-  return isActiveRoute(active, 'index', {})
-}
-
 let routeChangeStarted
 
 const HeaderNew = ({
@@ -83,7 +73,7 @@ const HeaderNew = ({
   const dark = darkProp && !isAnyNavExpanded
   const textFill = dark ? colors.negative.text : colors.text
   const logoFill = dark ? colors.logoDark || '#fff' : colors.logo || '#000'
-  const backButton = inNativeIOSApp && me && !isFront(router)
+  const backButton = !hasOverviewNav && inNativeIOSApp && me
 
   const toggleExpanded = target => {
     if (target === expandedNav) {

--- a/components/Frame/HeaderNew.js
+++ b/components/Frame/HeaderNew.js
@@ -266,7 +266,7 @@ const HeaderNew = ({
                 <ToggleNew
                   expanded={isAnyNavExpanded}
                   dark={dark}
-                  size={26}
+                  size={28}
                   title={t(
                     `header/nav/${
                       expandedNav === 'main' ? 'close' : 'open'

--- a/components/Frame/SecondaryNav.js
+++ b/components/Frame/SecondaryNav.js
@@ -10,7 +10,7 @@ import NavLink from './Popover/NavLink'
 import {
   HEADER_HEIGHT,
   HEADER_HEIGHT_MOBILE,
-  SUBHEADER_HEIGHT_MOBILE,
+  SUBHEADER_HEIGHT,
   ZINDEX_HEADER
 } from '../constants'
 
@@ -153,7 +153,7 @@ const styles = {
     zIndex: ZINDEX_HEADER,
     left: 0,
     right: 0,
-    height: SUBHEADER_HEIGHT_MOBILE,
+    height: SUBHEADER_HEIGHT,
     display: 'flex',
     justifyContent: 'flex-start',
     padding: `0px ${Math.floor((HEADER_HEIGHT_MOBILE - 26) / 2)}px`,
@@ -167,7 +167,7 @@ const styles = {
     overflowX: 'auto',
     whiteSpace: 'nowrap',
     zIndex: ZINDEX_HEADER,
-    height: SUBHEADER_HEIGHT_MOBILE,
+    height: SUBHEADER_HEIGHT,
     left: 0,
     right: 0,
     WebkitOverflowScrolling: 'touch',
@@ -183,7 +183,7 @@ const styles = {
       display: 'inline-block',
       whiteSpace: 'nowrap',
       fontSize: 14,
-      margin: '10px 16px 0px 16px',
+      margin: '12px 16px 0px 16px',
       '::after': {
         ...fontStyles.sansSerifMedium,
         display: 'block',
@@ -201,7 +201,7 @@ const styles = {
     }
   }),
   linkItem: css({
-    height: SUBHEADER_HEIGHT_MOBILE
+    height: SUBHEADER_HEIGHT
   })
 }
 

--- a/components/Frame/SecondaryNav.js
+++ b/components/Frame/SecondaryNav.js
@@ -62,6 +62,10 @@ export const SecondaryNav = ({
       {hasOverviewNav ? (
         <div
           {...styles.miniNav}
+          onTouchStart={e => {
+            // prevent touchstart from bubbling to Pullable
+            e.stopPropagation()
+          }}
           style={{
             borderTop: `1px solid ${
               dark ? colors.negative.divider : colors.divider

--- a/components/Frame/ToggleNew.js
+++ b/components/Frame/ToggleNew.js
@@ -41,13 +41,14 @@ const styles = {
     boxShadow: 'none',
     outline: 'none',
     padding: `${Math.floor((HEADER_HEIGHT_MOBILE - 26) / 2)}px`,
+    paddingRight: 16,
     [mediaQueries.mUp]: {
       padding: `${Math.floor((HEADER_HEIGHT - 26) / 2)}px`
     }
   }),
   closeButton: css({
     position: 'absolute',
-    right: 4,
+    right: 10,
     transition: `opacity ${TRANSITION_MS}ms ease-out`,
     [mediaQueries.mUp]: {
       right: 16

--- a/components/Frame/UserNew.js
+++ b/components/Frame/UserNew.js
@@ -6,7 +6,7 @@ import { MdPersonOutline } from 'react-icons/md'
 import withT from '../../lib/withT'
 
 const BUTTON_SIZE = 32
-const BUTTON_SIZE_MOBILE = 24
+const BUTTON_SIZE_MOBILE = 26
 const BUTTON_PADDING = (HEADER_HEIGHT - BUTTON_SIZE) / 2
 const BUTTON_PADDING_MOBILE = (HEADER_HEIGHT_MOBILE - BUTTON_SIZE_MOBILE) / 2
 const ICON_SIZE = 26
@@ -35,9 +35,7 @@ const User = ({ t, me, title, dark, backButton, onClick }) => {
         {...styles.button}
         style={{
           color,
-          paddingLeft: backButton
-            ? BUTTON_PADDING_MOBILE / 2
-            : BUTTON_PADDING_MOBILE
+          paddingLeft: backButton ? BUTTON_PADDING_MOBILE / 2 : 16
         }}
         role='button'
         title={title}

--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -87,6 +87,10 @@ const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
           background: '#000',
           zIndex: ZINDEX_GALLERY
         }}
+        onTouchStart={e => {
+          // prevent touchstart from bubbling to Pullable
+          e.stopPropagation()
+        }}
       >
         <div className='pswp__bg' />
         <div className='pswp__scroll-wrap'>

--- a/components/constants.js
+++ b/components/constants.js
@@ -1,10 +1,9 @@
 import { Logo, mediaQueries } from '@project-r/styleguide'
 
 export const HEADER_HEIGHT = 60
-export const HEADER_HEIGHT_MOBILE = 45
+export const HEADER_HEIGHT_MOBILE = 48
 export const HEADER_ICON_SIZE = 22
-export const SUBHEADER_HEIGHT = 36
-export const SUBHEADER_HEIGHT_MOBILE = 36
+export const SUBHEADER_HEIGHT = 40
 
 export const HEADER_HEIGHT_CONFIG = [
   { minWidth: 0, headerHeight: HEADER_HEIGHT_MOBILE },


### PR DESCRIPTION
iPhone SE screens:

before
![Screenshot 2020-07-08 at 11 03 27](https://user-images.githubusercontent.com/20746301/86899894-e12edd00-c10a-11ea-977a-76c99a74fe10.jpg)

after
![Screenshot 2020-07-08 at 11 02 37](https://user-images.githubusercontent.com/20746301/86899900-e429cd80-c10a-11ea-9c39-6efcdc398ec9.jpg)
