### PR TITLE
Hides NavBar on Magazine page

### DIFF
--- a/components/ActionBar/Article.js
+++ b/components/ActionBar/Article.js
@@ -3,9 +3,24 @@ import PropTypes from 'prop-types'
 import ActionBar from './'
 import DiscussionIconLink from '../Discussion/IconLink'
 import { getDiscussionIconLinkProps } from './utils'
+import { css } from 'glamor'
 
 import { fontStyles, plainButtonRule } from '@project-r/styleguide'
 import ShareButtons from './ShareButtons'
+
+const styles = {
+  grandSharing: css({
+    marginBottom: 20,
+    marginTop: 20,
+    '@media print': {
+      display: 'none'
+    }
+  }),
+  grandSharingTitle: css({
+    marginBottom: 0,
+    ...fontStyles.sansSerifMedium16
+  })
+}
 
 const ArticleActionBar = (
   {
@@ -102,10 +117,8 @@ const ArticleActionBar = (
         />
       )}
       {!!grandSharing && (
-        <div style={{ marginBottom: 20, marginTop: 20 }}>
-          <h3 style={{ marginBottom: 0, ...fontStyles.sansSerifMedium16 }}>
-            {t('article/share/title')}
-          </h3>
+        <div {...styles.grandSharing}>
+          <h3 {...styles.grandSharingTitle}>{t('article/share/title')}</h3>
           <ShareButtons
             url={url}
             pocket

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -644,6 +644,7 @@ class ArticlePage extends Component {
         secondaryNav={seriesNavButton}
         formatColor={formatColor}
         hasOverviewNav={hasOverviewNav}
+        stickySecondaryNav={hasOverviewNav}
       >
         <Loader
           loading={data.loading}

--- a/components/Feed/index.js
+++ b/components/Feed/index.js
@@ -104,7 +104,7 @@ const Feed = ({
   }, [subscribeToMore])
 
   return (
-    <Frame hasOverviewNav raw meta={meta}>
+    <Frame hasOverviewNav stickySecondaryNav raw meta={meta}>
       <Center {...styles.container}>
         <Loader
           error={error}

--- a/components/Feedback/Page.js
+++ b/components/Feedback/Page.js
@@ -85,6 +85,7 @@ const FeedbackPage = props => {
       raw
       meta={pageMeta}
       formatColor={colors.primary}
+      stickySecondaryNav={!tab}
     >
       <FontSizeSync />
       <Center {...styles.container}>

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -54,7 +54,8 @@ const Header = ({
   pullable = true,
   hasOverviewNav,
   children,
-  cover
+  cover,
+  stickySecondaryNav
 }) => {
   const [isAnyNavExpanded, setIsAnyNavExpanded] = useState(false)
   const [expandedNav, setExpandedNav] = useState(null)
@@ -179,13 +180,18 @@ const Header = ({
     ]
   }, [hasOverviewNav, secondaryNav, headerOffset])
 
+  const navBarSecondaryHeight = stickySecondaryNav ? 0 : SUBHEADER_HEIGHT
+
   return (
     <HeaderHeightProvider config={headerConfig}>
       <ColorContext.Provider value={dark ? colors.negative : colors}>
         <div
           {...styles.navBar}
           style={{
-            backgroundColor: dark ? colors.negative.primaryBg : '#fff'
+            backgroundColor: dark ? colors.negative.primaryBg : '#fff',
+            height: isMobile
+              ? HEADER_HEIGHT_MOBILE + navBarSecondaryHeight
+              : HEADER_HEIGHT + navBarSecondaryHeight
           }}
           ref={fixedRef}
         >
@@ -340,15 +346,11 @@ export default compose(
 
 const styles = {
   navBar: css({
-    height: HEADER_HEIGHT_MOBILE,
     zIndex: ZINDEX_POPOVER + 1,
     position: 'fixed',
     top: 0,
     left: 0,
     right: 0,
-    [mediaQueries.mUp]: {
-      height: HEADER_HEIGHT
-    },
     '@media print': {
       position: 'absolute'
     }

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -60,14 +60,15 @@ const Header = ({
   const [isAnyNavExpanded, setIsAnyNavExpanded] = useState(false)
   const [expandedNav, setExpandedNav] = useState(null)
   const [isMobile, setIsMobile] = useState()
-  const [headerHeightState, setHeaderHeightState] = useState()
+  const [scrollableHeaderHeight, setScrollableHeaderHeight] = useState(
+    HEADER_HEIGHT_MOBILE
+  )
   const [headerOffset, setHeaderOffset] = useState(0)
   const [userNavExpanded, setUserNavExpanded] = useState(false)
 
   const fixedRef = useRef()
   const diff = useRef(0)
   const lastY = useRef()
-  const headerHeight = useRef()
   const lastDiff = useRef()
 
   const dark = darkProp && !isAnyNavExpanded
@@ -125,7 +126,7 @@ const Header = ({
         const newDiff = lastY.current ? lastY.current - y : 0
         diff.current += newDiff
         diff.current = Math.min(
-          Math.max(-headerHeight.current, diff.current),
+          Math.max(-scrollableHeaderHeight, diff.current),
           0
         )
       }
@@ -144,11 +145,6 @@ const Header = ({
       if (mobile !== isMobile) {
         setIsMobile(mobile)
       }
-      const { height } = fixedRef.current.getBoundingClientRect()
-      headerHeight.current = height
-      if (height !== headerHeightState) {
-        setHeaderHeightState(height)
-      }
       onScroll()
     }
 
@@ -159,28 +155,37 @@ const Header = ({
       window.removeEventListener('scroll', onScroll)
       window.removeEventListener('resize', measure)
     }
-  }, [isAnyNavExpanded, headerHeightState, isMobile])
+  }, [isAnyNavExpanded, scrollableHeaderHeight, isMobile])
 
+  const hasSecondaryNav = hasOverviewNav || secondaryNav
   const headerConfig = useMemo(() => {
     return [
       {
         minWidth: 0,
         headerHeight:
           HEADER_HEIGHT_MOBILE +
-          (hasOverviewNav || secondaryNav ? SUBHEADER_HEIGHT : 0) +
+          (hasSecondaryNav ? SUBHEADER_HEIGHT : 0) +
           headerOffset
       },
       {
         minWidth: mediaQueries.mBreakPoint,
         headerHeight:
           HEADER_HEIGHT +
-          (hasOverviewNav || secondaryNav ? SUBHEADER_HEIGHT : 0) +
+          (hasSecondaryNav ? SUBHEADER_HEIGHT : 0) +
           headerOffset
       }
     ]
-  }, [hasOverviewNav, secondaryNav, headerOffset])
+  }, [hasSecondaryNav, headerOffset])
 
-  const navBarSecondaryHeight = stickySecondaryNav ? 0 : SUBHEADER_HEIGHT
+  const hasStickySecondary = hasSecondaryNav && stickySecondaryNav
+  useEffect(() => {
+    setScrollableHeaderHeight(
+      (isMobile ? HEADER_HEIGHT_MOBILE : HEADER_HEIGHT) +
+        (hasSecondaryNav && !hasStickySecondary ? SUBHEADER_HEIGHT : 0) +
+        // scroll away thin HLine
+        (formatColor || hasStickySecondary ? 0 : 1)
+    )
+  }, [isMobile, hasSecondaryNav, hasStickySecondary, formatColor])
 
   return (
     <HeaderHeightProvider config={headerConfig}>
@@ -188,10 +193,7 @@ const Header = ({
         <div
           {...styles.navBar}
           style={{
-            backgroundColor: dark ? colors.negative.primaryBg : '#fff',
-            height: isMobile
-              ? HEADER_HEIGHT_MOBILE + navBarSecondaryHeight
-              : HEADER_HEIGHT + navBarSecondaryHeight
+            backgroundColor: dark ? colors.negative.primaryBg : '#fff'
           }}
           ref={fixedRef}
         >
@@ -262,7 +264,6 @@ const Header = ({
                 <Toggle
                   expanded={isAnyNavExpanded}
                   dark={dark}
-                  size={28}
                   title={t(
                     `header/nav/${
                       expandedNav === 'main' ? 'close' : 'open'
@@ -282,14 +283,9 @@ const Header = ({
             dark={dark}
             formatColor={formatColor}
             hasOverviewNav={hasOverviewNav}
-            isSecondarySticky={headerOffset === -headerHeightState}
+            isSecondarySticky={headerOffset === -scrollableHeaderHeight}
           />
-          {formatColor ||
-          secondaryNav ||
-          hasOverviewNav ||
-          headerOffset !== -headerHeightState ? (
-            <HLine formatColor={formatColor} dark={dark} />
-          ) : null}
+          <HLine formatColor={formatColor} dark={dark} />
         </div>
         <Popover formatColor={formatColor} expanded={expandedNav === 'main'}>
           <NavPopover
@@ -346,6 +342,10 @@ export default compose(
 
 const styles = {
   navBar: css({
+    height: HEADER_HEIGHT_MOBILE,
+    [mediaQueries.mUp]: {
+      height: HEADER_HEIGHT
+    },
     zIndex: ZINDEX_POPOVER + 1,
     position: 'fixed',
     top: 0,

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -374,14 +374,7 @@ const styles = {
     marginLeft: 'auto',
     width: '100%',
     display: 'flex',
-    justifyContent: 'flex-end',
-    height: HEADER_HEIGHT_MOBILE,
-    [mediaQueries.mUp]: {
-      height: HEADER_HEIGHT
-    },
-    '@media print': {
-      display: 'none'
-    }
+    justifyContent: 'flex-end'
   }),
   back: css({
     display: 'block',

--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -374,7 +374,10 @@ const styles = {
     marginLeft: 'auto',
     width: '100%',
     display: 'flex',
-    justifyContent: 'flex-end'
+    justifyContent: 'flex-end',
+    '@media print': {
+      display: 'none'
+    }
   }),
   back: css({
     display: 'block',

--- a/components/Frame/SecondaryNav.js
+++ b/components/Frame/SecondaryNav.js
@@ -190,6 +190,9 @@ const styles = {
           paddingRight: 0
         }
       }
+    },
+    '@media print': {
+      display: 'none'
     }
   }),
   linkItem: css({

--- a/components/Frame/Toggle.js
+++ b/components/Frame/Toggle.js
@@ -11,7 +11,9 @@ import {
   TRANSITION_MS
 } from '../constants'
 
-const ToggleNew = ({ dark, size, expanded, ...props }) => {
+const SIZE = 28
+
+const Toggle = ({ dark, expanded, ...props }) => {
   return (
     <div {...styles.menuToggle} {...props}>
       <SearchMenuIcon
@@ -20,12 +22,12 @@ const ToggleNew = ({ dark, size, expanded, ...props }) => {
           transition: `opacity ${TRANSITION_MS}ms ease-out`
         }}
         fill={dark ? colors.negative.text : colors.text}
-        size={size}
+        size={SIZE}
       />
       <MdClose
         style={{ opacity: expanded ? 1 : 0 }}
         {...styles.closeButton}
-        size={size}
+        size={SIZE}
         fill={dark ? colors.negative.text : colors.text}
       />
     </div>
@@ -40,10 +42,11 @@ const styles = {
     border: 'none',
     boxShadow: 'none',
     outline: 'none',
-    padding: `${Math.floor((HEADER_HEIGHT_MOBILE - 24) / 2)}px`,
+    padding: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
     paddingRight: 16,
+    lineHeight: 0,
     [mediaQueries.mUp]: {
-      padding: `${Math.floor((HEADER_HEIGHT - 24) / 2)}px`
+      padding: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`
     }
   }),
   closeButton: css({
@@ -57,4 +60,4 @@ const styles = {
   })
 }
 
-export default ToggleNew
+export default Toggle

--- a/components/Frame/index.js
+++ b/components/Frame/index.js
@@ -96,7 +96,8 @@ const Index = ({
   pullable,
   dark,
   isMember,
-  hasOverviewNav: wantOverviewNav
+  hasOverviewNav: wantOverviewNav,
+  stickySecondaryNav
 }) => {
   const hasOverviewNav = isMember && wantOverviewNav
   const hasSecondaryNav = !!(secondaryNav || hasOverviewNav)
@@ -139,6 +140,7 @@ const Index = ({
             formatColor={formatColor}
             pullable={pullable}
             hasOverviewNav={hasOverviewNav}
+            stickySecondaryNav={stickySecondaryNav}
           >
             <noscript>
               <Box style={{ padding: 30 }}>

--- a/pages/feed.js
+++ b/pages/feed.js
@@ -16,8 +16,4 @@ const FeedPage = ({ me, t }) => {
   return <Feed meta={meta} />
 }
 
-export default compose(
-  enforceMembership(),
-  withMe,
-  withT
-)(FeedPage)
+export default compose(enforceMembership(), withMe, withT)(FeedPage)

--- a/pages/sections.js
+++ b/pages/sections.js
@@ -16,7 +16,7 @@ const FormatsPage = ({ t }) => {
     image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`
   }
   return (
-    <Frame hasOverviewNav={true} raw meta={meta}>
+    <Frame hasOverviewNav stickySecondaryNav raw meta={meta}>
       <Center style={{ marginTop: 20, marginBottom: 60 }}>
         <Index />
       </Center>

--- a/pages/sections.js
+++ b/pages/sections.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { compose } from 'react-apollo'
 import Frame from '../components/Frame'
 import Index from '../components/Sections/Index'
-import { enforceMembership } from '../components/Auth/withMembership'
 import withT from '../lib/withT'
 
 import { CDN_FRONTEND_BASE_URL } from '../lib/constants'
@@ -24,7 +23,4 @@ const FormatsPage = ({ t }) => {
   )
 }
 
-export default compose(
-  // enforceMembership(),
-  withT
-)(FormatsPage)
+export default compose(withT)(FormatsPage)


### PR DESCRIPTION
Previously, the secondary nav bar would remain sticky after scroll. With this PR it only does so if the prop stickySecondaryNav is provided.