### PR TITLE
feat(Account): Show QR bill in PledgeList

### DIFF
--- a/components/Account/PledgeList.js
+++ b/components/Account/PledgeList.js
@@ -143,7 +143,6 @@ class PledgeList extends Component {
                                     )
                                   }
                                 ),
-                          hrid: payment.hrid,
                           method: t(
                             `account/pledges/payment/method/${payment.method}`
                           )

--- a/components/Account/PledgeList.js
+++ b/components/Account/PledgeList.js
@@ -15,7 +15,7 @@ import GiveMemberships from './Memberships/Give'
 
 import query from './belongingsQuery'
 
-import { RawHtml, linkRule } from '@project-r/styleguide'
+import { A, linkRule } from '@project-r/styleguide'
 
 const dayFormat = timeFormat('%d. %B %Y')
 
@@ -126,51 +126,43 @@ class PledgeList extends Component {
                     )
                   })}
                 {pledge.payments.map((payment, i) => (
-                  <Item key={`payment-${i}`}>
-                    {payment.method === 'PAYMENTSLIP' &&
-                      payment.status === 'WAITING' && (
-                        <span>
-                          <RawHtml
-                            dangerouslySetInnerHTML={{
-                              __html: t(
-                                `account/pledges/payment/PAYMENTSLIP/paperInvoice/${+payment.paperInvoice}`
-                              )
-                            }}
-                          />
-                          <br />
-                          <br />
-                        </span>
+                  <>
+                    <Item key={`payment-${i}`}>
+                      {t(
+                        `account/pledges/payment/status/generic/${payment.status}`,
+                        {
+                          formattedTotal: chfFormat(payment.total / 100),
+                          dateSuffix:
+                            pledge.payments.length === 1
+                              ? ''
+                              : t(
+                                  'account/pledges/payment/status/generic/PAID/dateSuffix',
+                                  {
+                                    createdAt: dayFormat(
+                                      new Date(payment.createdAt)
+                                    )
+                                  }
+                                ),
+                          hrid: payment.hrid,
+                          method: t(
+                            `account/pledges/payment/method/${payment.method}`
+                          )
+                        }
                       )}
-                    <RawHtml
-                      dangerouslySetInnerHTML={{
-                        __html: t.first(
-                          [
-                            `account/pledges/payment/status/${payment.method}/${pledge.package.company.name}/${payment.status}`,
-                            `account/pledges/payment/status/${payment.method}/${payment.status}`,
-                            `account/pledges/payment/status/generic/${payment.status}`
-                          ],
-                          {
-                            formattedTotal: chfFormat(payment.total / 100),
-                            dateSuffix:
-                              pledge.payments.length === 1
-                                ? ''
-                                : t(
-                                    'account/pledges/payment/status/generic/PAID/dateSuffix',
-                                    {
-                                      createdAt: dayFormat(
-                                        new Date(payment.createdAt)
-                                      )
-                                    }
-                                  ),
-                            hrid: payment.hrid,
-                            method: t(
-                              `account/pledges/payment/method/${payment.method}`
-                            )
-                          }
-                        )
-                      }}
-                    />
-                  </Item>
+                    </Item>
+                    {payment.paymentslipUrl && (
+                      <>
+                        <Item key={`paymentslip-${i}`}>
+                          <A href={payment.paymentslipUrl} target='_blank'>
+                            {t('account/pledges/payment/paymentslipLink')}
+                          </A>
+                        </Item>
+                        <Item key={`paymentslip-hint-${i}`}>
+                          {t('account/pledges/payment/paymentslipHint')}
+                        </Item>
+                      </>
+                    )}
+                  </>
                 ))}
               </List>
               <GiveMemberships

--- a/components/Account/PledgeList.js
+++ b/components/Account/PledgeList.js
@@ -126,8 +126,8 @@ class PledgeList extends Component {
                     )
                   })}
                 {pledge.payments.map((payment, i) => (
-                  <>
-                    <Item key={`payment-${i}`}>
+                  <Fragment key={`payment-${i}`}>
+                    <Item>
                       {t(
                         `account/pledges/payment/status/generic/${payment.status}`,
                         {
@@ -151,17 +151,17 @@ class PledgeList extends Component {
                     </Item>
                     {payment.paymentslipUrl && (
                       <>
-                        <Item key={`paymentslip-${i}`}>
+                        <Item>
                           <A href={payment.paymentslipUrl} target='_blank'>
                             {t('account/pledges/payment/paymentslipLink')}
                           </A>
                         </Item>
-                        <Item key={`paymentslip-hint-${i}`}>
+                        <Item>
                           {t('account/pledges/payment/paymentslipHint')}
                         </Item>
                       </>
                     )}
-                  </>
+                  </Fragment>
                 ))}
               </List>
               <GiveMemberships

--- a/components/Account/belongingsQuery.js
+++ b/components/Account/belongingsQuery.js
@@ -98,6 +98,8 @@ export default gql`
           total
           status
           hrid
+          reference(pretty: true)
+          paymentslipUrl
           createdAt
           updatedAt
         }

--- a/components/Account/belongingsQuery.js
+++ b/components/Account/belongingsQuery.js
@@ -94,14 +94,10 @@ export default gql`
         donation
         payments {
           method
-          paperInvoice
           total
           status
-          hrid
-          reference(pretty: true)
           paymentslipUrl
           createdAt
-          updatedAt
         }
         memberships {
           id

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -888,7 +888,7 @@
     },
     {
       "key": "account/pledges/payment/method/PAYMENTSLIP",
-      "value": "Banküberweisung"
+      "value": "Rechnung"
     },
     {
       "key": "account/pledges/payment/status/generic/WAITING",
@@ -912,7 +912,15 @@
     },
     {
       "key": "account/pledges/payment/status/generic/CANCELLED",
-      "value": "{formattedTotal} annulliert"
+      "value": "{formattedTotal} storniert"
+    },
+    {
+      "key": "account/pledges/payment/paymentslipLink",
+      "value": "QR-Rechnung anzeigen"
+    },
+    {
+      "key": "account/pledges/payment/paymentslipHint",
+      "value": "Die QR-Rechnung ersetzt den Einzahlungsschein. Sie können damit die Zahlung via Mobile Banking, E-Banking oder am Schalter bei Bank und Post auslösen."
     },
     {
       "key": "account/pledges/payment/status/PAYMENTSLIP/WAITING",
@@ -2296,7 +2304,7 @@
     },
     {
       "key": "payment/method/PAYMENTSLIP",
-      "value": "Banküberweisung"
+      "value": "Rechnung"
     },
     {
       "key": "payment/method/POSTFINANCECARD",
@@ -2404,7 +2412,7 @@
     },
     {
       "key": "payment/paymentslip/explanation",
-      "value": "Wir verschicken keine Einzahlungsscheine per Post. Sie erhalten die Zahlungsanweisungen per E-Mail. Ihre Adresse brauchen wir aus administrativen Gründen."
+      "value": "Nach der Bestellung senden wir Ihnen per E-Mail eine QR-Rechnung."
     },
     {
       "key": "payment/paymentslip/emailInvoice",


### PR DESCRIPTION
This Pull Request:
- shows a "Swiss QR Bill" in a users account. It replaces bank details.
- relabels "Überweisung" as "Rechnung" in checkout process.

---

**Pledges**

Example of a pledge using payment slip payment method.

<img width="814" alt="Bildschirmfoto 2020-12-30 um 13 50 13" src="https://user-images.githubusercontent.com/331800/103352456-9208aa00-4aa6-11eb-8110-917f46473990.png">

---

**Checkout**

<img width="663" alt="Bildschirmfoto 2020-12-30 um 13 54 32" src="https://user-images.githubusercontent.com/331800/103352480-9d5bd580-4aa6-11eb-889a-963fe2801396.png">



Depends on https://github.com/orbiting/backends/pull/552