### PR TITLE
enforce address in vote box

### DIFF
--- a/components/ErrorMessage.js
+++ b/components/ErrorMessage.js
@@ -1,14 +1,22 @@
 import React from 'react'
 import { errorToString } from '../lib/utils/errors'
 
-import { Interaction, colors } from '@project-r/styleguide'
+import { useColorContext, Interaction } from '@project-r/styleguide'
 
 const { P } = Interaction
 
-const ErrorMessage = ({ error, style }) => (
-  <P style={{ color: colors.error, margin: '20px 0', ...style }}>
-    {errorToString(error)}
-  </P>
-)
+export const ErrorContainer = ({ children }) => {
+  const [colorScheme] = useColorContext()
+  return <div {...colorScheme.set('color', 'error')}>{children}</div>
+}
+
+const ErrorMessage = ({ error, style }) => {
+  const [colorScheme] = useColorContext()
+  return (
+    <P style={{ margin: '20px 0', ...style }}>
+      <span {...colorScheme.set('color', 'error')}>{errorToString(error)}</span>
+    </P>
+  )
+}
 
 export default ErrorMessage

--- a/components/Vote/201907/VotePage.js
+++ b/components/Vote/201907/VotePage.js
@@ -26,7 +26,6 @@ import ActionBar from '../../ActionBar'
 import BudgetChart from './BudgetChart'
 import Loader from '../../Loader'
 import VoteInfo from './VoteInfo'
