### PR TITLE
Page template

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -130,6 +130,7 @@ const ActionBar = ({
     (meta && meta.podcast) ||
     (meta && meta.audioSource && meta.format && meta.format.meta.podcast)
   const hasPdf = meta && meta.template === 'article'
+  const notBookmarkable = meta && meta.template === 'staticPage'
   const isDiscussion = meta && meta.template === 'discussion'
   const emailSubject = t('article/share/emailSubject', {
     title: document.meta.title
@@ -264,7 +265,7 @@ const ActionBar = ({
         'feed',
         'bookmark'
       ],
-      show: true
+      show: !notBookmarkable
     },
     {
       title: t('PodcastButtons/play'),

--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -130,7 +130,7 @@ const ActionBar = ({
     (meta && meta.podcast) ||
     (meta && meta.audioSource && meta.format && meta.format.meta.podcast)
   const hasPdf = meta && meta.template === 'article'
-  const notBookmarkable = meta && meta.template === 'staticPage'
+  const notBookmarkable = meta && meta.template === 'page'
   const isDiscussion = meta && meta.template === 'discussion'
   const emailSubject = t('article/share/emailSubject', {
     title: document.meta.title

--- a/components/ActionBar/utils.js
+++ b/components/ActionBar/utils.js
@@ -8,7 +8,7 @@ export const getDiscussionLinkProps = (
 ) => {
   const isLinkedDiscussion =
     linkedDiscussion &&
-    template === 'article' &&
+    (template === 'article' || template === 'staticPage') &&
     (!linkedDiscussion.closed ||
       (linkedDiscussion.comments && linkedDiscussion.comments.totalCount > 0))
   const isOwnDiscussion =

--- a/components/ActionBar/utils.js
+++ b/components/ActionBar/utils.js
@@ -8,7 +8,7 @@ export const getDiscussionLinkProps = (
 ) => {
   const isLinkedDiscussion =
     linkedDiscussion &&
-    (template === 'article' || template === 'staticPage') &&
+    (template === 'article' || template === 'page') &&
     (!linkedDiscussion.closed ||
       (linkedDiscussion.comments && linkedDiscussion.comments.totalCount > 0))
   const isOwnDiscussion =

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -215,7 +215,8 @@ const ArticlePage = ({
   const documentId = useMemo(() => article && article?.id, [article])
   const repoId = useMemo(() => article && article.repoId, [article])
   const isEditorialNewsletter = meta && meta.template === 'editorialNewsletter'
-  const actionBar = article && (
+  const disableActionBar = meta && meta.disableActionBar
+  const actionBar = article && !disableActionBar && (
     <ActionBar mode='article-top' document={article} />
   )
   const actionBarEnd = actionBar

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -23,7 +23,7 @@ import createDossierSchema from '@project-r/styleguide/lib/templates/Dossier'
 import createDiscussionSchema from '@project-r/styleguide/lib/templates/Discussion'
 import createNewsletterSchema from '@project-r/styleguide/lib/templates/EditorialNewsletter/web'
 import createSectionSchema from '@project-r/styleguide/lib/templates/Section'
-import createStaticPageSchema from '@project-r/styleguide/lib/templates/StaticPage'
+import createPageSchema from '@project-r/styleguide/lib/templates/Page'
 import { Breakout } from '@project-r/styleguide/lib/components/Center'
 
 import ActionBarOverlay from './ActionBarOverlay'
@@ -74,7 +74,7 @@ const schemaCreators = {
   discussion: createDiscussionSchema,
   editorialNewsletter: createNewsletterSchema,
   section: createSectionSchema,
-  staticPage: createStaticPageSchema
+  page: createPageSchema
 }
 
 const dynamicComponentRequire = createRequire().alias({

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -23,6 +23,7 @@ import createDossierSchema from '@project-r/styleguide/lib/templates/Dossier'
 import createDiscussionSchema from '@project-r/styleguide/lib/templates/Discussion'
 import createNewsletterSchema from '@project-r/styleguide/lib/templates/EditorialNewsletter/web'
 import createSectionSchema from '@project-r/styleguide/lib/templates/Section'
+import createStaticPageSchema from '@project-r/styleguide/lib/templates/StaticPage'
 import { Breakout } from '@project-r/styleguide/lib/components/Center'
 
 import ActionBarOverlay from './ActionBarOverlay'
@@ -72,7 +73,8 @@ const schemaCreators = {
   dossier: createDossierSchema,
   discussion: createDiscussionSchema,
   editorialNewsletter: createNewsletterSchema,
-  section: createSectionSchema
+  section: createSectionSchema,
+  staticPage: createStaticPageSchema
 }
 
 const dynamicComponentRequire = createRequire().alias({

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -365,6 +365,12 @@ const ArticlePage = ({
 
           const format = meta.format
 
+          const showNewsletterSignup =
+            !me &&
+            isEditorialNewsletter &&
+            !!newsletterMeta &&
+            newsletterMeta.free
+
           return (
             <>
               <FontSizeSync />
@@ -411,36 +417,37 @@ const ArticlePage = ({
                             </Editorial.Credit>
                           </TitleBlock>
                         )}
-                        <Center>
-                          <div
-                            ref={actionBarRef}
-                            {...styles.actionBarContainer}
-                            style={{
-                              textAlign: titleAlign,
-                              marginBottom: isEditorialNewsletter
-                                ? 0
-                                : undefined
-                            }}
-                          >
-                            {actionBar}
-                          </div>
-                          {isSection && (
-                            <Breakout size='breakout'>
-                              <SectionNav
-                                color={sectionColor}
-                                linkedDocuments={article.linkedDocuments}
-                              />
-                            </Breakout>
-                          )}
-                          {!me &&
-                            isEditorialNewsletter &&
-                            !!newsletterMeta &&
-                            newsletterMeta.free && (
+                        {(actionBar || isSection || showNewsletterSignup) && (
+                          <Center>
+                            {actionBar && (
+                              <div
+                                ref={actionBarRef}
+                                {...styles.actionBarContainer}
+                                style={{
+                                  textAlign: titleAlign,
+                                  marginBottom: isEditorialNewsletter
+                                    ? 0
+                                    : undefined
+                                }}
+                              >
+                                {actionBar}
+                              </div>
+                            )}
+                            {isSection && (
+                              <Breakout size='breakout'>
+                                <SectionNav
+                                  color={sectionColor}
+                                  linkedDocuments={article.linkedDocuments}
+                                />
+                              </Breakout>
+                            )}
+                            {showNewsletterSignup && (
                               <div style={{ marginTop: 10 }}>
                                 <NewsletterSignUp {...newsletterMeta} />
                               </div>
                             )}
-                        </Center>
+                          </Center>
+                        )}
                         {!suppressFirstPayNote && payNote}
                       </div>
                     )}

--- a/components/Article/Progress/datetime.js
+++ b/components/Article/Progress/datetime.js
@@ -10,7 +10,7 @@ const getLastMidnight = () => {
   return today
 }
 
-export default (
+const DateTime = (
   t,
   date,
   baseKey = 'progress',
@@ -33,3 +33,4 @@ export default (
     time: displayTime
   })
 }
+export default DateTime

--- a/components/Article/graphql/getDocument.js
+++ b/components/Article/graphql/getDocument.js
@@ -135,6 +135,7 @@ export const getDocument = gql`
           name
           free
         }
+        disableActionBar
         estimatedReadingMinutes
         estimatedConsumptionMinutes
         indicateGallery

--- a/components/ErrorMessage.js
+++ b/components/ErrorMessage.js
@@ -5,8 +5,10 @@ import { Interaction, colors } from '@project-r/styleguide'
 
 const { P } = Interaction
 
-export default ({ error, style }) => (
+const ErrorMessage = ({ error, style }) => (
   <P style={{ color: colors.error, margin: '20px 0', ...style }}>
     {errorToString(error)}
   </P>
 )
+
+export default ErrorMessage

--- a/components/Frame/Meta.js
+++ b/components/Frame/Meta.js
@@ -5,7 +5,7 @@ import { imageSizeInfo, imageResizeUrl } from 'mdast-react-render/lib/utils'
 
 import { CDN_FRONTEND_BASE_URL } from '../../lib/constants'
 
-export default ({ data, data: { url, image } }) => {
+const Meta = ({ data, data: { url, image } }) => {
   const title = data.pageTitle || `${data.title} – Republik`
 
   // to prevent facebook from using a random image from the website we fall back to a square avatar and claim it's below 315px in size to trigger the small image layout
@@ -59,3 +59,5 @@ export default ({ data, data: { url, image } }) => {
     </Head>
   )
 }
+
+export default Meta

--- a/components/Icons/MdInsertChartOutlined.js
+++ b/components/Icons/MdInsertChartOutlined.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default ({ size = 24, fill }) => (
+const Icon = ({ size = 24, fill }) => (
   <svg width={size} height={size} viewBox='0 0 24 24'>
     <path
       fill={fill}
@@ -8,3 +8,4 @@ export default ({ size = 24, fill }) => (
     />
   </svg>
 )
+export default Icon

--- a/components/Link/Path.js
+++ b/components/Link/Path.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { matchPath, Link } from '../../lib/routes'
 import AreaLink from './Area'
 
-export default ({ path, query = {}, passHref, replace, scroll, children }) => {
+const Path = ({ path, query = {}, passHref, replace, scroll, children }) => {
   const result = matchPath(path)
   if (result) {
     const Component = passHref ? Link : AreaLink
@@ -22,3 +22,4 @@ export default ({ path, query = {}, passHref, replace, scroll, children }) => {
   // unrecognized links are handled by regular a tags
   return children
 }
+export default Path

--- a/components/Search/withSearchRouter.js
+++ b/components/Search/withSearchRouter.js
@@ -13,7 +13,7 @@ const FILTER_VALUE_PARAM = 'fvalue'
 const SORT_KEY_PARAM = 'skey'
 const SORT_DIRECTION_PARAM = 'sdir'
 
-export default WrappedComponent =>
+const WrapperRouter = WrappedComponent =>
   compose(withRouter)(({ router: { query }, ...props }) => {
     const urlQuery = query[QUERY_PARAM]
     const urlFilter = {
@@ -117,3 +117,5 @@ export default WrappedComponent =>
       />
     )
   })
+
+export default WrapperRouter

--- a/package-lock.json
+++ b/package-lock.json
@@ -2620,9 +2620,9 @@
       "integrity": "sha512-A19z/E6f08RXfBRc2STQ+5qo7iSPif7mNcww9dZAVli3Idu4umGP5dbpL71Hz1vyRs1eMUEylXTpXsY2WzY07g=="
     },
     "@project-r/styleguide": {
-      "version": "9.31.3",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-9.31.3.tgz",
-      "integrity": "sha512-4XbifiXazH3i94dbXvNURp7IX2Z8vgDoVCAM7vc1BMwzkZTp+laLRXy8yoH4HxPRQ4klDNTTvIujyP2xGQ+Jcg==",
+      "version": "9.32.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-9.32.0.tgz",
+      "integrity": "sha512-Crr32GVoRqsm3EAO8FsQPvNwtOzyWo4jK4HaPq/tlMln5rsE71tjsyrDvPYKFLWHUUzWQpICzThNpwGKsjidQw==",
       "requires": {
         "body-scroll-lock": "3.0.3",
         "react-icons": "^2.2.7"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "@next/bundle-analyzer": "^9.5.1",
-    "@project-r/styleguide": "^9.31.3",
+    "@project-r/styleguide": "^9.32.0",
     "@use-it/event-listener": "^0.1.5",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",


### PR DESCRIPTION
(This PR also gets rid on some of those "unnamed export" warnings)

<img width="1699" alt="Screenshot 2020-10-08 at 10 15 26" src="https://user-images.githubusercontent.com/3907984/95432663-40d99600-094f-11eb-9f18-38db453f818a.png">

### features

- interaction font for head & subhead
- routing from root (e.g. republik.ch/example-page)
- optional credits
- optional action bar
- title centered by default
- not in feed by default