### PR TITLE
Edit Button & Action Bar cleanup

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -7,12 +7,11 @@ import {
   PlayCircleIcon,
   DownloadIcon,
   PodcastIcon,
-  EditIcon,
   FontSizeIcon,
   ShareIcon,
   ChartIcon
 } from '@project-r/styleguide/icons'
-import { IconButton, colors, Interaction } from '@project-r/styleguide'
+import { IconButton, Interaction } from '@project-r/styleguide'
 import withT from '../../lib/withT'
 import withInNativeApp, { postMessage } from '../../lib/withInNativeApp'
 import { withEditor } from '../Auth/checkRoles'
@@ -21,7 +20,7 @@ import { splitByTitle } from '../../lib/utils/mdast'
 import { shouldIgnoreClick } from '../../lib/utils/link'
 import { trackEvent } from '../../lib/piwik'
 import { getDiscussionLinkProps } from './utils'
-import { PUBLIC_BASE_URL, PUBLIKATOR_BASE_URL } from '../../lib/constants'
+import { PUBLIC_BASE_URL } from '../../lib/constants'
 import PdfOverlay, { getPdfUrl } from '../Article/PdfOverlay'
 import FontSizeOverlay from '../FontSize/Overlay'
 import ShareOverlay from './ShareOverlay'
@@ -38,7 +37,6 @@ const ActionBar = ({
   mode,
   document,
   t,
-  isEditor,
   inNativeApp,
   share,
   download,
@@ -337,15 +335,6 @@ const ActionBar = ({
       ),
       modes: ['article-top', 'article-bottom', 'article-overlay', 'feed'],
       show: !!discussionId
-    },
-    {
-      Icon: EditIcon,
-      href: `${PUBLIKATOR_BASE_URL}/repo/${document.repoId}/tree`,
-      title: t('feed/actionbar/edit'),
-      target: '_blank',
-      fill: colors.social,
-      modes: ['article-top'],
-      show: isEditor && document.repoId && PUBLIKATOR_BASE_URL
     }
   ]
 

--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -57,12 +57,7 @@ const ActionBar = ({
     return (
       <div {...styles.topRow} {...(isCentered && { ...styles.centered })}>
         {download && (
-          <IconButton
-            href={download}
-            Icon={DownloadIcon}
-            label={share.label || ''}
-            target='_blank'
-          />
+          <IconButton href={download} Icon={DownloadIcon} target='_blank' />
         )}
         {fontSize && (
           <IconButton

--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -15,8 +15,10 @@ import {
   Editorial,
   ColorContextProvider,
   SHARE_IMAGE_HEIGHT,
-  SHARE_IMAGE_WIDTH
+  SHARE_IMAGE_WIDTH,
+  IconButton
 } from '@project-r/styleguide'
+import { EditIcon } from '@project-r/styleguide/icons'
 import { createRequire } from '@project-r/styleguide/lib/components/DynamicComponent'
 import createArticleSchema from '@project-r/styleguide/lib/templates/Article'
 import createFormatSchema from '@project-r/styleguide/lib/templates/Format'
@@ -35,7 +37,6 @@ import { PayNote, MAX_PAYNOTE_SEED } from './PayNote'
 import Progress from './Progress'
 import PodcastButtons from './PodcastButtons'
 import { getDocument } from './graphql/getDocument'
-
 import withT from '../../lib/withT'
 import { formatDate } from '../../lib/utils/format'
 import withInNativeApp, { postMessage } from '../../lib/withInNativeApp'
@@ -44,7 +45,11 @@ import { getRandomInt } from '../../lib/utils/helpers'
 import { splitByTitle } from '../../lib/utils/mdast'
 import withMemberStatus from '../../lib/withMemberStatus'
 import withMe from '../../lib/apollo/withMe'
-import { ASSETS_SERVER_BASE_URL, PUBLIC_BASE_URL } from '../../lib/constants'
+import {
+  ASSETS_SERVER_BASE_URL,
+  PUBLIC_BASE_URL,
+  PUBLIKATOR_BASE_URL
+} from '../../lib/constants'
 import ShareImage from './ShareImage'
 import FontSizeSync from '../FontSize/Sync'
 import Loader from '../Loader'
@@ -475,6 +480,19 @@ const ArticlePage = ({
                             </Editorial.Credit>
                           </TitleBlock>
                         )}
+                        {isEditor && repoId ? (
+                          <Center style={{ padding: '30px 15px 0 15px' }}>
+                            <IconButton
+                              Icon={EditIcon}
+                              href={`${PUBLIKATOR_BASE_URL}/repo/${repoId}/tree`}
+                              target='_blank'
+                              title={t('feed/actionbar/edit')}
+                              label={t('feed/actionbar/edit')}
+                              labelShort={t('feed/actionbar/edit')}
+                              fill={'#E9A733'}
+                            />
+                          </Center>
+                        ) : null}
                         {actionBar || isSection || showNewsletterSignupTop ? (
                           <Center>
                             {actionBar && (
@@ -510,6 +528,7 @@ const ArticlePage = ({
                             {/* space before paynote */}
                           </div>
                         )}
+
                         {!suppressFirstPayNote && payNote}
                       </div>
                     )}

--- a/components/Events/Detail.js
+++ b/components/Events/Detail.js
@@ -92,7 +92,8 @@ const Event = withT(
       url: `${PUBLIC_BASE_URL}/veranstaltung/${slug}`,
       emailSubject: title,
       tweet: title,
-      shareOverlayTitle: t('events/share/title')
+      shareOverlayTitle: t('events/share/title'),
+      label: t('events/share/title')
     }
     const borderRule = colorScheme.set('borderTopColor', 'divider')
 

--- a/components/Profile/Page.js
+++ b/components/Profile/Page.js
@@ -415,6 +415,7 @@ const LoadedProfile = props => {
 
   const shareObject = {
     title: t('profile/share/title', { name: user.name }),
+    label: t('profile/share/overlayTitle'),
     url: `${PUBLIC_BASE_URL}/~${user.slug}`,
     emailSubject: t('profile/share/emailSubject', { name: user.name }),
     emailAttachUrl: false,


### PR DESCRIPTION
### Adds share lables for events and profile page, removes unnecessary download label

before:
<img width="672" alt="Screenshot 2021-05-03 at 18 05 28" src="https://user-images.githubusercontent.com/20746301/116901405-2c861f00-ac3a-11eb-93e3-64b49aace429.png">

after (no label when mobile):
<img width="665" alt="Screenshot 2021-05-03 at 18 05 22" src="https://user-images.githubusercontent.com/20746301/116901411-2db74c00-ac3a-11eb-8861-cf6bd8325189.png">


### Removes editor from ActionBar and adds it to all article article pages with a repo id
before:
<img width="686" alt="Screenshot 2021-05-03 at 18 00 16" src="https://user-images.githubusercontent.com/20746301/116901292-0791ac00-ac3a-11eb-88d5-3614e01036ca.png">
after:
<img width="519" alt="Screenshot 2021-05-03 at 18 01 10" src="https://user-images.githubusercontent.com/20746301/116901301-09f40600-ac3a-11eb-85a1-272f1572c7d8.png">
