### PR TITLE
Activates darkmode for bookmark and notifications pages

### DIFF
--- a/components/Bookmarks/Page.js
+++ b/components/Bookmarks/Page.js
@@ -66,6 +66,7 @@ const Page = ({ t, me }) => {
         title: t('nav/bookmarks')
       }}
       raw
+      colorSchemeKey='auto'
     >
       <Center style={{ marginBottom: 56 }}>
         <div {...styles.title}>{t('pages/bookmarks/title')}</div>

--- a/pages/subscriptions.js
+++ b/pages/subscriptions.js
@@ -15,7 +15,7 @@ const NotificationsPage = ({ t, me }) => {
     image: `${CDN_FRONTEND_BASE_URL}/static/social-media/logo.png`
   }
   return (
-    <Frame raw={!!me} meta={meta}>
+    <Frame raw={!!me} meta={meta} colorSchemeKey='auto'>
       {me ? (
         <Notifications />
       ) : (


### PR DESCRIPTION
As both of them rely on TeaserFeed, which is fully transitioned, they both work in darkmode out of the box:
![Screenshot 2020-11-05 at 13 39 01](https://user-images.githubusercontent.com/20746301/98242210-65d02180-1f6c-11eb-982c-3cd850cd1b4a.jpg)
![Screenshot 2020-11-05 at 13 39 14](https://user-images.githubusercontent.com/20746301/98242217-68327b80-1f6c-11eb-82b7-ba30f59a3cf5.jpg)
