### PR TITLE
fix(NativeApps): Scroll to top after pushing route in MessageSync

### DIFF
--- a/components/NativeApp/MessageSync.js
+++ b/components/NativeApp/MessageSync.js
@@ -108,7 +108,9 @@ const MessageSync = ({ upsertDevice, me, client }) => {
       } else if (content.type === 'authorization') {
         checkPendingAppSignIn()
       } else if (content.type === 'push-route') {
-        Router.pushRoute(content.url.replace(PUBLIC_BASE_URL, ''))
+        Router.pushRoute(content.url.replace(PUBLIC_BASE_URL, '')).then(() => {
+          window.scrollTo(0, 0)
+        })
       } else if (content.type === 'osColorScheme') {
         if (content.value) {
           setOSColorScheme(content.value)

--- a/components/NativeApp/MessageSync.js
+++ b/components/NativeApp/MessageSync.js
@@ -108,8 +108,11 @@ const MessageSync = ({ upsertDevice, me, client }) => {
       } else if (content.type === 'authorization') {
         checkPendingAppSignIn()
       } else if (content.type === 'push-route') {
-        Router.pushRoute(content.url.replace(PUBLIC_BASE_URL, '')).then(() => {
-          window.scrollTo(0, 0)
+        const targetUrl = content.url.replace(PUBLIC_BASE_URL, '')
+        Router.pushRoute(targetUrl).then(() => {
+          if (targetUrl.indexOf('#') === -1) {
+            window.scrollTo(0, 0)
+          }
         })
       } else if (content.type === 'osColorScheme') {
         if (content.value) {


### PR DESCRIPTION
When app pushes a route, scroll to top afterwards.