### PR TITLE
Custom Header Color Scheme Everywhere

### DIFF
--- a/components/Frame/Header.js
+++ b/components/Frame/Header.js
@@ -309,8 +309,7 @@ const HeaderWithContext = props => {
     children,
     hasOverviewNav,
     secondaryNav,
-    inNativeIOSApp,
-    colorSchemeKey: colorSchemeKeyProp
+    inNativeIOSApp
   } = props
 
   const hasSecondaryNav = hasOverviewNav || secondaryNav

--- a/components/Frame/index.js
+++ b/components/Frame/index.js
@@ -80,17 +80,15 @@ export const Content = ({ children, style }) => (
   </div>
 )
 
-const ColorContainer = ({ children }) => {
+const OverrideRootDefaultColors = () => {
   const [colorScheme] = useColorContext()
 
   return (
-    <div
-      {...colorScheme.set('color', 'text')}
-      {...colorScheme.set('backgroundColor', 'default')}
-    >
-      <div style={{ height: 1, width: '100%' }} />
-      {children}
-    </div>
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `html, body { background-color: ${colorScheme.default} !important; color: ${colorScheme.text} !important; }`
+      }}
+    />
   )
 }
 
@@ -164,31 +162,32 @@ const Frame = ({
             stickySecondaryNav={stickySecondaryNav}
           >
             <ColorContextProvider colorSchemeKey={contentColorSchemeKey}>
-              <ColorContainer>
-                <noscript>
-                  <Box style={{ padding: 30 }}>
-                    <RawHtml
-                      dangerouslySetInnerHTML={{
-                        __html: t('noscript')
-                      }}
-                    />
-                  </Box>
-                </noscript>
-                {me && me.prolongBeforeDate !== null && (
-                  <ProlongBox
-                    t={t}
-                    prolongBeforeDate={me.prolongBeforeDate}
-                    dark={dark}
+              {contentColorSchemeKey !== rootColorSchemeKey && (
+                <OverrideRootDefaultColors />
+              )}
+              <noscript>
+                <Box style={{ padding: 30 }}>
+                  <RawHtml
+                    dangerouslySetInnerHTML={{
+                      __html: t('noscript')
+                    }}
                   />
-                )}
-                {raw ? (
-                  children
-                ) : (
-                  <MainContainer>
-                    <Content>{children}</Content>
-                  </MainContainer>
-                )}
-              </ColorContainer>
+                </Box>
+              </noscript>
+              {me && me.prolongBeforeDate !== null && (
+                <ProlongBox
+                  t={t}
+                  prolongBeforeDate={me.prolongBeforeDate}
+                  dark={dark}
+                />
+              )}
+              {raw ? (
+                children
+              ) : (
+                <MainContainer>
+                  <Content>{children}</Content>
+                </MainContainer>
+              )}
             </ColorContextProvider>
           </Header>
         </div>

--- a/components/Frame/index.js
+++ b/components/Frame/index.js
@@ -7,7 +7,8 @@ import {
   RawHtml,
   fontFamilies,
   mediaQueries,
-  ColorContextProvider
+  ColorContextProvider,
+  useColorContext
 } from '@project-r/styleguide'
 import Meta from './Meta'
 import Header from './Header'
@@ -79,6 +80,20 @@ export const Content = ({ children, style }) => (
   </div>
 )
 
+const ColorContainer = ({ children }) => {
+  const [colorScheme] = useColorContext()
+
+  return (
+    <div
+      {...colorScheme.set('color', 'text')}
+      {...colorScheme.set('backgroundColor', 'default')}
+    >
+      <div style={{ height: 1, width: '100%' }} />
+      {children}
+    </div>
+  )
+}
+
 const Frame = ({
   t,
   me,
@@ -100,11 +115,17 @@ const Frame = ({
   isTester,
   colorSchemeKey: colorSchemeKeyProp = 'light'
 }) => {
-  const colorSchemeKey = isTester
+  const rootColorSchemeKey = isTester
+    ? 'auto'
+    : colorSchemeKeyProp === 'dark'
+    ? 'dark'
+    : 'light'
+  const contentColorSchemeKey = isTester
     ? colorSchemeKeyProp
     : colorSchemeKeyProp === 'auto'
     ? 'light'
     : colorSchemeKeyProp
+
   const hasOverviewNav = isMember && wantOverviewNav
   const hasSecondaryNav = !!(secondaryNav || hasOverviewNav)
   const padHeaderRule = useMemo(() => {
@@ -120,8 +141,8 @@ const Frame = ({
     })
   }, [hasSecondaryNav])
   return (
-    <ColorContextProvider root colorSchemeKey={colorSchemeKey}>
-      {colorSchemeKey === 'auto' && <ColorSchemeSync />}
+    <ColorContextProvider root colorSchemeKey={rootColorSchemeKey}>
+      {rootColorSchemeKey === 'auto' && <ColorSchemeSync />}
       <div
         {...(footer || inNativeApp ? styles.bodyGrowerContainer : undefined)}
       >
@@ -132,7 +153,7 @@ const Frame = ({
         >
           {!!meta && <Meta data={meta} />}
           <Header
-            colorSchemeKey={colorSchemeKey}
+            colorSchemeKey={rootColorSchemeKey}
             me={me}
             cover={cover}
             onNavExpanded={onNavExpanded}
@@ -142,29 +163,33 @@ const Frame = ({
             hasOverviewNav={hasOverviewNav}
             stickySecondaryNav={stickySecondaryNav}
           >
-            <noscript>
-              <Box style={{ padding: 30 }}>
-                <RawHtml
-                  dangerouslySetInnerHTML={{
-                    __html: t('noscript')
-                  }}
-                />
-              </Box>
-            </noscript>
-            {me && me.prolongBeforeDate !== null && (
-              <ProlongBox
-                t={t}
-                prolongBeforeDate={me.prolongBeforeDate}
-                dark={dark}
-              />
-            )}
-            {raw ? (
-              children
-            ) : (
-              <MainContainer>
-                <Content>{children}</Content>
-              </MainContainer>
-            )}
+            <ColorContextProvider colorSchemeKey={contentColorSchemeKey}>
+              <ColorContainer>
+                <noscript>
+                  <Box style={{ padding: 30 }}>
+                    <RawHtml
+                      dangerouslySetInnerHTML={{
+                        __html: t('noscript')
+                      }}
+                    />
+                  </Box>
+                </noscript>
+                {me && me.prolongBeforeDate !== null && (
+                  <ProlongBox
+                    t={t}
+                    prolongBeforeDate={me.prolongBeforeDate}
+                    dark={dark}
+                  />
+                )}
+                {raw ? (
+                  children
+                ) : (
+                  <MainContainer>
+                    <Content>{children}</Content>
+                  </MainContainer>
+                )}
+              </ColorContainer>
+            </ColorContextProvider>
           </Header>
         </div>
         {!inNativeApp && footer && <Footer />}


### PR DESCRIPTION
Allow the user to always pick the header color scheme and only override content color scheme when necessary—not yet supported or page is explicitly set to dark mode by editors.

<img width="1431" alt="Screenshot 2020-11-09 at 15 30 43" src="https://user-images.githubusercontent.com/410211/98554161-b3b49480-22a0-11eb-98ee-f1fbcdceffb2.png">
<img width="1431" alt="Screenshot 2020-11-09 at 15 29 51" src="https://user-images.githubusercontent.com/410211/98554172-b7481b80-22a0-11eb-9253-b38803e8694d.png">
