### PR TITLE
Suggested Total

### DIFF
--- a/components/Pledge/CustomizePackage.js
+++ b/components/Pledge/CustomizePackage.js
@@ -80,10 +80,31 @@ const calculateMinPrice = (pkg, values, userPrice) => {
   return absolutMinPrice
 }
 
-const getPrice = ({ values, pkg, userPrice }) => {
+const getPrice = ({ values, pkg, userPrice, router }) => {
   if (values.price !== undefined) {
     return values.price
   } else {
+    if (pkg.suggestedTotal) {
+      const regularMinPrice = calculateMinPrice(pkg, values, false)
+      if (
+        pkg.suggestedTotal < regularMinPrice &&
+        !userPrice &&
+        process.browser
+      ) {
+        router.replace(
+          {
+            pathname: 'pledge',
+            query: {
+              ...router.query,
+              userPrice: '1'
+            }
+          },
+          undefined,
+          { shallow: true }
+        )
+      }
+      return pkg.suggestedTotal
+    }
     if (userPrice) {
       return ''
     }

--- a/components/Pledge/CustomizePackage.js
+++ b/components/Pledge/CustomizePackage.js
@@ -93,7 +93,7 @@ const getPrice = ({ values, pkg, userPrice, router }) => {
       ) {
         router.replace(
           {
-            pathname: 'pledge',
+            pathname: 'angebote',
             query: {
               ...router.query,
               userPrice: '1'
@@ -322,7 +322,9 @@ class CustomizePackage extends Component {
     const { router } = this.props
     const query = { ...router.query }
     delete query.userPrice
-    router.replace({ pathname: 'pledge', query }, undefined, { shallow: true })
+    router.replace({ pathname: 'angebote', query }, undefined, {
+      shallow: true
+    })
   }
   componentWillUnmount() {
     this.resetPrice()

--- a/components/Pledge/CustomizePackage.js
+++ b/components/Pledge/CustomizePackage.js
@@ -6,6 +6,7 @@ import { nest } from 'd3-collection'
 import { sum, min, ascending } from 'd3-array'
 import { timeDay } from 'd3-time'
 import compose from 'lodash/flowRight'
+import omit from 'lodash/omit'
 import { withRouter } from 'next/router'
 import { format } from 'url'
 
@@ -482,14 +483,13 @@ class CustomizePackage extends Component {
           pkg.name === 'ABO_GIVE_MONTHS' ||
           pkg.name === 'ABO_GIVE'
         ? []
+        : userPrice
+        ? [{ value: regularMinPrice, key: 'normal' }]
         : [
-            userPrice && { value: regularMinPrice, key: 'normal' },
-            !userPrice &&
-              price >= minPrice &&
+            price >= minPrice &&
               bonusValue && { value: minPrice + bonusValue, key: 'bonus' },
-            !userPrice &&
-              price >= minPrice && { value: minPrice * 1.5, key: '1.5' },
-            !userPrice && price >= minPrice && { value: minPrice * 2, key: '2' }
+            price >= minPrice && { value: minPrice * 1.5, key: '1.5' },
+            price >= minPrice && { value: minPrice * 2, key: '2' }
           ].filter(Boolean)
     const payMoreReached = payMoreSuggestions
       .filter(({ value }) => price >= value)
@@ -1265,10 +1265,14 @@ class CustomizePackage extends Component {
               {payMoreSuggestions.length > 0 && (
                 <Fragment>
                   <Interaction.Emphasis>
-                    {t.first([
-                      `package/customize/price/payMore/${pkg.name}`,
-                      'package/customize/price/payMore'
-                    ])}
+                    {t.first(
+                      [
+                        userPrice &&
+                          'package/customize/price/payMore/userPrice',
+                        `package/customize/price/payMore/${pkg.name}`,
+                        'package/customize/price/payMore'
+                      ].filter(Boolean)
+                    )}
                   </Interaction.Emphasis>
                   <ul {...styles.ul}>
                     {payMoreSuggestions.map(({ value, key }) => {
@@ -1436,20 +1440,20 @@ class CustomizePackage extends Component {
                   <Editorial.A
                     href={format({
                       pathname: '/angebote',
-                      query: { ...query, price: undefined }
+                      query: omit(query, ['price', 'userPrice'])
                     })}
                     onClick={e => {
                       if (shouldIgnoreClick(e)) {
                         return
                       }
                       e.preventDefault()
-                      onPriceChange(undefined, minPrice / 100, true)
+                      onPriceChange(undefined, regularMinPrice / 100, true)
 
                       router
                         .replace(
                           {
                             pathname: '/angebote',
-                            query: { ...query, price: undefined }
+                            query: omit(query, ['price', 'userPrice'])
                           },
                           undefined,
                           { shallow: true }
@@ -1474,7 +1478,7 @@ class CustomizePackage extends Component {
                   <Editorial.A
                     href={format({
                       pathname: '/angebote',
-                      query: { ...query, price: undefined, userPrice: 1 }
+                      query: { ...omit(query, ['price']), userPrice: 1 }
                     })}
                     onClick={e => {
                       if (shouldIgnoreClick(e)) {
@@ -1507,7 +1511,7 @@ class CustomizePackage extends Component {
                         .replace(
                           {
                             pathname: '/angebote',
-                            query: { ...query, price: undefined, userPrice: 1 }
+                            query: { ...omit(query, ['price']), userPrice: 1 }
                           },
                           undefined,
                           { shallow: true }

--- a/components/Pledge/Form.js
+++ b/components/Pledge/Form.js
@@ -561,6 +561,7 @@ const query = gql`
         name
         group
         paymentMethods
+        suggestedTotal
         options {
           id
           price

--- a/components/Pledge/Form.js
+++ b/components/Pledge/Form.js
@@ -148,12 +148,10 @@ class Pledge extends Component {
       : null
     if (pkg) {
       if (query.userPrice) {
-        // do not offer goodies unless userPrice true
+        // only offer userPrice true options
         pkg = {
           ...pkg,
-          options: pkg.options.filter(
-            option => option.reward.__typename !== 'Goodie' || option.userPrice
-          )
+          options: pkg.options.filter(option => option.userPrice)
         }
       }
       const hasAccessGrantedAndNot =

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -6317,6 +6317,10 @@
       "value": "Republik-Maske"
     },
     {
+      "key": "package/customize/price/payMore/userPrice",
+      "value": "Können Sie Ihr Investment erhöhen?"
+    },
+    {
       "key": "package/customize/price/payMore/DONATE_POT",
       "value": "Vorschläge"
     },


### PR DESCRIPTION
Depends on https://github.com/orbiting/backends/pull/690

This automatically pre fills the price with a new suggested total from the backend. If it's lower than the regular minimum price it will turn on user pricing and display the reason field (not pre filled).

Additionally the wording was improved when in user pricing mode for switching back to regular:
<img width="1258" alt="Screenshot 2021-12-07 at 14 42 26" src="https://user-images.githubusercontent.com/410211/145039951-5449e994-40c4-43e5-846a-4a3bf5d09345.png">

Also all non user pricing options, including gifted memberships, are now hidden when user pricing is on. This might lead to odd situation when someone already has a reduced price (suggested total below min price) and a gifted membership. I'll verify if that case exists.
