### PR TITLE
remove link style-overwrite

### DIFF
--- a/components/Notifications/SubscribedAuthors.js
+++ b/components/Notifications/SubscribedAuthors.js
@@ -40,6 +40,9 @@ const styles = {
       marginBottom: 0
     }
   }),
+  authorLink: css({
+    cursor: 'pointer'
+  }),
   checkbox: css({
     display: 'flex',
     flexDirection: 'row',
@@ -141,7 +144,7 @@ const SubscribedAuthors = ({
                 >
                   <div {...styles.author}>
                     <Link href={`/~${author.userDetails.slug}`}>
-                      <A>{author.object.name}</A>
+                      <A {...styles.authorLink}>{author.object.name}</A>
                     </Link>
                   </div>
                   <div {...styles.checkbox}>

--- a/components/Notifications/SubscribedAuthors.js
+++ b/components/Notifications/SubscribedAuthors.js
@@ -40,13 +40,6 @@ const styles = {
       marginBottom: 0
     }
   }),
-  userLink: css({
-    color: 'inherit',
-    textDecoration: 'underline',
-    '&:visited': {
-      color: 'inherit'
-    }
-  }),
   checkbox: css({
     display: 'flex',
     flexDirection: 'row',
@@ -148,7 +141,7 @@ const SubscribedAuthors = ({
                 >
                   <div {...styles.author}>
                     <Link href={`/~${author.userDetails.slug}`}>
-                      <A {...styles.userLink}>{author.object.name}</A>
+                      <A>{author.object.name}</A>
                     </Link>
                   </div>
                   <div {...styles.checkbox}>


### PR DESCRIPTION
## Description

Beneath the "Abonnierte Profile" heading the links to the profiles behave in an unexpected way. When the URL is accessed from an other site, the link styling isn't as expected (see first screenshot). However when the page is reloaded, the links are styled as expected (see second screenshot)

## Screenshots

<img width="802" alt="Screenshot 2021-09-16 at 10 39 25" src="https://user-images.githubusercontent.com/30313631/133579924-af91e76c-3b12-4590-ac78-38ca22b98b7c.png">
Profile link is black and underlined after accessing the page from a different URL.
(This is fixed with this PR )

<img width="802" alt="Screenshot 2021-09-16 at 10 39 57" src="https://user-images.githubusercontent.com/30313631/133579994-631025f0-8e33-48d8-b9a7-82d2a03ce879.png">
Profile link is green as expected after reloading the page
