### PR TITLE
(vote): amendments for vote result component

### DIFF
--- a/components/Vote/VoteResult.js
+++ b/components/Vote/VoteResult.js
@@ -76,7 +76,7 @@ const VoteResult = compose(
   return (
     <div>
       <ChartTitle>{messages.description || data.description}</ChartTitle>
-      {options.hasChartLead && !!winner && (
+      {!options.hideChartLead && !!winner && (
         <ChartLead>
           {messages.chartLead
             ? messages.chartLead.replace(

--- a/components/Vote/translations-vote.json
+++ b/components/Vote/translations-vote.json
@@ -269,8 +269,12 @@
       "value": "{formattedCount} Stimmen"
     },
     {
-      "key": "vote/voting/turnout",
+      "key": "vote/voting/turnout/withEmpty",
       "value": "Stimmbeteiligung: {formattedPercent}. Es sind {formattedCount} Stimmen eingegangen, davon {formattedEmptyCount} leer."
+    },
+    {
+      "key": "vote/voting/turnout/withoutEmpty",
+      "value": "Stimmbeteiligung: {formattedPercent}. Es sind {formattedCount} Stimmen eingegangen."
     },
     {
       "key": "vote/voting/winner/YES",


### PR DESCRIPTION
* empty ballots count will only be displayed in turnout if empty ballots were allowed
* chart votes label, chart lead and footnote can be overwritten by messages prop
* chart lead can be hidden

can be tested on love https://republik.love/vote/2021 or https://publikator.republik.love/repo/republik/love-page-ihre-stimme-fuer-project-r/tree respectively to change props in component