### PR TITLE
Fixes for Payments

### DIFF
--- a/components/Payment/Form.js
+++ b/components/Payment/Form.js
@@ -106,7 +106,6 @@ const styles = {
     borderStyle: 'solid',
     height: PAYMENT_METHOD_HEIGHT - 2, // 2px borders
     padding: 10,
-    cursor: 'pointer',
     marginRight: 10,
     marginBottom: 10,
     lineHeight: 0,
@@ -150,7 +149,8 @@ const PaymentMethodLabel = ({
       )}
       style={{
         backgroundColor,
-        opacity: active ? 1 : 0.4
+        opacity: active ? 1 : 0.4,
+        cursor: active ? 'default' : 'pointer'
       }}
     >
       {children}

--- a/components/Pledge/ReceivePayment.js
+++ b/components/Pledge/ReceivePayment.js
@@ -248,7 +248,8 @@ class PledgeReceivePayment extends Component {
         method,
         pspPayload
       })
-      .then(() => {
+      .then(async ({ trackEcommerceOrder }) => {
+        await trackEcommerceOrder()
         if (!pledge || (!pledge.user && !me)) {
           gotoMerci({
             id: pledgeId

--- a/components/Pledge/ReceivePayment.js
+++ b/components/Pledge/ReceivePayment.js
@@ -248,8 +248,7 @@ class PledgeReceivePayment extends Component {
         method,
         pspPayload
       })
-      .then(async ({ trackEcommerceOrder }) => {
-        await trackEcommerceOrder()
+      .then(() => {
         if (!pledge || (!pledge.user && !me)) {
           gotoMerci({
             id: pledgeId

--- a/components/Pledge/Submit.js
+++ b/components/Pledge/Submit.js
@@ -541,7 +541,10 @@ class Submit extends Component {
       return true
     }
     if (autoPay === undefined) {
-      return options.every(option => option.autoPay !== false)
+      return (
+        options.every(option => option.autoPay !== false) &&
+        options.some(option => option.autoPay)
+      )
     }
     return autoPay
   }


### PR DESCRIPTION
- only show payment method cursor when not active
- fix `makeDefault` on `payPledge` being true for donation and give pledges
- only track order in matomo after confirm card payment