### PR TITLE
fix editbutton alignment when titleAlign is centered

### DIFF
--- a/components/Article/Page.js
+++ b/components/Article/Page.js
@@ -481,7 +481,16 @@ const ArticlePage = ({
                           </TitleBlock>
                         )}
                         {isEditor && repoId ? (
-                          <Center style={{ padding: '30px 15px 0 15px' }}>
+                          <Center
+                            style={{
+                              padding: '30px 15px 0 15px',
+                              display: 'flex',
+                              justifyContent:
+                                titleAlign === 'center'
+                                  ? 'center'
+                                  : 'flex-start'
+                            }}
+                          >
                             <IconButton
                               Icon={EditIcon}
                               href={`${PUBLIKATOR_BASE_URL}/repo/${repoId}/tree`}


### PR DESCRIPTION
before
<img width="950" alt="Bildschirmfoto 2021-05-04 um 17 04 22" src="https://user-images.githubusercontent.com/20746301/117026440-16d92e00-acfc-11eb-8262-b8940fb9e79e.png">

after
<img width="445" alt="Screenshot 2021-05-04 at 17 13 31" src="https://user-images.githubusercontent.com/20746301/117026466-1ccf0f00-acfc-11eb-977e-51feee6738ed.png">
