### PR TITLE
Gallery fixes

### DIFF
--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -1,7 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import Gallery from './Gallery'
-import get from 'lodash/get'
 import { imageSizeInfo } from 'mdast-react-render/lib/utils'
 import { postMessage } from '../../lib/withInNativeApp'
 import { removeQuery } from '../../lib/utils/link'
@@ -41,11 +40,11 @@ const findFigures = (node, acc = []) => {
 }
 
 const getImageProps = node => {
-  const url = get(node, 'children[0].children[0].url', '')
-  const urlDark = get(node, 'children[0].children[2].url')
-  const captionMdast = get(node, 'children[1].children', [])
+  const url = node?.children[0]?.children[0]?.url || ''
+  const urlDark = node?.children[0]?.children[2]?.url
+  const captionMdast = node?.children[1]?.children
   const included =
-    !get(node, 'data.excludeFromGallery', false) &&
+    !node?.data?.excludeFromGallery &&
     imageSizeInfo(url) &&
     imageSizeInfo(url).width > MIN_GALLERY_IMG_WIDTH
 
@@ -137,7 +136,7 @@ class ArticleGallery extends Component {
     const { children } = this.props
     const { article } = this.props
     const { show, startItemSrc, galleryItems } = this.state
-    const enabled = get(article, 'content.meta.gallery', true)
+    const enabled = article?.content?.meta?.gallery !== false
     return (
       <Fragment>
         {article.content && enabled && show && (

--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -122,7 +122,6 @@ class ArticleGallery extends Component {
   }
 
   static getDerivedStateFromProps(nextProps) {
-    console.log(getGalleryItems(nextProps))
     return {
       galleryItems: getGalleryItems(nextProps)
     }

--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -4,6 +4,7 @@ import Gallery from './Gallery'
 import get from 'lodash/get'
 import { imageSizeInfo } from 'mdast-react-render/lib/utils'
 import { postMessage } from '../../lib/withInNativeApp'
+import { removeQuery } from '../../lib/utils/link'
 
 export const mdastToString = node =>
   node
@@ -32,6 +33,7 @@ const findFigures = (node, acc = []) => {
 
 const getImageProps = node => {
   const url = get(node, 'children[0].children[0].url', '')
+  const urlDark = get(node, 'children[0].children[2].url')
   const captionMdast = get(node, 'children[1].children', [])
 
   // Children of type "emphasis" ought to be caption byline
@@ -47,6 +49,7 @@ const getImageProps = node => {
 
   return {
     src: url,
+    srcDark: urlDark,
     title: true, // otherwise PhotoSwipe won't call addCaptionHTMLFn
     caption,
     byLine
@@ -58,8 +61,6 @@ const getGalleryItems = ({ article }) => {
     .map(getImageProps)
     .filter(i => imageSizeInfo(i.src) && imageSizeInfo(i.src).width > 600)
 }
-
-const removeQuery = (url = '') => url.split('?')[0]
 
 class ArticleGallery extends Component {
   constructor(props) {

--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -42,7 +42,7 @@ const findFigures = (node, acc = []) => {
 const getImageProps = node => {
   const url = node?.children[0]?.children[0]?.url || ''
   const urlDark = node?.children[0]?.children[2]?.url
-  const captionMdast = node?.children[1]?.children
+  const captionMdast = node?.children[1]?.children || []
   const included =
     !node?.data?.excludeFromGallery &&
     imageSizeInfo(url) &&

--- a/components/Gallery/ArticleGallery.js
+++ b/components/Gallery/ArticleGallery.js
@@ -17,11 +17,11 @@ export const mdastToString = node =>
 const getGroupFigures = group => {
   const nodes = group.children
   if (!nodes || nodes.length < 2) return []
-  const captionMdast = nodes[nodes.length - 1]
-  const figures = nodes.slice(0, nodes.length - 1)
+  const groupCaptionMdast = nodes.find(n => n.type === 'paragraph')
+  const figures = nodes.slice(0, nodes.length - (groupCaptionMdast ? 1 : 0))
   return figures.map(f => ({
     ...f,
-    children: f.children.concat(captionMdast)
+    children: f.children.concat(groupCaptionMdast)
   }))
 }
 

--- a/components/Gallery/Gallery.js
+++ b/components/Gallery/Gallery.js
@@ -8,8 +8,7 @@ import { Spinner } from '@project-r/styleguide'
 import withT from '../../lib/withT'
 import photoswipeStyle from './photoswipeStyle'
 import { ZINDEX_GALLERY } from '../constants'
-
-const removeQuery = (url = '') => url.split('?')[0]
+import { removeQuery } from '../../lib/utils/link'
 
 const MAX_SPREAD_ZOOM = 2
 
@@ -60,12 +59,13 @@ const Gallery = ({ items, onClose, startItemSrc, children, t }) => {
       )
 
       gallery.listen('gettingData', function(index, item) {
-        const sizeInfo = imageSizeInfo(item.src)
+        const src = item.srcDark || item.src
+        const sizeInfo = imageSizeInfo(src)
         const maxWidth = Math.min(
           sizeInfo.width,
           Math.ceil((window.innerWidth * MAX_SPREAD_ZOOM) / 500) * 500
         )
-        const resizeUrl = imageResizeUrl(item.src, `${maxWidth}x`)
+        const resizeUrl = imageResizeUrl(src, `${maxWidth}x`)
         const aspectRatio = sizeInfo.height / sizeInfo.width
         item.src = resizeUrl
         item.w = maxWidth

--- a/lib/utils/link.js
+++ b/lib/utils/link.js
@@ -15,6 +15,8 @@ export const shouldIgnoreClick = (event, ignoreTarget) => {
   )
 }
 
-export const cleanAsPath = asPath => asPath.split('?')[0].split('#')[0]
+export const removeQuery = (url = '') => url.split('?')[0]
+
+export const cleanAsPath = asPath => removeQuery(asPath).split('#')[0]
 
 export const scrollTop = () => window.scrollTo(0, 0)


### PR DESCRIPTION
## prioritise shower dark mode images
<img width="1458" alt="Screenshot 2021-09-21 at 16 36 01" src="https://user-images.githubusercontent.com/3907984/134191175-9cb4048b-522e-4b8f-98af-c1a95cedfa14.png">

## show image group captions in gallery
(when no individual caption is set)
<img width="1920" alt="Screenshot 2021-09-21 at 16 29 00" src="https://user-images.githubusercontent.com/3907984/134192761-b24af3d0-2d3a-4a1d-b518-e58dae743d8d.png">
<img width="1920" alt="Screenshot 2021-09-21 at 16 29 07" src="https://user-images.githubusercontent.com/3907984/134192782-881f693b-ce92-49a5-9fda-c8b7fa981bf2.png">
 