### PR TITLE
Use ColorContext in Frame/ProlongBox

### DIFF
--- a/components/Frame/ProlongBox.js
+++ b/components/Frame/ProlongBox.js
@@ -6,10 +6,10 @@ import { timeDay } from 'd3-time'
 import {
   Editorial,
   Interaction,
-  colors,
   mediaQueries,
   Button,
-  Center
+  Center,
+  useColorContext
 } from '@project-r/styleguide'
 
 import { css } from 'glamor'
@@ -29,13 +29,6 @@ const styles = {
     [mediaQueries.mUp]: {
       fontSize: 16
     }
-  }),
-  boxLight: css({
-    backgroundColor: colors.primaryBg
-  }),
-  boxDark: css({
-    backgroundColor: colors.negative.primaryBg,
-    color: '#fff'
   })
 }
 
@@ -45,7 +38,9 @@ const SingleLine = ({ children }) => (
 
 const dayFormat = timeFormat('%d. %B %Y')
 
-const ProlongBox = ({ t, prolongBeforeDate, router, dark: inDarkFrame }) => {
+const ProlongBox = ({ t, prolongBeforeDate, router }) => {
+  const [colorScheme] = useColorContext()
+
   if (
     router.pathname === '/pledge' ||
     router.pathname === '/cancel' ||
@@ -60,16 +55,14 @@ const ProlongBox = ({ t, prolongBeforeDate, router, dark: inDarkFrame }) => {
     const key =
       numberOfDays <= 2 ? (numberOfDays < 0 ? 'overdue' : 'due') : 'before'
     const baseKey = `prolongNecessary/${key}`
-
-    const dark = inDarkFrame || key !== 'before'
-    const colorStyle = { color: dark ? '#fff' : undefined }
+    const styleTextColor = colorScheme.set('color', 'text')
 
     const explanation = t.elements(
       `${baseKey}/explanation`,
       {
         cancelLink: (
           <Link key='cancelLink' route='cancel' passHref>
-            <Editorial.A style={colorStyle}>
+            <Editorial.A {...styleTextColor}>
               {t(`${baseKey}/explanation/cancelText`)}
             </Editorial.A>
           </Link>
@@ -85,9 +78,13 @@ const ProlongBox = ({ t, prolongBeforeDate, router, dark: inDarkFrame }) => {
     const buttonText = t(`${baseKey}/button`, undefined, '')
 
     return (
-      <div {...styles.box} {...styles[dark ? 'boxDark' : 'boxLight']}>
+      <div
+        {...styles.box}
+        {...styleTextColor}
+        {...colorScheme.set('backgroundColor', 'alert')}
+      >
         <Wrapper>
-          <Title style={colorStyle}>
+          <Title>
             {t.elements(baseKey, {
               link: (
                 <TokenPackageLink
@@ -95,7 +92,7 @@ const ProlongBox = ({ t, prolongBeforeDate, router, dark: inDarkFrame }) => {
                   params={{ package: 'PROLONG' }}
                   passHref
                 >
-                  <Editorial.A style={colorStyle}>
+                  <Editorial.A {...styleTextColor}>
                     {t(`${baseKey}/linkText`)}
                   </Editorial.A>
                 </TokenPackageLink>
@@ -110,7 +107,7 @@ const ProlongBox = ({ t, prolongBeforeDate, router, dark: inDarkFrame }) => {
             </TokenPackageLink>
           )}
           {hasExplanation && (
-            <Interaction.P style={{ ...colorStyle, marginTop: 10 }}>
+            <Interaction.P style={{ marginTop: 10 }} {...styleTextColor}>
               {explanation}
             </Interaction.P>
           )}


### PR DESCRIPTION
Notice leading up to last day was not readable because white font on bright green.

**Before**

<img width="717" alt="Bildschirmfoto 2020-12-29 um 08 53 29" src="https://user-images.githubusercontent.com/331800/103268783-6f966400-49b4-11eb-8c22-4111f862ac8b.png">

**After**

<img width="717" alt="Bildschirmfoto 2020-12-29 um 08 55 51" src="https://user-images.githubusercontent.com/331800/103268794-7624db80-49b4-11eb-9107-19a2e981650e.png">

Caveat: I am unable to imitate behaviour which rendered due/overdue notice in pitch black background and white font. When dark mode is on, it did not adopt colors on account page correctly (a page not yet available in dark mode).

Due to the boxes "intrusivness" nature either way, lack of knowledge on my account, and some urgency to have prolong box readable in dark mode, due/overdue notice is rendered in alert colors, too:

**Before**

<img width="716" alt="Bildschirmfoto 2020-12-29 um 08 54 40" src="https://user-images.githubusercontent.com/331800/103268975-f77c6e00-49b4-11eb-8006-ed20ccc6836e.png">

**After**

<img width="705" alt="Bildschirmfoto 2020-12-29 um 08 54 54" src="https://user-images.githubusercontent.com/331800/103268981-fba88b80-49b4-11eb-9bd7-28ea60a41177.png">
