### PR TITLE
fixes time being displayed wrong

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -141,12 +141,13 @@ const ActionBar = ({
 
   const { toggleAudioPlayer } = useContext(AudioContext)
 
-  const displayMinutes = Math.max(
+  const readingMinutes = Math.max(
     meta.estimatedConsumptionMinutes,
     meta.estimatedReadingMinutes
   )
-  const displayHours = Math.floor(displayMinutes / 60)
 
+  const displayMinutes = readingMinutes % 60
+  const displayHours = Math.floor(readingMinutes / 60)
   const forceShortLabel = mode === 'article-overlay' || mode === 'feed'
 
   // centering


### PR DESCRIPTION
Forgot modulus on reading minutes when creating new ActionBar.

before
![Screenshot 2020-09-11 at 09 25 48](https://user-images.githubusercontent.com/20746301/92883131-e19c6a80-f410-11ea-8382-1f6cedcf34f7.jpg)

after
![Screenshot 2020-09-11 at 09 24 07](https://user-images.githubusercontent.com/20746301/92883144-e4975b00-f410-11ea-8ab3-7db4fafa3d04.jpg)

