### PR TITLE
chore: Bump @project-r/styleguide to 13.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1296,9 +1296,9 @@
       "integrity": "sha512-88p7+M0QGxKpmnkfXjS4V26AnoC/eiqZutE8GLdaI5X12NY75bXSdTY9NkmYb2Xyk1O+MmkuO6Frmsj84V6I8Q=="
     },
     "@project-r/styleguide": {
-      "version": "13.7.3",
-      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-13.7.3.tgz",
-      "integrity": "sha512-QzOVbHzmj26DjmaVFPYtykt0UN0WAaTOAhbP2B8EEkXSYES/yFirg49gfcVXc77i0yUc020lZtYfmdFrd+QqRw==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@project-r/styleguide/-/styleguide-13.8.0.tgz",
+      "integrity": "sha512-Lk2TIkHmi5Xmefh/0OHbtFdDUu1+DPJVQU88K9j3dbExE3ezqwfKNimoRySSuzAcr9IuhJ4R9QXVI12hs8AjkA==",
       "requires": {
         "body-scroll-lock": "^3.1.5",
         "react-icons": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "dependencies": {
     "@apollo/client": "^3.4.15",
     "@next/bundle-analyzer": "^10.2.3",
-    "@project-r/styleguide": "^13.7.3",
+    "@project-r/styleguide": "^13.8.0",
     "@stripe/react-stripe-js": "^1.5.0",
     "@use-it/event-listener": "^0.1.6",
     "apollo-fetch": "^0.7.0",


### PR DESCRIPTION
Provides means to handle memo nodes.