### PR TITLE
update bucket count

### DIFF
--- a/components/Discussion/TagFilter.js
+++ b/components/Discussion/TagFilter.js
@@ -59,7 +59,7 @@ const TagFilter = ({ discussion }) => {
     value: tag,
     count: tagBuckets.find(t => t.value === tag)?.count || 0
   }))
-  const totalCount = tagBuckets.reduce((acc, bucket) => acc + bucket.count, 0)
+  const totalCount = discussion.allComments.totalCount
   return (
     <div
       {...styles.tagsContainer}

--- a/components/Discussion/graphql/documents.js
+++ b/components/Discussion/graphql/documents.js
@@ -81,6 +81,17 @@ export const discussionQuery = gql`
     }
     discussion(id: $discussionId) {
       ...Discussion
+      allComments: comments(
+        parentId: $parentId
+        after: $after
+        orderBy: $orderBy
+        first: 100
+        flatDepth: $depth
+        focusId: $focusId
+        includeParent: $includeParent
+      ) {
+        totalCount
+      }
       comments(
         parentId: $parentId
         after: $after

--- a/components/Discussion/graphql/store.js
+++ b/components/Discussion/graphql/store.js
@@ -34,6 +34,7 @@ export const mergeComment = ({ comment, initialParentId }) => draft => {
   })
 
   bumpCounts({ comment, initialParentId })(draft)
+  bumpTagCounts({ comment, initialParentId })(draft)
 }
 
 // we keep track of which cache keys we've already bumped
@@ -56,6 +57,7 @@ export const bumpCounts = ({ comment, initialParentId }) => draft => {
      * increment 'directTotalCount' if it was a root comment.
      */
     draft.discussion.comments.totalCount += 1
+    draft.discussion.allComments.totalCount += 1 // all tags: used for filter count
     if (!parentId) {
       draft.discussion.comments.directTotalCount += 1
     }
@@ -81,6 +83,26 @@ export const bumpCounts = ({ comment, initialParentId }) => draft => {
         bumpedKeys.add(commentCommentsKey)
       }
     }
+  }
+}
+
+/**
+ * Give a new comment, bump the tag buckets counts
+ */
+export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
+  const nodes = draft.discussion.comments.nodes
+
+  const rootComment = comment.parentIds?.length
+    ? nodes.find(n => n.id === comment.parentIds[0])
+    : comment
+
+  const tags = rootComment.tags
+
+  if (!tags?.length) return
+
+  for (const tag of tags) {
+    const bucket = draft.discussion.tagBuckets?.find(b => b.value === tag)
+    bucket.count++
   }
 }
 

--- a/components/Discussion/graphql/store.js
+++ b/components/Discussion/graphql/store.js
@@ -92,18 +92,19 @@ export const bumpCounts = ({ comment, initialParentId }) => draft => {
 export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
   const nodes = draft.discussion.comments.nodes
 
-  const rootComment = comment.parentIds?.length
-    ? nodes.find(n => n.id === comment.parentIds[0])
+  const parentId = comment.parentIds[0]
+  const rootComment = parentId
+    ? nodes.find(n => n.id === parentId)
     : comment
 
-  const tags = rootComment.tags
+  const affectedTags = rootComment?.tags
 
-  if (!tags?.length) return
+  if (!affectedTags?.length) return
 
-  for (const tag of tags) {
+  for (const tag of affectedTags) {
     const bucket = draft.discussion.tagBuckets?.find(b => b.value === tag)
     if (bucket) {
-      bucket.count++
+      bucket.count =+ 1
     }
   }
 }

--- a/components/Discussion/graphql/store.js
+++ b/components/Discussion/graphql/store.js
@@ -93,9 +93,7 @@ export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
   const nodes = draft.discussion.comments.nodes
 
   const parentId = comment.parentIds[0]
-  const rootComment = parentId
-    ? nodes.find(n => n.id === parentId)
-    : comment
+  const rootComment = parentId ? nodes.find(n => n.id === parentId) : comment
 
   const affectedTags = rootComment?.tags
 
@@ -104,7 +102,7 @@ export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
   for (const tag of affectedTags) {
     const bucket = draft.discussion.tagBuckets?.find(b => b.value === tag)
     if (bucket) {
-      bucket.count =+ 1
+      bucket.count += 1
     }
   }
 }

--- a/components/Discussion/graphql/store.js
+++ b/components/Discussion/graphql/store.js
@@ -102,7 +102,9 @@ export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
 
   for (const tag of tags) {
     const bucket = draft.discussion.tagBuckets?.find(b => b.value === tag)
-    bucket.count++
+    if (bucket) {
+      bucket.count++
+    }
   }
 }
 


### PR DESCRIPTION
- Increment count in correct tag bucket after publishing a comment
- Fix logic error in how the code gets its count for `All` comments (previous method didn't account for comments without tags).