### PR TITLE
update sibilings element display style to fix link-height

### DIFF
--- a/components/Overview/TeaserBlock.js
+++ b/components/Overview/TeaserBlock.js
@@ -220,12 +220,17 @@ class TeaserBlock extends Component {
                     highlight={highlight}
                   />
                 )}
-                <div style={{ position: 'relative' }} data-teaser={teaser.id}>
+                <div
+                  style={{
+                    position: 'relative'
+                  }}
+                  data-teaser={teaser.id}
+                >
                   <Image
                     onLoad={this.measure}
                     src={getImgSrc(teaser, path)}
                     style={{
-                      display: 'inline-block',
+                      display: 'block',
                       // unbreakable margin
                       // GAP needs to be with an inline-block to prevent
                       // the browser from breaking the margin between columns

--- a/components/Overview/TeaserBlock.js
+++ b/components/Overview/TeaserBlock.js
@@ -222,7 +222,11 @@ class TeaserBlock extends Component {
                 )}
                 <div
                   style={{
-                    position: 'relative'
+                    position: 'relative',
+                    // unbreakable margin
+                    // GAP needs to be with an inline-block to prevent
+                    // the browser from breaking the margin between columns
+                    display: 'inline-block'
                   }}
                   data-teaser={teaser.id}
                 >
@@ -231,9 +235,6 @@ class TeaserBlock extends Component {
                     src={getImgSrc(teaser, path)}
                     style={{
                       display: 'block',
-                      // unbreakable margin
-                      // GAP needs to be with an inline-block to prevent
-                      // the browser from breaking the margin between columns
                       marginBottom: GAP,
                       width: '100%'
                     }}


### PR DESCRIPTION
## Description

Fix an issue where the absolutely positioned link didn't cover the full image on firefox ([issue 621](https://github.com/orbiting/republik-frontend/issues/621)). The issue was fixed by updating the images display style from 'inline-block' to 'block'.

## Screenshots

### Before fix

<img width="590" alt="Screenshot 2021-09-23 at 15 42 06" src="https://user-images.githubusercontent.com/30313631/134518368-3e893097-1067-47d8-9d70-5ed82610fee0.png">

<img width="590" alt="Screenshot 2021-09-23 at 15 42 12" src="https://user-images.githubusercontent.com/30313631/134518380-985ed8ea-1c22-45be-9a2d-4421ff6b3b70.png">


### After fix

<img width="590" alt="Screenshot 2021-09-23 at 15 43 05" src="https://user-images.githubusercontent.com/30313631/134518405-7db85873-5cd0-4496-9d48-747f687f4931.png">

<img width="590" alt="Screenshot 2021-09-23 at 15 43 10" src="https://user-images.githubusercontent.com/30313631/134518423-efbd210c-4a9b-4aee-9e84-9941117b619e.png">

