### PR TITLE
Fixes header line visibility and nav last item bug

### DIFF
--- a/components/Frame/HLine.js
+++ b/components/Frame/HLine.js
@@ -7,7 +7,7 @@ import { ZINDEX_POPOVER } from '../constants'
 const HLine = ({
   formatColor,
   dark,
-  isSecondarySticky,
+  isHeaderFullyScrolledAway,
   secondaryNav,
   hasOverviewNav
 }) => {
@@ -15,7 +15,8 @@ const HLine = ({
   const hrColorStyle = {
     color: hrColor,
     backgroundColor: hrColor,
-    opacity: isSecondarySticky && !secondaryNav && !hasOverviewNav ? 0 : 1
+    opacity:
+      isHeaderFullyScrolledAway && !secondaryNav && !hasOverviewNav ? 0 : 1
   }
   return (
     <hr

--- a/components/Frame/HLine.js
+++ b/components/Frame/HLine.js
@@ -5,14 +5,14 @@ import { colors } from '@project-r/styleguide'
 import { ZINDEX_POPOVER } from '../constants'
 
 const HLine = ({ formatColor, dark }) => {
-  const hrColor = dark ? colors.negative.divider : colors.divider
+  const color = formatColor || (dark ? colors.negative.divider : colors.divider)
   return (
     <hr
       {...styles.hr}
-      {...styles[formatColor ? 'hrThick' : 'hrThin']}
       style={{
-        color: formatColor || hrColor,
-        backgroundColor: formatColor || hrColor
+        color,
+        backgroundColor: color,
+        height: formatColor ? 3 : 1
       }}
     />
   )
@@ -27,11 +27,5 @@ const styles = {
     border: 0,
     width: '100%',
     zIndex: ZINDEX_POPOVER + 2
-  }),
-  hrThin: css({
-    height: 1
-  }),
-  hrThick: css({
-    height: 3
   })
 }

--- a/components/Frame/HLine.js
+++ b/components/Frame/HLine.js
@@ -4,30 +4,16 @@ import { colors } from '@project-r/styleguide'
 
 import { ZINDEX_POPOVER } from '../constants'
 
-const HLine = ({
-  formatColor,
-  dark,
-  isHeaderFullyScrolledAway,
-  secondaryNav,
-  hasOverviewNav
-}) => {
+const HLine = ({ formatColor, dark }) => {
   const hrColor = dark ? colors.negative.divider : colors.divider
-  const hrStyle = formatColor
-    ? {
-        color: formatColor,
-        backgroundColor: formatColor
-      }
-    : {
-        color: hrColor,
-        backgroundColor: hrColor,
-        opacity:
-          isHeaderFullyScrolledAway && !secondaryNav && !hasOverviewNav ? 0 : 1
-      }
   return (
     <hr
       {...styles.hr}
       {...styles[formatColor ? 'hrThick' : 'hrThin']}
-      style={hrStyle}
+      style={{
+        color: formatColor || hrColor,
+        backgroundColor: formatColor || hrColor
+      }}
     />
   )
 }

--- a/components/Frame/HLine.js
+++ b/components/Frame/HLine.js
@@ -1,16 +1,22 @@
 import React from 'react'
 import { css } from 'glamor'
-import { colors, mediaQueries } from '@project-r/styleguide'
+import { colors } from '@project-r/styleguide'
 
-import {
-  HEADER_HEIGHT,
-  HEADER_HEIGHT_MOBILE,
-  ZINDEX_POPOVER
-} from '../constants'
+import { ZINDEX_POPOVER } from '../constants'
 
-const HLine = ({ formatColor, dark }) => {
+const HLine = ({
+  formatColor,
+  dark,
+  isSecondarySticky,
+  secondaryNav,
+  hasOverviewNav
+}) => {
   const hrColor = dark ? colors.negative.divider : colors.divider
-  const hrColorStyle = { color: hrColor, backgroundColor: hrColor }
+  const hrColorStyle = {
+    color: hrColor,
+    backgroundColor: hrColor,
+    opacity: isSecondarySticky && !secondaryNav && !hasOverviewNav ? 0 : 1
+  }
   return (
     <hr
       {...styles.hr}

--- a/components/Frame/HLine.js
+++ b/components/Frame/HLine.js
@@ -12,24 +12,22 @@ const HLine = ({
   hasOverviewNav
 }) => {
   const hrColor = dark ? colors.negative.divider : colors.divider
-  const hrColorStyle = {
-    color: hrColor,
-    backgroundColor: hrColor,
-    opacity:
-      isHeaderFullyScrolledAway && !secondaryNav && !hasOverviewNav ? 0 : 1
-  }
+  const hrStyle = formatColor
+    ? {
+        color: formatColor,
+        backgroundColor: formatColor
+      }
+    : {
+        color: hrColor,
+        backgroundColor: hrColor,
+        opacity:
+          isHeaderFullyScrolledAway && !secondaryNav && !hasOverviewNav ? 0 : 1
+      }
   return (
     <hr
       {...styles.hr}
       {...styles[formatColor ? 'hrThick' : 'hrThin']}
-      style={
-        formatColor
-          ? {
-              color: formatColor,
-              backgroundColor: formatColor
-            }
-          : hrColorStyle
-      }
+      style={hrStyle}
     />
   )
 }

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -278,13 +278,12 @@ const Header = ({
             hasOverviewNav={hasOverviewNav}
             isSecondarySticky={headerOffset === -headerHeightState}
           />
-          <HLine
-            isHeaderFullyScrolledAway={headerOffset === -headerHeightState}
-            secondaryNav={secondaryNav}
-            hasOverviewNav={hasOverviewNav}
-            formatColor={formatColor}
-            dark={dark}
-          />
+          {formatColor ||
+          secondaryNav ||
+          hasOverviewNav ||
+          headerOffset !== -headerHeightState ? (
+            <HLine formatColor={formatColor} dark={dark} />
+          ) : null}
         </div>
         <Popover formatColor={formatColor} expanded={expandedNav === 'main'}>
           <NavPopover

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -278,7 +278,13 @@ const Header = ({
             hasOverviewNav={hasOverviewNav}
             isSecondarySticky={headerOffset === -headerHeightState}
           />
-          <HLine formatColor={formatColor} dark={dark} />
+          <HLine
+            isHeaderFullyScrolledAway={headerOffset === -headerHeightState}
+            secondaryNav={secondaryNav}
+            hasOverviewNav={hasOverviewNav}
+            formatColor={formatColor}
+            dark={dark}
+          />
         </div>
         <Popover formatColor={formatColor} expanded={expandedNav === 'main'}>
           <NavPopover

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -22,6 +22,7 @@ const Nav = ({
   closeHandler,
   t,
   inNativeApp,
+  inIOS,
   inNativeIOSApp,
   isMember,
   onSearchSubmit
@@ -107,13 +108,10 @@ const Nav = ({
             <div {...styles.navSection}>
               <div
                 {...styles.navLinks}
-                {...css({
+                style={{
                   // ensures last item is visible in iOS safari
-                  marginBottom: inNativeApp ? 24 : 64,
-                  [mediaQueries.mUp]: {
-                    marginBottom: 24
-                  }
-                })}
+                  marginBottom: inIOS && !inNativeApp ? 64 : 24
+                }}
               >
                 <NavLink
                   inline

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -108,6 +108,7 @@ const Nav = ({
               <div
                 {...styles.navLinks}
                 {...css({
+                  // ensures last item is visible in iOS safari
                   marginBottom: inNativeApp ? 24 : 64,
                   [mediaQueries.mUp]: {
                     marginBottom: 24

--- a/components/Frame/Popover/Nav.js
+++ b/components/Frame/Popover/Nav.js
@@ -105,7 +105,15 @@ const Nav = ({
             </div>
             <hr {...styles.hr} />
             <div {...styles.navSection}>
-              <div {...styles.navLinks}>
+              <div
+                {...styles.navLinks}
+                {...css({
+                  marginBottom: inNativeApp ? 24 : 64,
+                  [mediaQueries.mUp]: {
+                    marginBottom: 24
+                  }
+                })}
+              >
                 <NavLink
                   inline
                   large


### PR DESCRIPTION
To specify, this increases the bottom margin of the last element of the nav for all mobile browsers, but not native (as no danger of UI elements overlapping there)

After
![IMG_1860](https://user-images.githubusercontent.com/20746301/87804847-bbb17a00-c854-11ea-9436-74901f92cedc.PNG)

Before
![IMG_5344DD8C0DC3-1](https://user-images.githubusercontent.com/20746301/87804852-bce2a700-c854-11ea-8004-8c5eb0bd9c0d.jpeg)
