### PR TITLE
Fix a bug that causes an error when running fetchMore on the Dialog

### DIFF
--- a/lib/apollo/apolloClient.ts
+++ b/lib/apollo/apolloClient.ts
@@ -26,6 +26,9 @@ type Options = {
 }
 
 function mergeExistingData(existing, incoming) {
+  // Null values should be overwritten by the incoming value
+  if (!existing) return incoming
+
   return { ...existing, ...incoming }
 }
 


### PR DESCRIPTION
## Description

Fixes a bug caused by trying to merge null values inside the mergeExistingData helper function inside the apolloClient.
Before this fix, trying to merge two "null" values, resulted in an empty object to be returned.