### PR TITLE
replace author-link with editorial link for better UX

### DIFF
--- a/components/Notifications/SubscribedAuthors.js
+++ b/components/Notifications/SubscribedAuthors.js
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react'
 import { compose, graphql } from 'react-apollo'
 import { myUserSubscriptions } from './enhancers'
 import {
+  Editorial,
   plainButtonRule,
   A,
   Interaction,
@@ -141,7 +142,7 @@ const SubscribedAuthors = ({
                 >
                   <div {...styles.author}>
                     <Link href={`/~${author.userDetails.slug}`} passHref>
-                      <A>{author.object.name}</A>
+                      <Editorial.A>{author.object.name}</Editorial.A>
                     </Link>
                   </div>
                   <div {...styles.checkbox}>


### PR DESCRIPTION
## Description

Use an editorial link instead of a regular link to make for a better UX. Since accessing the author-profile is not the main focus of the author-list the emphasis should be on the subscription checkboxes and not the author-link. Replacing the regular (green) link with the editorial-link (black text and underlined) achieves this.

## Screenshots

### Before

<img width="966" alt="Screenshot 2021-09-16 at 13 23 14" src="https://user-images.githubusercontent.com/30313631/133603614-5dd68477-8fa4-4b45-88bd-5048f0249ae3.png">

### After

<img width="966" alt="Screenshot 2021-09-16 at 13 23 33" src="https://user-images.githubusercontent.com/30313631/133603656-46f0b7e1-3d31-4558-adde-565c731bc24c.png">

