### PR TITLE
Track App Version with Custom Dimension

### DIFF
--- a/components/Track.js
+++ b/components/Track.js
@@ -1,11 +1,14 @@
-import { Component } from 'react'
+import { useEffect } from 'react'
 import Router from 'next/router'
 
 import { parse, format } from 'url'
 
+import { usePrevious } from '@project-r/styleguide'
+
 import withMe from '../lib/apollo/withMe'
 import track from '../lib/matomo'
 import { payload, getUtmParams } from '../lib/utils/track'
+import { useInNativeApp } from '../lib/withInNativeApp'
 
 import { PUBLIC_BASE_URL } from '../lib/constants'
 
@@ -71,39 +74,47 @@ const trackUrl = url => {
   track(['trackPageView'])
 }
 
-class Track extends Component {
-  componentDidMount() {
-    payload.disable(this.props.me && this.props.me.activeMembership)
-    trackRoles(this.props.me)
-    trackUrl(window.location.href)
-    Router.events.on('routeChangeComplete', this.onRouteChangeComplete)
-  }
-  onRouteChangeComplete = url => {
-    // give pages time to set correct page title
-    // may not always be enough, e.g. if data dependent and slow query/network, but works fine for many cases
-    setTimeout(() => {
-      // update url and title manually, necessary after client navigation
-      trackUrl(`${PUBLIC_BASE_URL}${url}`)
-    }, 600)
-  }
-  componentWillUnmount() {
-    Router.events.off('routeChangeComplete', this.onRouteChangeComplete)
-  }
-  UNSAFE_componentWillReceiveProps({ me }) {
-    if (
-      me !== this.props.me &&
-      (!me || !this.props.me || me.email !== this.props.me.email)
-    ) {
-      // start new visit with potentially different roles
-      track(['appendToTrackingUrl', 'new_visit=1'])
-      track(['deleteCookies'])
+const Track = ({ me }) => {
+  const prevMe = usePrevious(me)
+  useEffect(() => {
+    if (prevMe !== me && (!prevMe || !me || prevMe.email !== me.email)) {
+      if (prevMe !== undefined) {
+        // start new visit with potentially different roles
+        track(['appendToTrackingUrl', 'new_visit=1'])
+        track(['deleteCookies'])
+      }
       trackRoles(me)
     }
-    payload.disable(me && me.activeMembership)
-  }
-  render() {
-    return null
-  }
+    payload.disable(me?.activeMembership)
+  }, [me, prevMe])
+
+  const { inNativeAppVersion } = useInNativeApp()
+  useEffect(() => {
+    if (inNativeAppVersion) {
+      track(['setCustomDimension', 2, inNativeAppVersion])
+    } else {
+      track(['deleteCustomDimension', 2])
+    }
+  }, [inNativeAppVersion])
+
+  useEffect(() => {
+    trackUrl(window.location.href)
+
+    const onRouteChangeComplete = url => {
+      // give pages time to set correct page title
+      // may not always be enough, e.g. if data dependent and slow query/network, but works fine for many cases
+      setTimeout(() => {
+        // update url and title manually, necessary after client navigation
+        trackUrl(`${PUBLIC_BASE_URL}${url}`)
+      }, 600)
+    }
+    Router.events.on('routeChangeComplete', onRouteChangeComplete)
+    return () => {
+      Router.events.off('routeChangeComplete', onRouteChangeComplete)
+    }
+  }, [])
+
+  return null
 }
 
 export default withMe(Track)

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -113,6 +113,7 @@ export const useInNativeApp = () => {
   return {
     inNativeApp,
     inNativeAppLegacy: isLegacyApp(inNativeAppVersion),
+    inNativeAppVersion,
     inIOS,
     inNativeIOSApp: inNativeApp && inIOS
   }


### PR DESCRIPTION
before with simulated app ua:
```
track setCustomDimension 1 guest
track setCustomUrl http://localhost:3010/
track setDocumentTitle Anmelden – Republik
track trackPageView
```

after
```
track setCustomDimension 1 guest
track setCustomDimension 2 2.0.0
track setCustomUrl http://localhost:3010/
track setDocumentTitle Anmelden – Republik
track trackPageView
```

tracking of role still works as expected
```
track setCustomDimension 1 accomplice accountant admin associate editor member producer supporter tester
track deleteCustomDimension 2
track setCustomUrl http://localhost:3010/
track setDocumentTitle Magazin – Republik
track trackPageView
```
here an example of accessing through web where custom dimension 2 is deleted (no op if not present)
