### PR TITLE
fix position bug close icon

### DIFF
--- a/components/Frame/Toggle.js
+++ b/components/Frame/Toggle.js
@@ -15,6 +15,8 @@ import {
 } from '../constants'
 
 const SIZE = 28
+const PADDING_MOBILE = Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)
+const PADDING_DESKTOP = Math.floor((HEADER_HEIGHT - SIZE) / 2)
 
 const Toggle = ({ expanded, onClick, ...props }) => {
   const [colorScheme] = useColorContext()
@@ -46,21 +48,21 @@ const styles = {
     border: 'none',
     boxShadow: 'none',
     outline: 'none',
-    padding: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
+    padding: PADDING_MOBILE,
     paddingRight: 16,
     lineHeight: 0,
     [mediaQueries.mUp]: {
-      padding: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`
+      padding: PADDING_DESKTOP
     }
   }),
   closeButton: css({
     position: 'absolute',
-    right: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
-    top: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
+    right: PADDING_MOBILE,
+    top: PADDING_MOBILE,
     transition: `opacity ${TRANSITION_MS}ms ease-out`,
     [mediaQueries.mUp]: {
-      right: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`,
-      top: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`
+      right: PADDING_DESKTOP,
+      top: PADDING_DESKTOP
     }
   })
 }

--- a/components/Frame/Toggle.js
+++ b/components/Frame/Toggle.js
@@ -55,11 +55,12 @@ const styles = {
   }),
   closeButton: css({
     position: 'absolute',
-    marginTop: -2,
-    right: 10,
+    right: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
+    top: `${Math.floor((HEADER_HEIGHT_MOBILE - SIZE) / 2)}px`,
     transition: `opacity ${TRANSITION_MS}ms ease-out`,
     [mediaQueries.mUp]: {
-      right: 16
+      right: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`,
+      top: `${Math.floor((HEADER_HEIGHT - SIZE) / 2)}px`
     }
   })
 }


### PR DESCRIPTION
probably a regression from icon PR. Either way the previous implementation was not good and didn't define a top position, which it now does (corresponding to the padding of the search-icon)

before: 
![IMG_2415](https://user-images.githubusercontent.com/20746301/116847426-c625e000-abea-11eb-88c2-ea1c582fa86f.PNG)
