### PR TITLE
make regular nav clickable and add uniq title for user nav

### DIFF
--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -234,7 +234,7 @@ const Header = ({
                   isMobile={isMobile}
                   id='user'
                   title={t(
-                    `header/nav/${
+                    `header/nav/user/${
                       expandedNav === 'user' ? 'close' : 'open'
                     }/aria`
                   )}

--- a/components/Frame/Toggle.js
+++ b/components/Frame/Toggle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { MdClose } from 'react-icons/md'
 import SearchMenuIcon from '../Icons/SearchMenu'
-import { colors, mediaQueries } from '@project-r/styleguide'
+import { colors, mediaQueries, plainButtonRule } from '@project-r/styleguide'
 import { css } from 'glamor'
 
 import {
@@ -13,9 +13,9 @@ import {
 
 const SIZE = 28
 
-const Toggle = ({ dark, expanded, ...props }) => {
+const Toggle = ({ dark, expanded, onClick, ...props }) => {
   return (
-    <div {...styles.menuToggle} {...props}>
+    <button {...styles.menuToggle} onClick={onClick} {...props}>
       <SearchMenuIcon
         style={{
           opacity: expanded ? 0 : 1,
@@ -30,12 +30,12 @@ const Toggle = ({ dark, expanded, ...props }) => {
         size={SIZE}
         fill={dark ? colors.negative.text : colors.text}
       />
-    </div>
+    </button>
   )
 }
 
 const styles = {
-  menuToggle: css({
+  menuToggle: css(plainButtonRule, {
     cursor: 'pointer',
     zIndex: ZINDEX_FRAME_TOGGLE,
     backgroundColor: 'transparent',

--- a/components/Frame/User.js
+++ b/components/Frame/User.js
@@ -31,15 +31,13 @@ const getInitials = me =>
 const User = ({ t, me, title, dark, backButton, onClick, isMobile }) => {
   const color = dark ? colors.negative.text : colors.text
   return (
-    <button {...styles.user} onClick={onClick}>
+    <button {...styles.user} onClick={onClick} title={title}>
       <span
         {...styles.button}
         style={{
           color,
           paddingLeft: backButton ? BUTTON_PADDING_MOBILE / 2 : 16
         }}
-        role='button'
-        title={title}
       >
         {me &&
           (me.portrait ? (

--- a/components/Frame/User.js
+++ b/components/Frame/User.js
@@ -1,6 +1,11 @@
 import React, { Fragment } from 'react'
 import { css } from 'glamor'
-import { colors, mediaQueries, fontStyles } from '@project-r/styleguide'
+import {
+  colors,
+  mediaQueries,
+  fontStyles,
+  plainButtonRule
+} from '@project-r/styleguide'
 import { HEADER_HEIGHT, HEADER_HEIGHT_MOBILE } from '../constants'
 import { MdAccountBox } from 'react-icons/md'
 import withT from '../../lib/withT'
@@ -26,8 +31,8 @@ const getInitials = me =>
 const User = ({ t, me, title, dark, backButton, onClick, isMobile }) => {
   const color = dark ? colors.negative.text : colors.text
   return (
-    <div {...styles.user} onClick={onClick} role='button'>
-      <div
+    <button {...styles.user} onClick={onClick}>
+      <span
         {...styles.button}
         style={{
           color,
@@ -61,13 +66,13 @@ const User = ({ t, me, title, dark, backButton, onClick, isMobile }) => {
             <span {...styles.label}>{t('header/signin')}</span>
           </Fragment>
         )}
-      </div>
-    </div>
+      </span>
+    </button>
   )
 }
 
 const styles = {
-  user: css({
+  user: css(plainButtonRule, {
     cursor: 'pointer',
     opacity: 'inherit',
     textAlign: 'left',

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-09-04T16:23:13.312Z",
+  "updated": "2020-09-11T20:44:06.366Z",
   "title": "live",
   "data": [
     {
@@ -1401,6 +1401,14 @@
     {
       "key": "header/nav/close/aria",
       "value": "Navigation schliessen"
+    },
+    {
+      "key": "header/nav/user/open/aria",
+      "value": "Meine Republik öffnen"
+    },
+    {
+      "key": "header/nav/user/close/aria",
+      "value": "Meine Republik schliessen"
     },
     {
       "key": "header/nav/search/aria",


### PR DESCRIPTION
Currently the `onClick` handler for opening the nav overlays are divs. And in the main nav case even without `role='button'`.

<img width="1170" alt="Screenshot 2020-09-11 at 22 47 12" src="https://user-images.githubusercontent.com/410211/92971499-d6812300-f480-11ea-9804-998d980bfba2.png">
<img width="1170" alt="Screenshot 2020-09-11 at 22 47 28" src="https://user-images.githubusercontent.com/410211/92971504-d97c1380-f480-11ea-89d5-81a913c3f3e2.png">

This PR uses real button elements, hopefully making the nav more accessible, and also ensuring that both navs have a distinguishable title on the clickable element.

Also fixes our end to end test for navigation which assumes a button 😄 

https://github.com/orbiting/republik-tests/blob/77d64a39425e41d110b38c75520d92ffce0d1295/tests/navigation.js#L7-L16