### PR TITLE
Refactor Document List

### DIFF
--- a/components/Feed/DocumentListContainer.js
+++ b/components/Feed/DocumentListContainer.js
@@ -1,11 +1,10 @@
-import React, { Component } from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Query } from '@apollo/client/react/components'
 import Loader from '../Loader'
 import DocumentList from './DocumentList'
-import noop from 'lodash/noop'
 
 import { documentFragment } from './fragments'
+import { useQuery } from '@apollo/client'
 
 export const documentListQueryFragment = `
   fragment DocumentListConnection on DocumentConnection {
@@ -63,79 +62,71 @@ export const makeLoadMore = ({
     }
   })
 
-class LifecycleWrapper extends Component {
-  componentWillUnmount() {
-    this.props.onComponentWillUnmount && this.props.onComponentWillUnmount()
-  }
-  render() {
-    return this.props.children
-  }
-}
+const DocumentListContainer = props => {
+  const {
+    query,
+    variables,
+    getConnection,
+    mergeConnection,
+    mapNodes,
+    placeholder,
+    help,
+    empty,
+    feedProps,
+    refetchOnUnmount,
+    showTotal
+  } = props
 
-class DocumentListContainer extends Component {
-  render() {
-    const {
-      query,
-      variables,
-      getConnection,
-      mergeConnection,
-      mapNodes,
-      placeholder,
-      help,
-      empty,
-      feedProps,
-      refetchOnUnmount,
-      showTotal
-    } = this.props
+  const { loading, error, data, fetchMore, refetch } = useQuery(query, {
+    variables
+  })
 
-    return (
-      <Query query={query} variables={variables}>
-        {({ loading, error, data, fetchMore, refetch }) => (
-          <LifecycleWrapper
-            onComponentWillUnmount={refetchOnUnmount ? refetch : noop}
-          >
-            <Loader
-              loading={loading}
-              error={error}
-              render={() => {
-                const connection = getConnection(data)
-                const isEmpty = connection.totalCount < 1
-                if (isEmpty) {
-                  return placeholder
-                } else {
-                  const hasMore = connection.pageInfo.hasNextPage
-                  return (
-                    <>
-                      <DocumentList
-                        documents={connection.nodes
-                          .map(mapNodes)
-                          .filter(Boolean)}
-                        totalCount={connection.totalCount}
-                        hasMore={hasMore}
-                        loadMore={makeLoadMore({
-                          fetchMore,
-                          connection,
-                          getConnection,
-                          mergeConnection,
-                          mapNodes,
-                          variables
-                        })}
-                        feedProps={feedProps}
-                        showTotal={showTotal}
-                        help={help}
-                        empty={empty}
-                        variables={variables}
-                      />
-                    </>
-                  )
-                }
-              }}
+  useEffect(() => {
+    if (refetchOnUnmount) {
+      return () => {
+        refetch()
+      }
+    }
+  }, [refetchOnUnmount])
+  if (process.browser) {
+    window.refetch = refetch
+  }
+
+  return (
+    <Loader
+      loading={loading}
+      error={error}
+      render={() => {
+        const connection = getConnection(data)
+        const isEmpty = connection.totalCount < 1
+        if (isEmpty) {
+          return placeholder
+        } else {
+          const hasMore = connection.pageInfo.hasNextPage
+          return (
+            <DocumentList
+              documents={connection.nodes.map(mapNodes).filter(Boolean)}
+              totalCount={connection.totalCount}
+              hasMore={hasMore}
+              loadMore={makeLoadMore({
+                fetchMore,
+                connection,
+                getConnection,
+                mergeConnection,
+                mapNodes,
+                variables
+              })}
+              feedProps={feedProps}
+              showTotal={showTotal}
+              help={help}
+              empty={empty}
+              variables={variables}
             />
-          </LifecycleWrapper>
-        )}
-      </Query>
-    )
-  }
+          )
+        }
+      }}
+    />
+  )
 }
 
 DocumentListContainer.defaultProps = defaultProps

--- a/components/Feed/DocumentListContainer.js
+++ b/components/Feed/DocumentListContainer.js
@@ -62,8 +62,7 @@ export const makeLoadMore = ({
     }
   })
 
-const DocumentListContainer = props => {
-  const {
+const DocumentListContainer = ({
     query,
     variables,
     getConnection,
@@ -75,7 +74,7 @@ const DocumentListContainer = props => {
     feedProps,
     refetchOnUnmount,
     showTotal
-  } = props
+}) => {
 
   const { loading, error, data, fetchMore, refetch } = useQuery(query, {
     variables

--- a/lib/apollo/apolloClient.ts
+++ b/lib/apollo/apolloClient.ts
@@ -25,9 +25,9 @@ type Options = {
   onResponse?: any
 }
 
-function mergeExistingData(existing, incoming) {
-  // Null values should be overwritten by the incoming value
-  if (!existing) return incoming
+function mergeNullableData(existing, incoming) {
+  // only merge truthy objects
+  if (!existing || !incoming) return incoming
 
   return { ...existing, ...incoming }
 }
@@ -54,7 +54,7 @@ function createApolloClient(
         Discussion: {
           fields: {
             userPreference: {
-              merge: mergeExistingData
+              merge: mergeNullableData
             }
           }
         }


### PR DESCRIPTION
While trying to debug the issue of fetch more in format feeds not working I refactored some code which didn't help but is still nice to have after a careful review & test round.

The workaround I found for fetch more:
https://github.com/orbiting/republik-frontend/commit/468a2acb8524a5675b11721299c99581b5868dd1

It basically ensures that the whole `getFeedDocuments` query of format feeds is re-run and properly subscribed to. The issue also disappeared when `articleRefetch` in `Article/Page` was disabled. My theory is that somehow after a refetch nested queries get broken / no longer receive updates. Remounting the query then seems to help.

While debugging I also explored `typePolicies` for the Query type that merges documents. Following logic worked but did not solve the refetch / data update issue after fetch more.

```js
    new InMemoryCache({
      typePolicies: {
        Query: {
          fields: {
            documents: {
              keyArgs: args => {
                return Object.keys(args).filter(a => a !== 'after')
              },
              merge: (existing, incoming) => {
                // only merge truthy objects
                if (!existing || !incoming) return incoming
                return {
                  ...existing,
                  ...incoming,
                  nodes: [...existing.nodes, ...incoming.nodes].filter(
                    // deduplicating due to off by one in pagination API
                    (node, index, all) =>
                      all.findIndex(n => n.__ref === node.__ref) === index
                  )
                }
              }
            }
          }
        },
```

If we want to get ride of `updateQuery` we also need to handle `search` and probably a bunch of other queries.