### PR TITLE
fixes an error where key props where not unique due to titles missing

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -257,6 +257,7 @@ const ActionBar = ({
       show: true
     },
     {
+      title: t('PodcastButtons/play'),
       Icon: MdPlayCircleOutline,
       onClick: e => {
         e.preventDefault()
@@ -344,6 +345,7 @@ const ActionBar = ({
       show: (document.userProgress && displayMinutes > 1) || !podcast
     },
     {
+      title: t('PodcastButtons/play'),
       Icon: MdPlayCircleOutline,
       onClick: e => {
         e.preventDefault()
@@ -358,6 +360,7 @@ const ActionBar = ({
       show: !!meta.audioSource
     },
     {
+      title: t('PodcastButtons/title'),
       Icon: MdMic,
       onClick: e => {
         e.preventDefault()


### PR DESCRIPTION
Fixes an error on the ActionBar, where not every ActionBarItem had a title, which resulted in non-unique key props on the mappings:

![Screenshot 2020-09-11 at 09 34 09](https://user-images.githubusercontent.com/20746301/92884398-1b21a580-f412-11ea-8406-ddd1a0e63175.jpg)
