### PR TITLE
fixes bug that broke discussion pages

### DIFF
--- a/components/Discussion/Comments.js
+++ b/components/Discussion/Comments.js
@@ -17,7 +17,7 @@ import DiscussionPreferences from './DiscussionPreferences'
 import SecondaryActions from './SecondaryActions'
 import ShareOverlay from './ShareOverlay'
 import CommentLink, { getFocusHref, getFocusUrl } from './CommentLink'
-import { getDiscussionHref } from './DiscussionLink'
+import { getDiscussionUrlObject } from './DiscussionLink'
 import { composerHints } from './constants'
 
 import {
@@ -96,8 +96,7 @@ const Comments = props => {
   } = props
 
   const router = useRouter()
-  const discussionHref = getDiscussionHref(discussion)
-
+  const discussionHref = getDiscussionUrlObject(discussion)
   /*
    * Subscribe to GraphQL updates of the dicsussion query.
    */

--- a/components/Discussion/Comments.js
+++ b/components/Discussion/Comments.js
@@ -96,7 +96,7 @@ const Comments = props => {
   } = props
 
   const router = useRouter()
-  const discussionHref = getDiscussionUrlObject(discussion)
+  const discussionUrlObject = getDiscussionUrlObject(discussion)
   /*
    * Subscribe to GraphQL updates of the dicsussion query.
    */
@@ -387,26 +387,26 @@ const Comments = props => {
               <div {...styles.orderByContainer}>
                 {board && (
                   <OrderByLink
-                    href={discussionHref}
+                    href={discussionUrlObject}
                     t={t}
                     orderBy={resolvedOrderBy}
                     value='HOT'
                   />
                 )}
                 <OrderByLink
-                  href={discussionHref}
+                  href={discussionUrlObject}
                   t={t}
                   orderBy={resolvedOrderBy}
                   value='DATE'
                 />
                 <OrderByLink
-                  href={discussionHref}
+                  href={discussionUrlObject}
                   t={t}
                   orderBy={resolvedOrderBy}
                   value='VOTES'
                 />
                 <OrderByLink
-                  href={discussionHref}
+                  href={discussionUrlObject}
                   t={t}
                   orderBy={resolvedOrderBy}
                   value='REPLIES'

--- a/components/Discussion/DiscussionLink.js
+++ b/components/Discussion/DiscussionLink.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { GENERAL_FEEDBACK_DISCUSSION_ID } from '../../lib/constants'
 import Link from 'next/link'
 
-export const getDiscussionHref = discussion => {
+export const getDiscussionUrlObject = discussion => {
   let tab
   if (discussion && discussion.document) {
     const meta = discussion.document.meta || {}
@@ -21,34 +21,27 @@ export const getDiscussionHref = discussion => {
       query: { t: tab, id: tab === 'general' ? undefined : discussion.id }
     }
   }
+  if (discussion) {
+    return {
+      pathname:
+        discussion.document &&
+        discussion.document.meta &&
+        discussion.document.meta.path
+          ? discussion.document.meta.path
+          : discussion.path,
+      query: {}
+    }
+  }
 }
 
-export const getDiscussionPath = discussion => {
-  return discussion.document &&
-    discussion.document.meta &&
-    discussion.document.meta.path
-    ? discussion.document.meta.path
-    : discussion.path
-}
-
-const DiscussionLink = ({ children, discussion, orderBy }) => {
-  const href = getDiscussionHref(discussion)
+const DiscussionLink = ({ children, discussion }) => {
+  const href = getDiscussionUrlObject(discussion)
   if (href) {
     return (
       <Link href={href} passHref>
         {children}
       </Link>
     )
-  }
-  if (discussion) {
-    const path = getDiscussionPath(discussion)
-    if (path) {
-      return (
-        <Link href={path} passHref>
-          {children}
-        </Link>
-      )
-    }
   }
   return children
 }


### PR DESCRIPTION
Problem was that getDiscussionHref was returning undefined for discussion pages. Created a new function that includes both getDiscussioHref and getDiscussionPath, which returns a UrlObject.