### PR TITLE
fix merge comment for tags

### DIFF
--- a/components/Discussion/graphql/enhancers/withSubmitComment.js
+++ b/components/Discussion/graphql/enhancers/withSubmitComment.js
@@ -136,7 +136,8 @@ export const withSubmitComment = compose(
                 proxy.readQuery({ query: discussionQuery, variables }),
                 mergeComment({
                   comment,
-                  initialParentId
+                  initialParentId,
+                  activeTag
                 })
               )
             })

--- a/components/Discussion/graphql/store.js
+++ b/components/Discussion/graphql/store.js
@@ -14,7 +14,20 @@ import { debug } from '../debug'
  * from the submitComment mutation update function to merge the just created comment
  * into the discussion.
  */
-export const mergeComment = ({ comment, initialParentId }) => draft => {
+export const mergeComment = ({
+  comment,
+  initialParentId,
+  activeTag
+}) => draft => {
+  bumpCounts({ comment, initialParentId })(draft)
+  bumpTagCounts({ comment, initialParentId })(draft)
+
+  /*
+   * If the active tag and the comment tag don't match,
+   * we don't insert the new comment in the tree.
+   */
+  if (comment.tags?.length && !comment.tags.find(t => t === activeTag)) return
+
   const parentId = comment.parentIds[comment.parentIds.length - 1]
   const nodes = draft.discussion.comments.nodes
 
@@ -32,9 +45,6 @@ export const mergeComment = ({ comment, initialParentId }) => draft => {
     ...comment,
     comments: emptyCommentsConnection
   })
-
-  bumpCounts({ comment, initialParentId })(draft)
-  bumpTagCounts({ comment, initialParentId })(draft)
 }
 
 // we keep track of which cache keys we've already bumped
@@ -111,7 +121,12 @@ export const bumpTagCounts = ({ comment, initialParentId }) => draft => {
  * Merge multiple comments (a whole CommentConnection) into the Discussion draft. This
  * function is used in the discussionQuery fetchMore code path.
  */
-export const mergeComments = ({ parentId, appendAfter, comments }) => draft => {
+export const mergeComments = ({
+  parentId,
+  appendAfter,
+  comments,
+  activeTag
+}) => draft => {
   const nodes = draft.discussion.comments.nodes
 
   /*


### PR DESCRIPTION
Bug: new comment whose tag doesn't match active tag was insert into discussion nonetheless. 
We now check that for the tags while merge a new comment.