### PR TITLE
adds mobile label to userprogress: increase visibility of

### DIFF
--- a/components/ActionBar/UserProgress.js
+++ b/components/ActionBar/UserProgress.js
@@ -100,7 +100,13 @@ const UserProgress = (
                 percent: `${percent}%`
               })
         }
-        labelShort={`${percent}%`}
+        labelShort={
+          forceShortLabel
+            ? `${percent}%`
+            : t('progress/restore/titleShort', {
+                percent: `${percent}%`
+              })
+        }
         style={{ marginRight: 10 }}
       />
       {noCallout ? (

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-08-27T14:42:02.253Z",
+  "updated": "2020-08-28T13:03:40.575Z",
   "title": "live",
   "data": [
     {
@@ -3037,6 +3037,10 @@
     {
       "key": "progress/restore/title",
       "value": "Zu Ihrer Leseposition: {percent}"
+    },
+    {
+      "key": "progress/restore/titleShort",
+      "value": "Weiterlesen: {percent}"
     },
     {
       "key": "progress/restore/close",


### PR DESCRIPTION
before:
![Screenshot 2020-08-28 at 15 07 03](https://user-images.githubusercontent.com/20746301/91564000-31befb80-e940-11ea-8177-f488938c6040.jpg)

after:
![Screenshot 2020-08-28 at 15 04 43](https://user-images.githubusercontent.com/20746301/91564011-371c4600-e940-11ea-9c90-461838fb9e35.jpg)
