### PR TITLE
Fix: Name and rename GraphQL queries

### DIFF
--- a/components/Events/List.js
+++ b/components/Events/List.js
@@ -38,7 +38,7 @@ const styles = {
 }
 
 const query = gql`
-  query {
+  query EventsList {
     events {
       slug
       title

--- a/components/Faq/List.js
+++ b/components/Faq/List.js
@@ -148,7 +148,7 @@ export class RawList extends Component {
 }
 
 const publishedFaqs = gql`
-  query {
+  query FaqList {
     faqs {
       category
       question

--- a/components/Marketing/Carpet.js
+++ b/components/Marketing/Carpet.js
@@ -12,7 +12,7 @@ import {
 import TeaserBlock, { GAP } from '../Overview/TeaserBlock'
 import { getTeasersFromDocument } from '../Overview/utils'
 const query = gql`
-  query MarketingPage {
+  query MarketingCarpet {
     front: document(path: "/") {
       id
       children(first: 40) {

--- a/components/Marketing/Community.js
+++ b/components/Marketing/Community.js
@@ -68,7 +68,7 @@ const styles = {
 }
 
 const query = gql`
-  query FeaturedCommunityComments {
+  query MarketingCommunity {
     featured: comments(
       orderBy: FEATURED_AT
       orderDirection: DESC

--- a/components/Marketing/MiniFront.js
+++ b/components/Marketing/MiniFront.js
@@ -22,7 +22,7 @@ const MiniFront = ({ data: { loading, error, front }, t }) => {
 }
 
 const query = gql`
-  query MarketingFront {
+  query MarketingMiniFront {
     front: document(path: "/marketing") {
       id
       children {

--- a/components/Marketing/Team.js
+++ b/components/Marketing/Team.js
@@ -112,7 +112,7 @@ const styles = {
 }
 
 const query = gql`
-  query MarketingPage {
+  query MarketingTeam {
     employees(withBoosted: true, shuffle: 3, withPitch: true) {
       title
       name

--- a/components/Marketing/index.js
+++ b/components/Marketing/index.js
@@ -47,7 +47,7 @@ const Marketing = ({
 }
 
 const query = gql`
-  query MarketingPage {
+  query Marketing {
     meGuidance: me {
       id
       activeMembership {

--- a/components/Updates/List.js
+++ b/components/Updates/List.js
@@ -18,7 +18,7 @@ import { PUBLIC_BASE_URL, CDN_FRONTEND_BASE_URL } from '../../lib/constants'
 import Update from './Detail'
 
 const query = gql`
-  query {
+  query UpdatesList {
     updates {
       slug
       title

--- a/components/Vote/AddressEditor.js
+++ b/components/Vote/AddressEditor.js
@@ -133,7 +133,7 @@ const updateAddressMutation = gql`
 `
 
 const query = gql`
-  query {
+  query VoteAddressEditor {
     voteMe: me {
       id
       name

--- a/components/Vote/ElectionCandidacy.js
+++ b/components/Vote/ElectionCandidacy.js
@@ -574,7 +574,7 @@ const publishCredential = gql`
 `
 
 const query = gql`
-  query {
+  query VoteElectionCandidacy {
     election(slug: "${ELECTION_COOP_MEMBERS_SLUG}") {
       id
       candidacyEndDate

--- a/components/Vote/ElectionDiscussionPage.js
+++ b/components/Vote/ElectionDiscussionPage.js
@@ -149,7 +149,7 @@ const DiscussionPage = ({ router, data, vt }) => {
 }
 
 const query = gql`
-  query {
+  query VoteElectionDiscussionPage {
   ${ELECTION_COOP_PRESIDENT_SLUG}: election(slug: "${ELECTION_COOP_PRESIDENT_SLUG}") {
     id
     discussion {

--- a/pages/cardGroups.js
+++ b/pages/cardGroups.js
@@ -28,7 +28,7 @@ import {
 import DiscussionIcon from '../components/Icons/Discussion'
 
 const query = gql`
-  query {
+  query getCardGroups {
     nElected: cards(filters: { elects: ["nationalCouncil"] }) {
       totalCount
     }


### PR DESCRIPTION
This Pull Request renames GraphQL queries in components/Marketing, or names nameless queries. This should help recognizing queries especially when logging.