### PR TITLE
Disable save if Sections/Profile form has errors

### DIFF
--- a/components/Onboarding/Sections/Profile.js
+++ b/components/Onboarding/Sections/Profile.js
@@ -108,6 +108,8 @@ class Profile extends Component {
     const { user, onContinue, t } = this.props
     const { values, errors, dirty } = this.state
 
+    const hasErrors = !!Object.keys(errors).filter(key => !!errors[key]).length
+
     const mergedValues = Object.assign(
       {},
       user,
@@ -195,7 +197,12 @@ class Profile extends Component {
                   {loading ? (
                     <InlineSpinner />
                   ) : (
-                    <Button primary block disabled={loading} onClick={mutate}>
+                    <Button
+                      primary
+                      block
+                      disabled={hasErrors || loading}
+                      onClick={mutate}
+                    >
                       {t('Onboarding/Sections/Profile/button/save', null, '')}
                     </Button>
                   )}


### PR DESCRIPTION
Save button becomes disabled if Profile form on onboarding has errors.

<img width="475" alt="Bildschirmfoto 2021-07-02 um 08 59 01" src="https://user-images.githubusercontent.com/331800/124234025-cc193e00-db13-11eb-9919-0cb26b3d56d0.png">
