### PR TITLE
fix and refactor reading time printing

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -165,14 +165,33 @@ const ActionBar = ({
       mode !== 'article-bottom') ||
     meta.template === 'format' ||
     meta.template === 'section'
-  const readingTimeTitle = `${
-    displayHours ? `${displayHours}h\u202F` : ''
-  } ${displayMinutes} Minuten`
+
+  const hours =
+    displayHours > 0
+      ? t.pluralize('feed/actionbar/readingTime/hours', { count: displayHours })
+      : ''
+  const minutes =
+    displayMinutes > 0
+      ? t.pluralize('feed/actionbar/readingTime/minutes', {
+          count: displayMinutes
+        })
+      : ''
+  const minutesShort =
+    displayMinutes > 0
+      ? t.pluralize('feed/actionbar/readingTime/minutesShort', {
+          count: displayMinutes
+        })
+      : ''
+
+  const readingTimeTitle = t('feed/actionbar/readingTime/title', {
+    minutes,
+    hours
+  })
   const readingTimeLabel = !forceShortLabel
-    ? `${displayHours ? `${displayHours}h\u202F` : ''}
-      ${displayMinutes} Minuten`
-    : `${displayHours ? `${displayHours}h\u202F` : ''}
-      ${displayMinutes}'`
+    ? `${hours}${minutes}`
+    : `${hours}${minutesShort}`
+  const readingTimeLabelShort = `${hours}${minutesShort}`
+
   const showReadingTime =
     (displayMinutes > 0 || displayHours > 0) &&
     (meta.template === 'article' || meta.template === 'editorialNewsletter')
@@ -182,8 +201,7 @@ const ActionBar = ({
       title: readingTimeTitle,
       Icon: MdQueryBuilder,
       label: readingTimeLabel,
-      labelShort: `${displayHours ? `${displayHours}h\u202F` : ''}
-      ${displayMinutes}'`,
+      labelShort: readingTimeLabelShort,
       modes: ['feed'],
       show: showReadingTime
     },
@@ -342,8 +360,7 @@ const ActionBar = ({
       title: readingTimeTitle,
       Icon: MdQueryBuilder,
       label: readingTimeLabel,
-      labelShort: `${displayHours ? `${displayHours}h\u202F` : ''}
-      ${displayMinutes}'`,
+      labelShort: readingTimeLabelShort,
       no: true,
       show: showReadingTime
     },

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2020-11-01T19:26:17.216Z",
+  "updated": "2020-11-06T11:27:50.033Z",
   "title": "live",
   "data": [
     {
@@ -2695,12 +2695,24 @@
       "value": "Chart"
     },
     {
-      "key": "feed/actionbar/readingTime/1",
-      "value": "ungefähr {minutes} Minute"
+      "key": "feed/actionbar/readingTime/hours/other",
+      "value": "{count}h "
     },
     {
-      "key": "feed/actionbar/readingTime/other",
-      "value": "ungefähr {minutes} Minuten"
+      "key": "feed/actionbar/readingTime/minutes/1",
+      "value": "1 Minute"
+    },
+    {
+      "key": "feed/actionbar/readingTime/minutes/other",
+      "value": "{count} Minuten"
+    },
+    {
+      "key": "feed/actionbar/readingTime/minutesShort/other",
+      "value": "{count}'"
+    },
+    {
+      "key": "feed/actionbar/readingTime/title",
+      "value": "ungefähr {hours}{minutes}"
     },
     {
       "key": "feed/actionbar/edit",


### PR DESCRIPTION
Fix pluralisation of 1:
<img width="109" alt="Screenshot 2020-11-06 at 12 38 04" src="https://user-images.githubusercontent.com/410211/98362517-a2b01d00-202d-11eb-843c-4f2ee2c87708.png">

Hide 0 minutes:
<img width="319" alt="Screenshot 2020-11-06 at 12 38 17" src="https://user-images.githubusercontent.com/410211/98362519-a348b380-202d-11eb-894c-a62d6332c8ed.png">

Re-add «ungefähr» to tile attribute text.

Replace `u202F` with `u00a0` (done in translations/google sheet with utf8) because not all OS and browser support `u202F`.