### PR TITLE
Add preface to contact details form

### DIFF
--- a/components/Pledge/Form.js
+++ b/components/Pledge/Form.js
@@ -460,6 +460,17 @@ class Pledge extends Component {
               ''
             )
 
+            const contactPreface =
+              pkg &&
+              t.first(
+                [
+                  `pledge/contact/preface/${pkg.name}`,
+                  'pledge/contact/preface'
+                ],
+                undefined,
+                ''
+              )
+
             return (
               <div>
                 {(statementTitle ||
@@ -519,6 +530,11 @@ class Pledge extends Component {
                 </div>
                 {pkg && (
                   <Fragment>
+                    {contactPreface && (
+                      <div style={{ marginBottom: 40 }}>
+                        <P>{contactPreface}</P>
+                      </div>
+                    )}
                     <H2>
                       {t.first([
                         `pledge/contact/title/${pkg.name}`,

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -2423,6 +2423,14 @@
       "value": "Willkommen an Bord!"
     },
     {
+      "key": "pledge/contact/preface/ABO_GIVE",
+      "value": "Eine Mitgliedschaft als Geschenk erhalten Sie in Form eines Gutscheincodes, den Sie direkt der zu beschenkenden Person überreichen können."
+    },
+    {
+      "key": "pledge/contact/preface/ABO_GIVE_MONTHS",
+      "value": "Ein Monats-Abo als Geschenk erhalten Sie in Form eines Gutscheincodes, den Sie direkt der zu beschenkenden Person überreichen können."
+    },
+    {
       "key": "pledge/contact/title",
       "value": "Ihre Kontaktinformationen"
     },


### PR DESCRIPTION
Allows for some explanatory details before name and email address is asked for, see harshly pinked section.

Triggered by users, once more utterly confused users on how gifting process works.

<img width="696" alt="Bildschirmfoto 2020-12-11 um 15 40 50" src="https://user-images.githubusercontent.com/331800/101917064-1498fa80-3bc8-11eb-8af6-9d51b1a9981c.png">