### PR TITLE
refactor bottom panel overlays

### DIFF
--- a/components/ActionBar/index.js
+++ b/components/ActionBar/index.js
@@ -486,7 +486,7 @@ const styles = {
   overlay: css({
     marginTop: 0,
     width: '100%',
-    padding: '0 16px',
+    padding: '12px 16px',
     display: 'flex',
     justifyContent: 'space-between'
   }),

--- a/components/Article/ActionBarOverlay.js
+++ b/components/Article/ActionBarOverlay.js
@@ -1,17 +1,14 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { css } from 'glamor'
-import {
-  mediaQueries,
-  useColorContext,
-  useMediaQuery
-} from '@project-r/styleguide'
-import { ZINDEX_HEADER, AUDIO_PLAYER_HEIGHT } from '../constants'
+import { mediaQueries, useMediaQuery } from '@project-r/styleguide'
+import { AUDIO_PLAYER_HEIGHT } from '../constants'
+
+import BottomPanel from '../Frame/BottomPanel'
+
 const ACTIONBAR_FADE_AREA = 400
 const FOOTER_FADE_AREA = 800
 const FOOTER_FADE_AREA_MOBILE = 1200
 
-const ActionBarOverlay = ({ children, audioPlayerVisible, inNativeApp }) => {
-  const [colorScheme] = useColorContext()
+const ActionBarOverlay = ({ children, audioPlayerVisible }) => {
   const [overlayVisible, setOverlayVisible] = useState(false)
   const isDesktop = useMediaQuery(mediaQueries.mUp)
 
@@ -19,8 +16,6 @@ const ActionBarOverlay = ({ children, audioPlayerVisible, inNativeApp }) => {
   const diff = useRef(0)
 
   const audioPlayerOffset = audioPlayerVisible ? AUDIO_PLAYER_HEIGHT + 20 : 0
-  const bottomOffset = inNativeApp ? 20 : 44
-  const bottomPosition = audioPlayerOffset + bottomOffset
 
   useEffect(() => {
     const onScroll = () => {
@@ -57,34 +52,10 @@ const ActionBarOverlay = ({ children, audioPlayerVisible, inNativeApp }) => {
     }
   }, [isDesktop])
   return (
-    <div
-      style={{
-        opacity: overlayVisible ? 1 : 0,
-        pointerEvents: overlayVisible ? undefined : 'none',
-        bottom: bottomPosition,
-        zIndex: ZINDEX_HEADER
-      }}
-      {...colorScheme.set('backgroundColor', 'overlay')}
-      {...colorScheme.set('boxShadow', 'overlayShadow')}
-      {...styles.container}
-    >
+    <BottomPanel offset={audioPlayerOffset} visible={overlayVisible}>
       {children}
-    </div>
+    </BottomPanel>
   )
-}
-
-const styles = {
-  container: css({
-    position: 'fixed',
-    right: 0,
-    padding: '12px 0',
-    margin: '0 16px',
-    transition: 'opacity ease-out 0.3s, bottom ease-out 0.3s',
-    [mediaQueries.mUp]: {
-      right: 16,
-      left: 'auto'
-    }
-  })
 }
 
 export default ActionBarOverlay

--- a/components/Audio/AudioPlayer.js
+++ b/components/Audio/AudioPlayer.js
@@ -1,26 +1,19 @@
 import React from 'react'
-import { css } from 'glamor'
 import { AudioContext } from './AudioProvider'
-import {
-  mediaQueries,
-  zIndex,
-  AudioPlayer,
-  useColorContext
-} from '@project-r/styleguide'
+import { AudioPlayer } from '@project-r/styleguide'
 import ProgressComponent from '../../components/Article/Progress'
 import withT from '../../lib/withT'
 import { compose } from 'react-apollo'
 import { AUDIO_PLAYER_HEIGHT } from '../constants'
 import Link from '../Link/Href'
 
+import BottomPanel from '../Frame/BottomPanel'
+
 const AudioPlayerFrontend = ({ t }) => {
-  const [colorScheme] = useColorContext()
   return (
     <AudioContext.Consumer>
       {({
-        audioSource,
         audioPlayerVisible,
-        toggleAudioPlayer,
         onCloseAudioPlayer,
         audioState,
         autoPlayActive
@@ -28,64 +21,34 @@ const AudioPlayerFrontend = ({ t }) => {
         return (
           <>
             {audioState && (
-              <div
-                {...css(styles.audioPlayerContainer, {
-                  opacity: audioPlayerVisible ? 1 : 0,
-                  transform: audioPlayerVisible
-                    ? 'translateY(0)'
-                    : 'translateY(8px)'
-                })}
-              >
-                <div
-                  style={{
-                    boxShadow: colorScheme.getCSSColor('overlayShadow')
-                  }}
-                  {...colorScheme.set('backgroundColor', 'overlay')}
-                >
-                  <ProgressComponent isArticle={false}>
-                    <AudioPlayer
-                      key={audioState.mediaId || audioState.url}
-                      mediaId={audioState.mediaId}
-                      durationMs={audioState.audioSource.durationMs}
-                      src={audioState.audioSource}
-                      title={audioState.title}
-                      sourcePath={audioState.sourcePath}
-                      closeHandler={onCloseAudioPlayer}
-                      autoPlay={autoPlayActive}
-                      download
-                      scrubberPosition='bottom'
-                      t={t}
-                      fixed
-                      timePosition='left'
-                      height={AUDIO_PLAYER_HEIGHT}
-                      controlsPadding={18}
-                      Link={Link}
-                    />
-                  </ProgressComponent>
-                </div>
-              </div>
+              <BottomPanel wide visible={audioPlayerVisible}>
+                <ProgressComponent isArticle={false}>
+                  <AudioPlayer
+                    key={audioState.mediaId || audioState.url}
+                    mediaId={audioState.mediaId}
+                    durationMs={audioState.audioSource.durationMs}
+                    src={audioState.audioSource}
+                    title={audioState.title}
+                    sourcePath={audioState.sourcePath}
+                    closeHandler={onCloseAudioPlayer}
+                    autoPlay={autoPlayActive}
+                    download
+                    scrubberPosition='bottom'
+                    t={t}
+                    fixed
+                    timePosition='left'
+                    height={AUDIO_PLAYER_HEIGHT}
+                    controlsPadding={18}
+                    Link={Link}
+                  />
+                </ProgressComponent>
+              </BottomPanel>
             )}
           </>
         )
       }}
     </AudioContext.Consumer>
   )
-}
-
-const styles = {
-  audioPlayerContainer: css({
-    position: 'fixed',
-    width: '100%',
-    maxWidth: 414,
-    bottom: 44,
-    right: 0,
-    padding: '0 16px',
-    zIndex: zIndex.callout,
-    transition: 'all ease-out 0.3s',
-    [mediaQueries.mUp]: {
-      right: 16
-    }
-  })
 }
 
 const ComposedAudioPlayer = compose(withT)(AudioPlayerFrontend)

--- a/components/Frame/BottomPanel.js
+++ b/components/Frame/BottomPanel.js
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react'
+import { css } from 'glamor'
+
+import { useColorContext, mediaQueries, zIndex } from '@project-r/styleguide'
+import { useInNativeApp } from '../../lib/withInNativeApp'
+
+const MARGIN = 15
+
+const styles = {
+  container: css({
+    position: 'fixed',
+    right: 0,
+    zIndex: zIndex.callout,
+    transition: 'opacity ease-out 0.3s',
+    margin: `0 ${MARGIN}px`,
+    [mediaQueries.mUp]: {
+      right: MARGIN,
+      marginBottom: MARGIN
+    }
+  }),
+  wide: css({
+    width: [290, `calc(100% - ${MARGIN * 2}px)`],
+    maxWidth: 380
+  })
+}
+
+const BottomPanel = ({ children, visible, offset = 0, wide = false }) => {
+  const [colorScheme] = useColorContext()
+  const { inIOSVersion, inNativeApp } = useInNativeApp()
+
+  const bottomOffset =
+    !inNativeApp && inIOSVersion < 15
+      ? 44 // tap safety distance for iOS below 15
+      : MARGIN + 5 // 5px away from the bottom looks better
+  const bottomPosition = offset + bottomOffset
+
+  const bottomRule = useMemo(
+    () =>
+      css({
+        bottom: [
+          bottomPosition,
+          `calc(${bottomPosition}px + env(safe-area-inset-bottom))`
+        ]
+      }),
+    [bottomPosition]
+  )
+
+  return (
+    <div
+      style={{
+        opacity: visible ? 1 : 0,
+        pointerEvents: visible ? undefined : 'none'
+      }}
+      {...bottomRule}
+      {...colorScheme.set('backgroundColor', 'overlay')}
+      {...colorScheme.set('boxShadow', 'overlayShadow')}
+      {...styles.container}
+      {...(wide && styles.wide)}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default BottomPanel

--- a/lib/withInNativeApp.js
+++ b/lib/withInNativeApp.js
@@ -103,6 +103,11 @@ export const postMessage = !inNativeAppBrowser
       )
   : msg => console.warn('postMessage unavailable', msg)
 
+const getIOSVersion = userAgent => {
+  const matches = userAgent.match(/ OS ([\d_]+) /)
+  return matches ? parseFloat(matches[1]) : undefined
+}
+
 export const useInNativeApp = () => {
   const headers = useHeaders()
 
@@ -115,6 +120,7 @@ export const useInNativeApp = () => {
     inNativeAppLegacy: isLegacyApp(inNativeAppVersion),
     inNativeAppVersion,
     inIOS,
+    inIOSVersion: inIOS ? getIOSVersion(headers.userAgent) : undefined,
     inNativeIOSApp: inNativeApp && inIOS
   }
 }


### PR DESCRIPTION
- move bottom logic into one component for audio player and action bar
- introduce `env(safe-area-inset-bottom)` to fix #608 
- iOS 15 support without safe area needs

@ovbm recently found a [samuelkraft.com](https://samuelkraft.com/blog/safari-15-bottom-tab-bars-web) which this new logic is based on. Haven't tested on iOS 15 yet.

Side effects from unifying the logic and rendering path:
- same box shadow
- no more translate y animation (was audio player only)

<img width="855" alt="Screenshot 2021-07-15 at 16 56 02" src="https://user-images.githubusercontent.com/410211/125810214-c394a387-66e7-4556-a78a-3856e509b945.png">
<img width="565" alt="Screenshot 2021-07-15 at 16 56 14" src="https://user-images.githubusercontent.com/410211/125810239-dd7b034a-a578-40b3-9a78-ea0bb5b1c6da.png">
