### PR TITLE
fix(Gallery): Harden stringify caption

### DIFF
--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -36,18 +36,19 @@ const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
           'article/gallery/error'
         )}</a></div>`,
         addCaptionHTMLFn: (item, captionEl) => {
-          let caption = ''
-          if (item.title) {
-            caption = item.title.trim()
+          const { caption, byLine } = item
+          const innerHtml = []
+
+          if (caption) {
+            innerHtml.push(caption)
           }
-          if (item.author) {
-            if (caption.length) {
-              caption += ' '
-            }
-            caption += `<small>${item.author}</small>`
+
+          if (byLine) {
+            innerHtml.push(`<small>${byLine}</small>`)
           }
-          captionEl.children[0].innerHTML = caption
-          return caption.length > 0
+
+          captionEl.children[0].innerHTML = innerHtml.join(' ')
+          return !!innerHtml.length
         }
       }
 


### PR DESCRIPTION
Gallery picked first mdast child to caption an image and thus failing on more complex structure e.g. mdast containing a link.

This Pull Request will stringify mdast children.

It assumes [children of type "emphasis" is a caption byline](https://github.com/orbiting/styleguide/blob/198f43845d282b498baafbc1e5684b90857bbb4f/src/templates/Article/base.js#L222), everything else is caption itself.

Figure caption in article view:

<img width="373" alt="Bildschirmfoto 2021-05-13 um 15 30 55" src="https://user-images.githubusercontent.com/331800/118132845-6dcbbb00-b400-11eb-812a-779a9515ea35.png">

Caption in gallery view:

<img width="382" alt="Bildschirmfoto 2021-05-13 um 15 31 20" src="https://user-images.githubusercontent.com/331800/118132870-758b5f80-b400-11eb-9eea-552a10fa77a8.png">
