### PR TITLE
support domains with mutated vowels (Umlaute)

### DIFF
--- a/components/Profile/Contact.js
+++ b/components/Profile/Contact.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { isWebUri } from 'valid-url'
+import { isURL } from 'validator'
 import { compose } from 'react-apollo'
 import { css } from 'glamor'
 import { Dropdown, Label, Interaction, IconButton } from '@project-r/styleguide'
@@ -27,7 +27,7 @@ const fields = t => [
     name: 'publicUrl',
     validator: value =>
       !!value &&
-      !isWebUri(value) &&
+      !isURL(value, { require_protocol: true, protocols: ['http', 'https'] }) &&
       value !== DEFAULT_VALUES.publicUrl &&
       t('profile/contact/publicUrl/error')
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12029,11 +12029,6 @@
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
       "dev": true
     },
-    "valid-url": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
-    },
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "topojson": "^3.0.2",
     "useragent": "^2.3.0",
     "uuid": "^3.4.0",
-    "valid-url": "^1.0.9",
     "validator": "^9.4.1"
   }
 }


### PR DESCRIPTION
This PR addresses #94.

I used the "isURL" function from the validator package and removed the valid-url package from the project.

Per default the function doesn't validate that the URL should have a protocol and `ftp://` is included in the default protocol list. As this is not what we want, I added options to the function call for validating that the protocol should be either `http` or `https`.

For an overview on which URLs the package regards as valid/invalid I recommend to look at their tests: https://github.com/validatorjs/validator.js/blob/master/test/validators.js#L333


I think it would be a good idea to run the new validator rules over all currently defined domains in the database, to see if any of them are non-compliant.

_PS: As I wasn't able to do the backend setup locally yet, I used the `npm run yaproxy ` command to test this change._