### PR TITLE
Removes linkRule from Dialoge title and a couple of other places

### DIFF
--- a/components/Bookmarks/Page.js
+++ b/components/Bookmarks/Page.js
@@ -13,7 +13,7 @@ import {
   fontStyles,
   Center,
   Interaction,
-  linkRule,
+  A,
   plainButtonRule
 } from '@project-r/styleguide'
 import { Link } from '../../lib/routes'
@@ -108,9 +108,7 @@ const Page = ({ t, me }) => {
                 {
                   feedLink: (
                     <Link route='feed' key='link'>
-                      <a {...linkRule}>
-                        {t('pages/bookmarks/placeholder/feedText')}
-                      </a>
+                      <A>{t('pages/bookmarks/placeholder/feedText')}</A>
                     </Link>
                   ),
                   bookmarkIcon

--- a/components/Feedback/ActiveDiscussions.js
+++ b/components/Feedback/ActiveDiscussions.js
@@ -8,11 +8,9 @@ import { withActiveDiscussions } from './enhancers'
 import DiscussionLink from '../Discussion/DiscussionLink'
 
 import {
-  Interaction,
   Loader,
   fontStyles,
   mediaQueries,
-  linkRule,
   useColorContext
 } from '@project-r/styleguide'
 

--- a/components/Feedback/DiscussionTitle.js
+++ b/components/Feedback/DiscussionTitle.js
@@ -4,7 +4,7 @@ import { compose } from 'react-apollo'
 import { withDiscussionDocumentMeta } from './enhancers'
 import withT from '../../lib/withT'
 import Link from '../Link/Href'
-import { inQuotes, linkRule } from '@project-r/styleguide'
+import { inQuotes, A } from '@project-r/styleguide'
 
 const ArticleDiscussionHeadline = ({ t, discussionId, meta, documentMeta }) => {
   const articleMeta = meta || documentMeta
@@ -14,9 +14,7 @@ const ArticleDiscussionHeadline = ({ t, discussionId, meta, documentMeta }) => {
 
   const ArticleLink = (
     <Link href={articleMeta.path} passHref key='articlelink'>
-      <a {...linkRule} href={articleMeta.path}>
-        {inQuotes(articleMeta.title)}
-      </a>
+      <A href={articleMeta.path}>{inQuotes(articleMeta.title)}</A>
     </Link>
   )
 

--- a/components/Notifications/Settings.js
+++ b/components/Notifications/Settings.js
@@ -1,11 +1,5 @@
 import React from 'react'
-import {
-  Interaction,
-  Center,
-  linkRule,
-  A,
-  mediaQueries
-} from '@project-r/styleguide'
+import { Interaction, Center, A, mediaQueries } from '@project-r/styleguide'
 import { compose } from 'react-apollo'
 import SubscribedDocuments from './SubscribedDocuments'
 import SubscribedAuthors from './SubscribedAuthors'
@@ -42,7 +36,7 @@ export default compose(
           {t('Notifications/settings/title')}
         </H1>
         <Link route='subscriptions' passHref>
-          <A {...linkRule}>{t('Notifications/settings/back')}</A>
+          <A>{t('Notifications/settings/back')}</A>
         </Link>
         {!isMember && (
           <Box style={{ margin: '10px 0', padding: 15 }}>
@@ -80,7 +74,7 @@ export default compose(
           <Interaction.P>
             {t.elements('Notifications/settings/newsletter', {
               link: (
-                <A key='link' href='/konto#newsletter' {...linkRule}>
+                <A key='link' href='/konto#newsletter'>
                   {t('Notifications/settings/newsletter/link')}
                 </A>
               )


### PR DESCRIPTION
linkRule is deprecated (it has a hover with secondary color, which is deprecated), should be removed everywhere and replaced by the new <A> element that is exported from styleguide.