-import AddressEditor from '../AddressEditor'
 import VoteResult from '../VoteResult'
 
 import {
@@ -128,12 +127,6 @@ class VotePage extends Component {
 
             const hasResults = votings.map(d => d.result).every(Boolean)
 
-            const missingAdress = userIsEligible && !me.address
-
-            const dangerousDisabledHTML = missingAdress
-              ? vt('common/missingAddressDisabledMessage')
-              : undefined
-
             const shareObject = {
               url: `${PUBLIC_BASE_URL}/vote/juli19`,
               title: vt('vote/201907/page/title'),
@@ -221,16 +214,6 @@ class VotePage extends Component {
                   <Collapsible>
                     <Small dangerousHTML={vt('vote/201907/intro/more2')} />
                   </Collapsible>
-                  {missingAdress && (
-                    <Fragment>
-                      <a {...styles.anchor} id='adresse' />
-                      <Heading>{vt('common/missingAddressTitle')}</Heading>
-                      <P>{vt('common/missingAddressBody')}</P>
-                      <div style={{ margin: '30px 0' }}>
-                        <AddressEditor />
-                      </div>
-                    </Fragment>
-                  )}
                   {!me && !hasEnded && (
                     <div style={{ margin: '30px 0' }}>
                       <SignIn
@@ -258,10 +241,7 @@ class VotePage extends Component {
                     <Collapsible>
                       <Small dangerousHTML={vt(`vote/${id}/more`)} />
                     </Collapsible>
-                    <Voting
-                      slug={slug}
-                      dangerousDisabledHTML={dangerousDisabledHTML}
-                    />
+                    <Voting slug={slug} />
                   </Section>
                 ))}
 

--- a/components/Vote/201912/VotePage.js
+++ b/components/Vote/201912/VotePage.js
@@ -26,7 +26,6 @@ import { getVotingStage, VOTING_STAGES } from '../votingStage'
 import ActionBar from '../../ActionBar'
 import Loader from '../../Loader'
 import VoteInfo from './VoteInfo'
-import AddressEditor from '../AddressEditor'
 import VoteResult from '../VoteResult'
 import md from 'markdown-in-js'
 import { mdComponents } from '../text'
@@ -131,12 +130,6 @@ class VotePage extends Component {
 
             const hasResults = votings.map(d => d.result).every(Boolean)
 
-            const missingAdress = userIsEligible && !me.address
-
-            const dangerousDisabledHTML = missingAdress
-              ? vt('common/missingAddressDisabledMessage')
-              : undefined
-
             const shareObject = {
               url: `${PUBLIC_BASE_URL}/vote/dez19`,
               title: vt('vote/201912/page/title'),
@@ -204,16 +197,6 @@ class VotePage extends Component {
                   />
                   <FigureCaption>{vt('vote/201912/caption')}</FigureCaption>
                 </div>
-                {missingAdress && (
-                  <Fragment>
-                    <a {...styles.anchor} id='adresse' />
-                    <H2>{vt('common/missingAddressTitle')}</H2>
-                    <P>{vt('common/missingAddressBody')}</P>
-                    <div style={{ margin: '30px 0' }}>
-                      <AddressEditor />
-                    </div>
-                  </Fragment>
-                )}
                 {!me && !hasEnded && (
                   <div style={{ margin: '80px 0' }}>
                     <SignIn
@@ -312,10 +295,7 @@ Ganz einfach: weil uns das Geld ausgeht. Wenn wir im laufenden Geschäftsjahr gl
 Schreiben Sie uns in der [Abstimmungsdebatte](/vote/dez19/diskutieren). Auch wenn Sie von den Revisoren zur Durchführung und zum Ergebnis der Prüfung etwas wissen möchten. Wir sammeln die Fragen an die Revisionsstelle bis zum 17. Dezember, und Sie erhalten in der Abstimmungsdebatte bis zum 19. Dezember eine Antwort.
                 `}</Collapsible>
 
-                <Voting
-                  slug={'gen1819report'}
-                  dangerousDisabledHTML={dangerousDisabledHTML}
-                />
+                <Voting slug={'gen1819report'} />
                 {md(mdComponents)`
 ## Jahresrechnung Project R
 
@@ -336,10 +316,7 @@ Nun, dann wird es richtig kompliziert. Wir könnten zum Beispiel die Steuererkl�
 Schreiben Sie uns in der [Abstimmungsdebatte](/vote/dez19/diskutieren). Auch wenn Sie von den Revisoren zur Durchführung und zum Ergebnis der Prüfung etwas wissen möchten. Wir sammeln die Fragen an die Revisionsstelle bis zum 17. Dezember, und Sie erhalten in der Abstimmungsdebatte bis zum 19. Dezember eine Antwort.
                 `}</Collapsible>
 
-                <Voting
-                  slug={'gen1819accounts'}
-                  dangerousDisabledHTML={dangerousDisabledHTML}
-                />
+                <Voting slug={'gen1819accounts'} />
 
                 {md(mdComponents)`
 ## Entlastung
@@ -356,10 +333,7 @@ Die Entlastung gilt gegenüber den Mitgliedern des Vorstands sowie gegenüber 
 Schreiben Sie uns in der [Abstimmungsdebatte](/vote/dez19/diskutieren).
                 `}</Collapsible>
 
-                <Voting
-                  slug={'gen19discharge'}
-                  dangerousDisabledHTML={dangerousDisabledHTML}
-                />
+                <Voting slug={'gen19discharge'} />
 
                 {md(mdComponents)`
 ## Revisionsstelle
@@ -373,10 +347,7 @@ Wir würden das abklären – wahrscheinlich müssten Vorstand und Genossenschaf
 **Warum schon wieder?**  
 Sie haben die Revisionsstelle im Sommer 2019 bestätigt, und damit konnte diese die Finanzen des vergangenen Geschäftsjahres prüfen. In [Artikel 35 unserer Statuten](https://www.republik.ch/statuten) ist festgelegt, dass die Revisionsstelle jedes Jahr gewählt werden muss. Heute geht es darum, ob die BDO auch das laufende Geschäftsjahr prüfen und im Jahr 2020 die Revisionsberichte erstellen soll.
                 `}</Collapsible>
-                <Voting
-                  slug={'gen1920revision'}
-                  dangerousDisabledHTML={dangerousDisabledHTML}
-                />
+                <Voting slug={'gen1920revision'} />
 
                 {!hasEnded && (
                   <Body dangerousHTML={vt('vote/201912/nextsteps')} />

--- a/components/Vote/VotePage.js
+++ b/components/Vote/VotePage.js
@@ -157,10 +157,9 @@ class VotePage extends Component {
                     <Fragment>
                       <a {...styles.anchor} id='adresse' />
                       <Heading>{vt('common/missingAddressTitle')}</Heading>
-                      <P>{vt('common/missingAddressBody')}</P>
-                      <div style={{ margin: '30px 0' }}>
-                        <AddressEditor />
-                      </div>
+                      <AddressEditor />
+                      <br />
+                      <br />
                     </Fragment>
                   )}
                   {!me && !hasEnded && (
@@ -194,10 +193,7 @@ class VotePage extends Component {
                     <Collapsible>
                       <Small dangerousHTML={vt(`vote/${id}/more`)} />
                     </Collapsible>
-                    <Voting
-                      slug={slug}
-                      dangerousDisabledHTML={dangerousDisabledHTML}
-                    />
+                    <Voting slug={slug} />
                   </Section>
                 ))}
 
@@ -332,7 +328,4 @@ const query = gql`
   }
 `
 
-export default compose(
-  voteT,
-  graphql(query)
-)(VotePage)
+export default compose(voteT, graphql(query))(VotePage)

--- a/components/Vote/Voting.js
+++ b/components/Vote/Voting.js
@@ -19,6 +19,7 @@ import voteT from './voteT'
 import gql from 'graphql-tag'
 import { compose, graphql } from 'react-apollo'
 import ErrorMessage from '../ErrorMessage'
+import AddressEditor, { withAddressData } from './AddressEditor'
 
 const { H3, P } = Interaction
 
@@ -226,12 +227,13 @@ class Voting extends React.Component {
       const {
         vt,
         data: { voting },
+        addressData,
         me
       } = this.props
       const { selectedValue } = this.state
       const { P } = Interaction
 
-      let dangerousDisabledHTML = this.props.dangerousDisabledHTML
+      let dangerousDisabledHTML
       if (voting.userHasSubmitted) {
         dangerousDisabledHTML = vt('vote/voting/thankyou', {
           submissionDate: messageDateFormat(new Date(voting.userSubmitDate))
@@ -242,6 +244,10 @@ class Voting extends React.Component {
         dangerousDisabledHTML = vt('vote/voting/notSignedIn')
       } else if (!voting.userIsEligible) {
         dangerousDisabledHTML = vt('vote/voting/notEligible')
+      }
+
+      if (voting.userIsEligible && !addressData.voteMe?.address) {
+        return <AddressEditor />
       }
 
       if (dangerousDisabledHTML) {
@@ -380,5 +386,6 @@ export default compose(
         slug
       }
     })
-  })
+  }),
+  withAddressData
 )(Voting)

--- a/components/Vote/Voting.js
+++ b/components/Vote/Voting.js
@@ -46,7 +46,7 @@ const styles = {
   }),
   cardActions: css({
     marginTop: 15,
-    height: 90,
+    minHeight: 90,
     textAlign: 'center',
     '& button': {
       display: 'block',
@@ -126,7 +126,7 @@ class Voting extends React.Component {
       }
     }
 
-    this.submitVotingBallot = async () => {
+    this.submitVotingBallot = () => {
       const { submitVotingBallot } = this.props
       const {
         data: { voting }
@@ -135,19 +135,19 @@ class Voting extends React.Component {
 
       this.setState({ updating: true })
 
-      await submitVotingBallot(voting.id, selectedValue)
+      submitVotingBallot(voting.id, selectedValue)
         .then(() => {
-          this.setState(() => ({
+          this.setState({
             updating: false,
             error: null
-          }))
+          })
         })
         .catch(error => {
-          this.setState(() => ({
+          this.setState({
             pollState: POLL_STATES.DIRTY,
             updating: false,
             error
-          }))
+          })
         })
     }
 
@@ -170,9 +170,9 @@ class Voting extends React.Component {
                 primary
                 onClick={e => {
                   e.preventDefault()
-                  this.setState(() => ({
+                  this.setState({
                     pollState: POLL_STATES.READY
-                  }))
+                  })
                 }}
               >
                 {vt('vote/voting/labelVote')}
@@ -188,9 +188,9 @@ class Voting extends React.Component {
                 primary
                 onClick={e => {
                   e.preventDefault()
-                  this.setState(() => ({
+                  this.setState({
                     pollState: POLL_STATES.READY
-                  }))
+                  })
                 }}
               >
                 {vt('vote/voting/labelVote')}
@@ -230,7 +230,7 @@ class Voting extends React.Component {
         addressData,
         me
       } = this.props
-      const { selectedValue } = this.state
+      const { selectedValue, updating } = this.state
       const { P } = Interaction
 
       let dangerousDisabledHTML
@@ -272,6 +272,7 @@ class Voting extends React.Component {
                   black
                   value={id}
                   checked={id === selectedValue}
+                  disabled={!!updating}
                   onChange={() =>
                     this.setState({
                       selectedValue: id,


### PR DESCRIPTION
Enforce address in voting boxes. Moved to the vote box because the CMS just renders those. Old way is kept in the original voting page from 2018 because it also contains elections which are not yet CMSified.

<img width="709" alt="Screenshot 2020-11-05 at 21 31 02" src="https://user-images.githubusercontent.com/410211/98293211-39d59000-1fae-11eb-9109-ce2a7060180c.png">
